### PR TITLE
Update mode option stop_on_ball_end:

### DIFF
--- a/config/mode.rst
+++ b/config/mode.rst
@@ -154,7 +154,32 @@ Single value, type: ``boolean`` (Yes/No or True/False). Default: ``True``
 The default behavior for modes in MPF is that they're automatically
 stopped when the ball ends. Some modes (like the built-in *game* and
 *credit* modes) need to stay running even when the ball ends, so to
-support that you can add ``stop_on_ball_end: false``.
+support that you can add ``stop_on_ball_end: false``.  
+
+Another use of this option is to retain each player's progress towards 
+the mode's completion after draining a ball; allowing the player
+to start where they left off in the mode on the next ball. To retain 
+the mode, you can use ``stop_on_ball_end: false`` to keep the state 
+of the mode for each player between balls.  
+
+However, it is very likely that a mode will be left unfinished (open) 
+after the final ball, causing MPF to shutdown unexpectedly.  You will 
+get an error similar to this:
+
+::
+
+   AssertionError('Mode terra_2 is not supposed to run outside of game.',)
+
+To avoid this
+unexpected crash of MPF, add ``game_ending`` to the ``stop_events:``
+
+::
+
+   mode:
+      start_events: mode_terra_2_start
+      stop_events: mode_complete, game_ending
+      stop_on_ball_end: false
+
 
 stop_priority:
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
Added information about possible shutdown of MPF and how this option can be used to retain the state of the mode between balls.