### PR TITLE
Update widget positioning docs with anchor-independent rounding

### DIFF
--- a/config/displays.rst
+++ b/config/displays.rst
@@ -73,9 +73,9 @@ round_anchor_x:
 ~~~~~~~~~~~~~~~
 Single value, type: ``string``. Default: ``center``
 
-Indicates that this display should not render center-aligned widgets on partial horizontal pixels,
+Indicates that this display should not render widgets on fractional horizontal pixels,
 e.g. anchoring an 11px-wide widget at -5.5 pixels. When specified with ``left`` or ``right``, this
-display will round the pixel anchor position to the nearest whole pixel in that direction.
+display will round the pixel position to the nearest whole pixel in that direction.
 
 This setting can also be configured on an individual widget to override the display's configuration.
 
@@ -83,9 +83,9 @@ round_anchor_y:
 ~~~~~~~~~~~~~~~
 Single value, type: ``string``. Default: ``middle``
 
-Indicates that this display should not render middle-aligned widgets on partial vertical pixels,
+Indicates that this display should not render widgets on fractional vertical pixels,
 e.g. anchoring an 11px-high widget at -5.5 pixels. When specified with ``bottom`` or ``top``, this
-display will round the pixel anchor position to the nearest whole pixel in that direction.
+display will round the pixel position to the nearest whole pixel in that direction.
 
 This setting can also be configured on an individual widget to override the display's configuration.
 

--- a/displays/widgets/positioning.rst
+++ b/displays/widgets/positioning.rst
@@ -179,10 +179,10 @@ not cropping, and they will not "cut off" or "trim" the widget.
 7. Widget position rounding
 -------------------------------------------
 
-Sometimes a center-anchored widget will have an odd number of pixels and receive a position with a half pixel. High-resolution
+Sometimes a center-anchored or percentage-based widget will end up at a position with a fractional pixel. High-resolution
 displays have no trouble smoothing out partial pixels, but low-resolution displays (like DMDs) may render the widget blurry.
 
-You can prevent MPF-MC from positioning widgets on partial pixels with the ``round_anchor_x:`` and ``round_anchor_y:``
+You can prevent MPF-MC from positioning widgets on pixel fractions with the ``round_anchor_x:`` and ``round_anchor_y:``
 setting, either locally on a widget or globally on the display. When present, this setting will force MPF-MC to round
 fractional anchor positions in the specified direction.
 


### PR DESCRIPTION
This PR updates the documentation on widget rounding to remove center/middle-only phrasing and include percentage-based positions.

Based on the MPF-MC changes in https://github.com/missionpinball/mpf-mc/pull/296