### PR TITLE
Correct dynamic property name for multiball_locks

### DIFF
--- a/game_logic/multiballs/multiball_locks.rst
+++ b/game_logic/multiballs/multiball_locks.rst
@@ -69,7 +69,7 @@ Monitorable Properties
 
 For :doc:`dynamic values </config/instructions/dynamic_values>` and
 :doc:`conditional events </events/overview/conditional>`,
-the prefix for multiballs is ``device.multiballs.<name>``.
+the prefix for multiball locks is ``device.multiball_locks.<name>``.
 
 *enabled*
    Boolean (true/false) as to whether this multiball lock is enabled.


### PR DESCRIPTION
It looks like the documentation for `multiball_locks` was copied over from `multiballs`, because it still contained a reference to multiballs where it should say multiball_locks.