### PR TITLE
Update config setting for mechanical troughs doc

### DIFF
--- a/mechs/troughs/modern_mechanical.rst
+++ b/mechs/troughs/modern_mechanical.rst
@@ -329,7 +329,7 @@ Here's the complete config
 
         # bd_plunger is a placeholder just so the trough's eject_targets are valid
         bd_plunger:
-            tags: add_ball_live
+            tags: ball_add_live
             mechanical_eject: true
 
     virtual_platform_start_active_switches:


### PR DESCRIPTION
Per error using `add_ball_live` as specified prior. "AssertionError:
Received request to add a ball to the playfield, but no source device
was passed and no ball devices are tagged with 'ball_add_live'. Cannot
add a ball."