### PR TITLE
OPP docs for supporting switch matrices

### DIFF
--- a/about/contributing_to_mpf.rst
+++ b/about/contributing_to_mpf.rst
@@ -45,14 +45,14 @@ To work on MPF you need to install it in developer/editable mode:
    for smaller bug fixed. Do what works best for you. We can help to forward or
    backport your changes.
 #. Create a local branch to work on (``git checkout -b your_feature_name``).
-#. Makes your changes.
+#. Make your changes.
 #. Add your name to the ``AUTHORS`` file.
 #. If possible add an unit test. We can help with that and a first Pull Request
    without a test is definitely fine.
 #. Run ``python3 -m unittest discover -s mpf.tests`` and check that all tests
    still pass. You achieve the same for mpf-mc with ``python3 -m unittest discover -s mpfmc.tests``.
 #. Commit your changes (``git commit -a``)
-#. Push your changes to your github (``git push your_feature_name``).
+#. Push your changes to your github (``git push origin your_feature_name``).
 #. Create and submit your pull request on github.
 
 We recommend you to use a decent IDE because it makes life easier.

--- a/hardware/opp/drivers.rst
+++ b/hardware/opp/drivers.rst
@@ -51,13 +51,10 @@ and hold_power/8 = time share the coil is on.
 The period is fixed at 16ms for OPP. To set the hold power to 25%, set
 hold_power to 2 and OPP will use 4ms/16ms = 25%.
 
-Because of firmware limitations in OPP hold_power 8 will translate to 15ms/16ms
-= 93.75% on. Same happens when allow_enable is set to true and no hold_power is
-provided. There is currently no way to permanently enable a hold coil in OPP.
-
 By using the MPF hold_power parameter you can only use 8 out of 16 possible
 steps. Therefore, you can also use the OPP specific parameter hold_power16
-which can range from 0 to 15.
+which can range from 0 to 16.  If hold_power16 is 16 or more, the coil will
+be held on at 100% power.
 
 ::
 

--- a/hardware/opp/switches.rst
+++ b/hardware/opp/switches.rst
@@ -33,3 +33,13 @@ only four inputs are available for each wing card, it uses the first
 four switch numbers.  Solenoid wing 0 uses switch numbers 0 to 3.
 Solenoid wing 1 uses switch numbers 8 to 11.  Solenoid wing 2 uses
 switch numbers 16 to 19.  Solenoid wing 3 uses switch numbers 24 to 27.
+
+Switch inputs for a switch matrix are number slightly differently.  To
+configure an 8x8 switch matrix wing 2 is configured as the matrix input
+and wing 3 is configured as a matrix output.  The OPP hardware strobes
+the eight outputs while reading from the eight inputs.  This allows 64
+inputs to be read using only 16 wires.  The matrix switch inputs are
+numbered from 32 to 95.  Switches 32 - 39 are column 0, switches 40 -
+47 are column 1, switch 48 - 55 are column 2, switches 56 - 63 are
+column 3, switches 64 - 71 are column 4, switches 72 to 79 are column
+5, switches 80 to 87 are column 6, and switches 88 to 95 are column 7.


### PR DESCRIPTION
Added documentation on OPP switch matrices.  Added 'origin' to git push instruction on contributing_to_mpf.rst page.