### PR TITLE
Remove config settings that break on Pi3

### DIFF
--- a/install/raspberry.rst
+++ b/install/raspberry.rst
@@ -82,15 +82,10 @@ To tell mpf-mc and the underlying kivy to use the framebuffer via SDL2 you have 
   window:
     width: 1280
     height: 800
-    title: Your ultimate pinball
-    resizable: false
-    fullscreen: auto
-    borderless: false
-    exit_on_escape: true
 
   kivy_config:
     graphics:
-	  fbo: force-hardware
+      fbo: force-hardware
 
 More or less important last steps:
 ----------------------------------


### PR DESCRIPTION
While following these instructions getting our machine config running on a new Pi3 last night, there were errors when any of these lines were included. Here I am dropping those lines and fixing the indentation of the kivy-specific part.

A bit off topic, but what does `fbo: force-hardware` do? Our machine config loads into the attract mode with or without it. I should mention that it is **not fully working**; however, as neither the keyboard switch triggering or sound is functioning at the moment. The sound/keyboard issues are still present regardless of the `fbo: force-hardware` setting.