### PR TITLE
Documentation for conditional event handlers and asset (sound) pools

### DIFF
--- a/config/event_player.rst
+++ b/config/event_player.rst
@@ -21,7 +21,10 @@ implement game logic. (e.g. "When this happens, do this.")
 If you add
 this section to your machine-wide config file, the entries here will
 always be active. If you enter it into a mode-specific config file,
-entries will only be active while that mode is active. Here's an example:
+entries will only be active while that mode is active. 
+
+Basic Event Playing
+-------------------
 
 ::
 
@@ -64,3 +67,45 @@ shoot here mode's shoot_here.yaml mode configuration file:
       mode_shoot_here_started:
         cmd_upper_target_reset
 
+Conditional Event Playing
+-------------------------
+
+Events in the event player can be conditional, to allow precise control over
+when an event is played:
+
+::
+
+   event_player:
+       mode_base_started{current_player.score>10000}:
+         start_mode_superbonusround
+         play_show_richy_rich
+       start_mode_battle{device.achievements.ironthrone.state!="completed"}:
+         start_mode_choose_battle
+       start_mode_battle{device.achievements.ironthrone.state=="completed"}:
+         start_mode_victory_lap
+
+In the above example, both "start_mode_superbonusround" and "play_show_richy_rich" will
+only be posted if the player's score is over 10,000 when base mode starts. And if the
+battle mode is started, either "start_mode_choose_battle" or "start_mode_victory_lap"
+will be posted depending on whether the *ironthrone* achievement has been completed.
+
+Conditions can also be applied to events within a list, to allow one event to
+trigger a variable number of handlers:
+
+::
+
+   event_player:
+      reenable_nonrecruit_modes:
+         - start_mode_shadowbroker_base
+         - start_mode_n7_assignments
+         - start_mode_overlordlight{device.achievements.collectorship.state!="complete"}
+         - start_mode_arrival{device.achievements.collectorship.state=="complete"}
+         - start_mode_shopping{current_player.cash>=1000}
+
+In the above example, both "start_mode_shadowbroker_base" and "start_mode_n7_assignments" will
+be posted every time. One of either "start_mode_overlord" or "start_mode_arrival" will be posted,
+depending on whether the player has completed the collectorship achievement. And if the player_var
+"cash" is high enough, "start_mode_shopping" will also be posted. 
+
+In many cases, conditions can be applied to either the triggering event or the handling event.
+For more information and examples of conditions, see :doc:`conditional events </events/overview/conditional>`.

--- a/sound/variations.rst
+++ b/sound/variations.rst
@@ -109,9 +109,27 @@ process.  ``triangle_01`` has a relative weight of ``5`` out of a total weightin
 ``|1`` appended to ``triangle_04`` is unnecessary because a relative weight of ``1`` is the default
 value for all sounds in the pool that do not have explicit weight values assigned.
 
-That's it. Your sound pool has been configured to play a weighted random variation of our triangle
-sound every time the ``triangle`` sound pool is played. For additional sound pool setting options,
-take a look at the :doc:`sound_pools </config/sound_pools>` documentation.
+Sometimes you may want to have sounds included based on conditional events. You can add a condition
+to any sound and the sound pool will only include that sound if the condition evaluates to true at
+playback time. If the selection is random, excluded events will not be weighted in the distribution.
+If the selection is sequential, excluded events will simply be skipped.
+
+::
+
+   sound_pools:
+      triangle:
+         type: random
+         sounds:
+            - triangle_01
+            - triangle_02{current_player.triangles_found>1}|2
+            - triangle_03{current_player.triangles_found>2}
+            - triangle_04{device.achievements.supertriangle.state=="complete"}|5
+
+Sound conditions are formatted the same as all :doc:`conditional events </events/overview/conditional>`.
+Any sound in a pool can have a weight, a condition, both, or neither.
+
+For additional sound pool setting options, take a look at the :doc:`sound_pools </config/sound_pools>`
+documentation.
 
 4. Configuring the sound player
 -------------------------------


### PR DESCRIPTION
This PR updates the documentation for `event_player` and `sound_pools` with examples of conditional event implementations from https://github.com/missionpinball/mpf/pull/1067