### PR TITLE
Fix example of using 'block' in scoring config

### DIFF
--- a/config/scoring.rst
+++ b/config/scoring.rst
@@ -129,10 +129,19 @@ Note that when you use block, you also have to include the ``score:`` setting in
 
 .. code-block:: yaml
 
-   scoring:
-      ramp_1_hit:
-         score: 5000
-         block: true
+  scoring:
+    ramp_1_hit:
+      score:
+        score: 5000
+        block: true
+
+There is also a shorthand way:
+
+.. code-block:: yaml
+
+  scoring:
+    ramp_1_hit:
+      score: 5000|block
 
 string:
 ~~~~~~~


### PR DESCRIPTION
`block` wasn't working for me when specified per the example. However, I noticed the existing scoring tests machine files refer to `block` per the format I'm changing the example to here. Both the nested score:score and shorthand ways caused my existing code to pass as well.