### PR TITLE
Various 0.50-related doc updates

### DIFF
--- a/config/instructions/dynamic_values.rst
+++ b/config/instructions/dynamic_values.rst
@@ -31,6 +31,14 @@ in your scoring config like this:
       shot_jackpot_hit:
          score: current_player.troll_hits * 100000
 
+You can access other values dynamically as well, such as a timer ticking away
+a hurry-up or a counter to track how many times a multiplier switch has been hit
+
+.. code-block:: yaml
+   scoring:
+      collect_hurryup: 1000 * device.timers.hurryup_clock.ticks_remaining * device.counters.hurryup_multiplier.value
+
+
 Another example might be operator settings. Rather than hard coding
 tilt warnings to 3, you might want to like the operator choose the
 tilt warnings.
@@ -64,6 +72,8 @@ current_player
    A list of player variables is here.
 
 players
+   Used to access player variables from specific players (by number), regardless
+   of who the current player is.
    ``players[0].variable_name``
 
 game
@@ -83,7 +93,10 @@ settings
 
 device
 
-   todo
+   Devices that have been registered with the machine can be found here, like logic blocks.
+   ``device.counters.superjets_counter.value``
+   ``device.accruals.magic_tokens.enabled``
+   ``device.sequences.world_tour.completed``
 
 Using if/else logic with dynamic values
 ---------------------------------------

--- a/config/leds.rst
+++ b/config/leds.rst
@@ -13,10 +13,13 @@ leds:
 
 .. overview
 
-The ``leds:`` section of your config is where you...
+The ``leds:`` section of your config is where you configure physical LED 
+(i.e. discrete-addressable) lights for your hardware platform. 
 
-.. todo::
-   Add description.
+
+.. warning::
+   As of MPF 0.50, ``matrix_lights`` and ``leds`` have been combined into a single
+   ``lights`` configuration. See :doc: `/config/lights` for details.
 
 Required settings
 -----------------

--- a/config/lights.rst
+++ b/config/lights.rst
@@ -1,0 +1,153 @@
+lights:
+=======
+
+*Config file section*
+
++----------------------------------------------------------------------------+---------+
+| Valid in :doc:`machine config files </config/instructions/machine_config>` | **YES** |
++----------------------------------------------------------------------------+---------+
+| Valid in :doc:`mode config files </config/instructions/mode_config>`       | **NO**  |
++----------------------------------------------------------------------------+---------+
+
+.. overview
+
+The ``lights:`` section of your config is where you configure physical lights for your 
+hardware platform. 
+
+.. note::
+   As of MPF 0.50, all lights have been combined into this single
+   ``lights`` configuration. If you are using 0.33 or earlier, please see
+   :doc:`/config/matrix_lights` for incandescent bulbs and :doc:`/config/leds` for LEDs.
+
+Required settings
+-----------------
+
+The following sections are required in the ``lights:`` section of your config:
+
+channels:
+~~~~~~~~~
+List of ``lights`` settings for multi-color LEDs. Default: ``None``
+
+Instead of a single ``number`` address for a light, you can enter channels 
+corresponding to the multi-color channels of an RGB or RGBW LED. Each channel entry can
+contain any of the ``lights`` parameters listed on this page, but at least ``number`` is required.
+
+.. code-block:: yaml
+  
+  lights:
+    rainbow_star:
+      type: rgb
+      channels:
+        red:
+          number: 9-29
+        green:
+          number: 9-30
+        blue:
+          number: 9-31
+
+Note that a light must have either ``channels`` or ``number`` defined, but cannot have both.
+
+number:
+~~~~~~~
+Single value, type: ``string``.
+
+This is the number of the light which specifies which output the
+hardware bulb or LED is physically connected to. The exact format used here will
+depend on which control system you're using and how the light is connected.
+
+See the :doc:`/hardware/numbers` guide for details.
+
+Note that a light must have either ``channels`` or ``number`` defined, but cannot have both.
+
+
+Optional settings
+-----------------
+
+The following sections are optional in the ``lights:`` section of your config. (If you don't include them, the default will be used).
+
+
+color_correction_profile:
+~~~~~~~~~~~~~~~~~~~~~~~~~
+Single value, type: ``string``. Default: ``None``
+
+If provided, a color correction profile will be applied to all color settings this light receives.
+By order of operations, the light will be set to the requested color first and then the color
+correction profile will be applied on top.
+
+debug:
+~~~~~~
+Single value, type: ``boolean`` (Yes/No or True/False). Default: ``False``
+
+If ``True``, this light will log its configuration and color changes to the debug log.
+
+default_on_color:
+~~~~~~~~~~~~~~
+Single value, type: ``color`` (*color name*, *hex*, or list of values *0*-*255*). Default: ``ffffff``
+
+For multi-color LEDs, the color defined here will be used when the light is enabled via "on" 
+(as opposed to being enabled with a specific color). Not intended for single-color lights.
+
+fade_ms:
+~~~~~~~~
+Single value, type: ``time string (ms)`` (:doc:`Instructions for entering time strings) </config/instructions/time_strings>` . Default: ``None``
+
+When this light receives instructions to change color, it can interpolate from its current value to the 
+new value over a fade time. If no value is provided, the machine default will be used. If this light is
+part of a show that defines a fade time, the show's value will supercede this light's setting.
+
+label:
+~~~~~~
+Single value, type: ``string``. Default: ``%``
+
+.. todo::
+   Add description.
+
+platform:
+~~~~~~~~~
+Single value, type: ``string``. Default: ``None``
+
+Name of the platform this LED is connected to. The default value of ``None`` means the
+default hardware platform will be used. You only need to change this if you have
+multiple different hardware platforms in use and this coil is not connected
+to the default platform.
+
+See the :doc:`/hardware/platform` guide for details.
+
+tags:
+~~~~~
+List of one (or more) values, each is a type: ``string``. Default: ``None``
+
+.. todo::
+   Add description.
+
+type:
+~~~~~
+Single value, type: ``string`` (case-insensitive). Default: ``rgb``
+
+This describes the channel order of an LED. Can be 1 to many channels (if supported by hardware). 
+Valid channels: r (red), g (green), b (blue), w (white=minimum of red, green and blue), 
++ (always on), - (always off).
+
+When using serial LEDs (e.g. with FAST or Fadecandy), use `rgb` for WS2812 and `grb` for WS2811 LEDs.
+
+x:
+~~
+Single value, type: ``integer``. Default: ``None``
+
+.. todo::
+   *Defined as part of ``light_groups``. No longer used here?*
+
+y:
+~~
+Single value, type: ``integer``. Default: ``None``
+
+.. todo::
+   *Defined as part of ``light_groups``. No longer used here?*
+
+z:
+~~
+Single value, type: ``integer``. Default: ``None``
+
+.. todo::
+   *No longer used?*
+

--- a/config/matrix_lights.rst
+++ b/config/matrix_lights.rst
@@ -13,10 +13,13 @@ matrix_lights:
 
 .. overview
 
-The ``matrix_lights:`` section of your config is where you...
+The ``matrix_lights:`` section of your config is where you configure physical matrix 
+(i.e. non-LED) lights for your hardware platform. 
 
-.. todo::
-   Add description.
+
+.. warning::
+   As of MPF 0.50, ``matrix_lights`` and ``leds`` have been combined into a single
+   ``lights`` configuration. See :doc: `/config/lights` for details.
 
 Required settings
 -----------------

--- a/config/multiball_locks.rst
+++ b/config/multiball_locks.rst
@@ -21,7 +21,10 @@ as the number of balls that are physically contained in a ball device.
 
 When a ball is locked, it will add a new ball into play from the ball device
 tagged with ``ball_add_live`` unless the device that just locked it is full,
-in which case it will eject a ball from the full device.
+in which case it will eject a ball from the full device. The events that
+control the ball ejections are queue events, so you can interrupt the delivery
+of a new ball with the :doc: `/config/queue_relay_player` (for example, to have
+a mode selection screen before returning to play).
 
 Whenever a new ball is locked, the event *multiball_lock_<name>_locked_ball*
 is posted with an argument "total_balls_locked". When the lock is full, it

--- a/config/spike.rst
+++ b/config/spike.rst
@@ -62,6 +62,13 @@ debug:
 Set to true for troubleshooting to print more details in the log.
 Default is ``False``.
 
+flow_control:
+~~~~~~
+
+Set to ``True`` to enable serial RTS/CTS flow control between MPF and the Spike bridge. May
+help improve responsiveness and reduce latency when streaming display data to the DMD.
+Default is ``False``.
+
 poll_hz:
 ~~~~~~~~
 

--- a/config_players/light_player.rst
+++ b/config_players/light_player.rst
@@ -1,8 +1,8 @@
 Light player
 ============
 
-The *light player* is a :doc:`config player </config_players/index>` that's used to set the brightness
-of matrix lights (including turning them on and off).
+The *light player* is a :doc:`config player </config_players/index>` that's used to set the brightness and
+color of lights (including turning them on and off).
 
 Usage in config files
 ---------------------

--- a/example_games/index.rst
+++ b/example_games/index.rst
@@ -33,6 +33,18 @@ actually run it, but you can look through the configs (which are well commented)
 
 The BnD repo is at https://github.com/gabeknuth/bnd
 
+Mass Effect 2
+-------------
+
+An extensive project to build a complete MPF game from scratch and play on a
+re-skinned Game of Thrones cabinet (Spike platform), inspired by the video game
+Mass Effect 2. With the exception of audio tracks extracted from the Mass Effect
+2 data files, all of the game code is available to clone from the repo and run.
+MPF monitor is supported so you can simulate gameplay without the Spike GoT hardware.
+
+All of the project code is at https://github.com/avanwinkle/masseffect2
+
+
 .. toctree::
    :hidden:
 

--- a/game_logic/logic_blocks/accruals.rst
+++ b/game_logic/logic_blocks/accruals.rst
@@ -135,24 +135,4 @@ those two logic blocks, if the events were posted in the order event2, event3, e
 then event5, that would complete logic block 2. Then later if event1 was posted, that
 would complete logic block 1.
 
-player_variable:
-~~~~~~~~~~~~~~~~
-
-By default, the current "state" (or progress) of accrual logic blocks
-are stored in a :doc:`player variable </game_logic/players/index>` called *<accrual_name>_status*.
-For example, a logic block called "logic_block_1" would store its state
-in a player variable called *logic_block_1_status*.
-
-However, you can use the ``player_variable:`` setting to change this to
-any player variable you want.
-
-Making this change doesn't really affect anything other than the name of the
-variable. It's just for convenience if you prefer a different name.
-
-Note that this player variable stores the state of this logic block in an
-internal list that's not easily accessible for text display purposes on a slide.
-If you want to display status or progress on a slide, you can use a combination
-of the logic block events or an event player along with slide or widget player
-entries to show whatever messages you want.
-
 .. include:: common.rst

--- a/game_logic/logic_blocks/common.rst
+++ b/game_logic/logic_blocks/common.rst
@@ -1,9 +1,56 @@
+player_variable:
+~~~~~~~~~~~~~~~~
+
+By default, the current "state" (or progress) of logic blocks
+is stored in a :doc:`player variable </game_logic/players/index>` called
+*<counter_name>_state*.
+For example, a logic block called "logic_block_1" would store its state
+in a player variable called *logic_block_1_state*.
+
+However, you can use the ``player_variable:`` setting to change this to
+any player variable you want. Making this change doesn't really affect anything 
+other than the name of the variable. It's just for convenience if you prefer a 
+different name.
+
+Note that this player variable stores the state the logic block as a numerical 
+value: current count value for counters, steps accrued for accruals, and current 
+step number for sequences. In other words, when a logic block is just started or 
+reset, the player variable tracking it is set to ``0``. Then that increases by 
+one as each step/count is complete.
+
+You can easily use this numerical value in a text widget to show the number of 
+combos complete, or the number of pop bumper hits required for super jets, etc. 
+This player variable "state" is different than the state of the logic block itself,
+which is an object with `enabled`, `completed`, and `value` attributes. Note the 
+difference in accessing the logic block state as a dynamic value vs. placeholder 
+text:
+
+.. code-block:: yaml
+
+  scoring:
+    counter_hit:
+      score: 100 * device.counters.logic_block_1.value   
+                   # The logic block stores the count as the 'value' attribute
+
+  widgets:
+    counter_widget:
+      - type: text
+        text: (logic_block_1_state) Hits!
+              # The player variable is the count value itself
+
+.. note::
+   The player variable is only saved if the logic block is configured 
+   with ``persist_state: True``. If ``persist_state`` is ``False``, the logic block 
+   value will _not_ be saved under any variable name (not even the default).
+
 persist_state:
 ~~~~~~~~~~~~~~
 
 Boolean setting (yes/no or true/false) which controls whether this logic block
 remembers where it was from ball-to-ball. If ``False``, then this logic block will
-reset itself whenever a new ball starts.
+reset itself whenever a new ball starts. If ``True``, then this logic block will
+be saved to the player variable *<logic_block_name>_state*.
+
 
 Note that logic block state is always maintained on a per-player basis,
 regardless of what this setting is configured for.

--- a/game_logic/logic_blocks/counters.rst
+++ b/game_logic/logic_blocks/counters.rst
@@ -143,27 +143,4 @@ Default is ``0``.
 Note that you can use a :doc:`dynamic value </config/instructions/dynamic_values>`
 for this setting.
 
-player_variable:
-~~~~~~~~~~~~~~~~
-
-By default, the current "state" (or progress) of sequence logic blocks
-are stored in a :doc:`player variable </game_logic/players/index>` called
-*<counter_name>_count*.
-For example, a logic block called "logic_block_1" would store its state
-in a player variable called *logic_block_1_count*.
-
-However, you can use the ``player_variable:`` setting to change this to
-any player variable you want.
-
-Making this change doesn't really affect anything other than the name of the
-variable. It's just for convenience if you prefer a different name.
-
-Note that this player variable stores the count of this logic block in a numeric
-value that represents what the current count value is. In other words, when a sequence
-logic block is just started or reset, the player variable tracking it is set to
-``0``. Then that increases by one as each step is complete.
-
-You can easily use it in a text widget to show the number of combos complete,
-or the number of pop bumper hits required for super jets, etc.
-
 .. include:: common.rst

--- a/game_logic/logic_blocks/integrating_logic_blocks_and_shows.rst
+++ b/game_logic/logic_blocks/integrating_logic_blocks_and_shows.rst
@@ -1,13 +1,16 @@
 Integrating Logic_Blocks and Shows
 ==================================
 
-Logic_blocks can be flexibly integrated with shows using the (name)_updated event.
+Logic_Block-Triggered Events
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Logic_blocks can be flexibly integrated with shows using the *(name)_updated* event.
 It is posted on every state change (i.e. when a counter is incremented) and when
 logic_blocks are restored (on mode restart). This means that the event may be posted
 more than once and all handlers should be idempotent (i.e. that you can execute them more
-than once without changing state after the first time). Therefore, this event should
-not be used for scoring. However, it works well to control shows, lights, slides and
-restore them on the next ball.
+than once without changing state after the first time). This event works well to control
+shows, lights, slides, and to restore them on the next ball. However it should not be used
+for scoring (to handle an event when the counter changes, consider the *(name)_hit* event instead).
 
 .. code-block:: yaml
 
@@ -22,10 +25,10 @@ restore them on the next ball.
       logicblock_my_counter_updated{value == 0}:
         my_show_initial:
           key: my_counter_show  # this is to remove the previous show from the same player
-    logicblock_my_counter_updated{value == 1}:
+      logicblock_my_counter_updated{value == 1}:
         my_show_first_hit:
           key: my_counter_show  # this is to remove the previous show from the same player
-    logicblock_my_counter_updated{value >= 2}:
+      logicblock_my_counter_updated{value >= 2}:
         my_show_final:
           key: my_counter_show  # this is to remove the previous show from the same player
 
@@ -35,4 +38,29 @@ Every time ``my_counter`` is updated (or restored) it will post
 either ``my_show_initial`` (value is 0), ``my_show_first_hit`` (value is 1) or
 ``my_show_final`` (value is 2 or 3) are shown. All show_players have the same key so
 they will stop any other show playing with the same key.
-      
+
+Other Triggered Events
+~~~~~~~~~~~~~~~~~~~~~~
+
+You can also have a show depend on the state of a logic block while being triggered
+by another event, using :docs:`Conditional Events </events/overview/conditional>`.
+
+If the logic_block has a persistent state (``persist_state: true``), you can make
+a condition based on the player variable for the block:
+
+.. code-block:: yaml
+
+  show_player:
+    some_other_event{current_player.my_counter_state==0}: my_show_initial
+    some_other_event{current_player.my_counter_state==1}: my_show_once_hit
+    some_other_event{current_player.my_counter_state==2}: my_show_twice_hit
+
+If the logic_block is not persistent (``persist_state: false``), you can access the
+value directly from the block device:
+
+.. code-block:: yaml
+
+  show_player:
+    some_other_event{devices.counters.my_counter.value==0}: my_show_initial
+    some_other_event{devices.counters.my_counter.value==1}: my_show_once_hit
+    some_other_event{devices.counters.my_counter.value==2}: my_show_twice_hit

--- a/game_logic/logic_blocks/sequences.rst
+++ b/game_logic/logic_blocks/sequences.rst
@@ -124,29 +124,6 @@ So in the second one, you could get event2, event4, then event5 posted, for exam
 and that will lead to *logic_block_2_done* being posted.
 
 Note that you can have two logic blocks with the same events at the same time, and
-MPF will track the state of each logic block separately. So in the above config with
-those two logic blocks, if the events were posted in the order event2, event3, event4,
-then event5 were posted, that would complete logic block 2,
-then later if event1 was posted, that would complete logic block 1.
-
-player_variable:
-~~~~~~~~~~~~~~~~
-
-By default, the current "state" (or progress) of sequence logic blocks
-are stored in a :doc:`player variable </game_logic/players/index>` called
-*<sequence_name>_step*.
-For example, a logic block called "logic_block_1" would store its state
-in a player variable called *logic_block_1_step*.
-
-However, you can use the ``player_variable:`` setting to change this to
-any player variable you want.
-
-Making this change doesn't really affect anything other than the name of the
-variable. It's just for convenience if you prefer a different name.
-
-Note that this player variable stores the state of this logic block in a numeric
-value that represents which step is complete. In other words, when a sequence
-logic block is just started or reset, the player variable tracking it is set to
-``0``. Then that increases by one as each step is complete.
+MPF will track the state of each logic block separately. 
 
 .. include:: common.rst

--- a/hardware/spike/mpf-spike-bridge.rst
+++ b/hardware/spike/mpf-spike-bridge.rst
@@ -45,6 +45,13 @@ You need to mount the Linux root partition (which is probably #3).
 On Windows you need an additional tools to mount ext3. We got a
 report that "Paragon ExtFS for Windows" works fine for this.
 
+On Mac OS X, the tool "FUSE-ext2" is an option. You will most likely need to use sudo, and depending on your configuration
+the appropriate disk device may vary. In the following example, the Linux root is on partition 3 of the SD card, which is disk2:
+
+::
+   > sudo fuse-ext2 /dev/disk2s3 /Volumes/SD -o force
+
+
 3. Edit /etc/inittab
 --------------------
 
@@ -106,6 +113,14 @@ Note that we have a precompiled binary in there (as well as the C source code).
       mount -o remount,rw /
       chmod +x /bin/bridge
       mount -o remount,ro /
+
+.. note:: On OS X with fuse-ext2, overwriting files can fail without a message. When updating mpf-spike-bridge, 
+   you may want to remove the old bridge file before copying the new one.
+
+   ::
+      rm <sd_mount>/bin/bridge
+      cp <your_path>/mpf-spike-bridge/bridge <sd_mount>/bin/bridge
+      chmod 755 <sd_mount>/bin/bridge
 
 
 6. Unmount the SD card. Put it back in your spike system

--- a/player_vars/logic_block_state.rst
+++ b/player_vars/logic_block_state.rst
@@ -8,6 +8,11 @@ with the name (logic_block). (In other words, a logic block called
 *mode1_hit_counter* will store its state in a player variable called
 ``mode1_hit_counter_state``).
 
-The state that's stored in this variable include whether the logic
-block is enabled and whether it's complete.
+The state that's stored in this variable includes whether the logic
+block is enabled and whether it's complete. However when this variable is
+referenced in a placeholder for :doc:`displays/widgets/text/text_dynamic`,
+only the _value_ of the logic block's counter will be rendered.
+
+Note that a logic block will only store this player variable if it is
+configured with ``persist_state: True``.
 


### PR DESCRIPTION
This PR updates a couple of documents related to 0.50 changes, based on areas where I personally struggled to find documentation or was confused due to 0.33/0.50 differences.

Mainly:
* Update `logic_block` behavior post-0.50-refactoring
* Unified `lights` config to replace `matrix_lights` and `leds`
* Minor Spike+OSX verbage for bridge setup
* More examples of conditional events and/vs dynamic text

The changes are all to the best of my understanding, so please take a look and let me know what needs to be corrected/clarified. Thanks!