### PR TITLE
shot_group: remove profiles and machine-wide support

### DIFF
--- a/config/event_player.rst
+++ b/config/event_player.rst
@@ -112,3 +112,90 @@ depending on whether the player has completed the collectorship achievement. And
 
 In many cases, conditions can be applied to either the triggering event or the handling event.
 For more information and examples of conditions, see :doc:`conditional events </events/overview/conditional>`.
+
+Dynamic Values in Events
+------------------------
+
+There are numerous ways to include dynamic values (player variables, device states,
+mathematical calculations) in events.
+
+Dynamic Event Names
+~~~~~~~~~~~~~~~~~~~
+
+An event name can use parenthetical values to dynamically determine the event.
+
+.. code-block:: mpf-config
+
+  event_player:
+    mode_dynamo_started:
+      # Player variables can be dropped into event names
+      - play_dynamo_show_phase_(current_player.phase_name)
+      # Machine and device states can be used
+      - dynamo_started_with_state_(device.achievements.dynamo.state)
+      # Dynamic evaluations can be done to calculate values
+      - player_score_is_("high" if current_player.score > 10000 else "low")
+
+In the above example:
+
+* With the player variable ``phase_name`` having a value of "attackwave", starting the mode would post the event *play_dynamo_show_phase_attackwave*
+* If the "dynamo" achievement was completed, starting the mode would post *dynamo_started_with_state_completed*. If the achievement was instead disabled, the event would be *dynamo_started_with_state_disabled*
+* If the player's score is over 10,000 the event *player_score_is_high* will be posted, otherwise the event *player_score_is_low* will be posted.
+
+Any :doc:`dynamic values </config/instructions/dynamic_values>` can be used.
+Because event names are always strings, all dynamic values will be converted
+to their string equivalent.
+
+Dynamic Event Arguments
+~~~~~~~~~~~~~~~~~~~~~~~
+
+An event post can include arguments to provide event handlers with additional
+information about the event. An event configured as an object will post
+the object properties as its arguments:
+
+.. code-block:: mpf-config
+
+  event_player:
+    mode_carchase_started:
+      # Objects can be expanded for a key/value pair per line
+      set_environment_sounds:
+        env_name: driving
+      # Objects can be inline for brevity
+      set_initial_laps_count: { count: 10 }
+
+You can go a step further and include dynamic values as the values for event
+arguments. To indicate that an argument's value is dynamic, use the ``value:``
+property.
+
+.. code-block:: mpf-config
+
+  event_player:
+    mode_dynamo_started:
+      set_dynamo_phase:
+        phase_name: { value: current_player.dynamo_phase }
+
+In the above example, if the player variable ``dynamo_phase`` had the value
+"attackwave", the event would be posted as such:
+
+.. code-block:: none
+
+  Event: ======'set_dynamo_phase'====== Args={'phase_name': 'attackwave', priority': 0}
+
+Because dynamic values can come from a variety of sources, you will need to
+explicitly define types for the value's format. Acceptable types are
+**int**, **float**, **bool**, and **string**. If no type is configured, the value will
+be posted as a string.
+
+.. code-block:: mpf-config
+
+  event_player:
+    mode_dynamo_started:
+      # This event arg will be correctly typed
+      set_dynamo_round_with_type:
+        round_number:
+          value: device.counters.dynamo_rounds.value
+          type: int
+      # This event arg will be converted to a string
+      set_dynamo_round_without_type:
+        round_number:
+          value: device.counters.dynamo_rounds.value
+

--- a/config/shot_groups.rst
+++ b/config/shot_groups.rst
@@ -226,6 +226,20 @@ Resetting a shot group means that every shot in the group
 jumps back to the first state in whatever shot profile is active at
 that time.
 
+restart_events:
+~~~~~~~~~~~~~~~
+One or more sub-entries, either as a list of events, or key/value pairs of
+event names and delay times. (See the
+:doc:`/config/instructions/device_control_events` documentation for details
+on how to enter settings here.
+
+Default: ``None``
+
+A list of one or more events that will restart all the shots in this shot group.
+A restart is the same as calling reset and enable, so restarting a shot group
+will jump every shot in the group to the first state of that shot's profile and
+immediately enable all the shots.
+
 rotate_events:
 ~~~~~~~~~~~~~~
 One or more sub-entries, either as a list of events, or key/value pairs of

--- a/config/shot_groups.rst
+++ b/config/shot_groups.rst
@@ -145,18 +145,12 @@ Default: ``None``
 
 Events in this list, when posted,
 
-A list of one or more events that will disable this shot group. This
+A list of one or more events that will disable all the shots in this shot group. This
 can be a simple list of events or a time-delayed list. If you do
 not specify any disable_events, then MPF will automatically create
 *disable_events* based on the list in the `config_validator:
 shot_groups: disable_events:` section of your machine-wide config. (By
-default that's *ball_ended*.) If you specify any *disable_events* in
-your machine-wide config, then none of the default *disable_events*
-will be added. (i.e. if you also want to include the default
-*disable_events*, you will have to add them here too.) If you specify
-any *disable_events* in a mode-specific config, then those events are
-only active during that mode. Mode-specific *disable_events* are in
-addition to machine-wide *disable_events*.
+default that's *ball_ended*.)
 
 disable_rotation_events:
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -185,22 +179,17 @@ Default: ``None``
 
 Events in this list, when posted,
 
-A list of one or more events that will enable this shot group.
-(Enabling a shot group will also enable all of the individual shots
-that make up this group.) This can be a simple list of events or a
-time-delayed list. If a shot group is not enabled, then it will not
-post hit events and shot rotation is disabled. If you do not specify
-any enable_events, then MPF will automatically create enable events
-based on the list in the `config_validator: shot_groups:
-enable_events:` section of your machine-wide config. (By default
-that's *ball_started*, meaning your shot groups are automatically
-enabled when a ball starts.) If you specify any *enable_events* in
-your machine-wide config, then none of the default enable events will
-be added. (i.e. if you also want to include the default
-*enable_events*, you will have to add them here too.) If you specify
-any *enable_events* in a mode-specific config, then those events are
-only active during that mode. Mode-specific *enable_events* are in
-addition to machine-wide *enable_events*.
+A list of one or more events that will enable all of the individual shots
+in this shot group. (The shot group itself has no enabled/disabled state
+except for rotation.) This can be a simple list of events or a
+time-delayed list. If a shot in the group is not enabled, then it will not
+post hit events but it *will* still rotate its profile state when the shot group
+rotates.
+
+The presence or absence of this value will not affect whether individual shots
+in the group can be enabled via their own `enable_events` settings. An individual
+shot can always be enabled/disabled regardless of the group state, although
+a subsequent group enable/disable events will also affect that individual shot.
 
 enable_rotation_events:
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/config/shot_groups.rst
+++ b/config/shot_groups.rst
@@ -4,7 +4,7 @@ shot_groups:
 *Config file section*
 
 +----------------------------------------------------------------------------+---------+
-| Valid in :doc:`machine config files </config/instructions/machine_config>` | **YES** |
+| Valid in :doc:`machine config files </config/instructions/machine_config>` | **NO**  |
 +----------------------------------------------------------------------------+---------+
 | Valid in :doc:`mode config files </config/instructions/mode_config>`       | **YES** |
 +----------------------------------------------------------------------------+---------+
@@ -226,44 +226,6 @@ Single value, type: ``string``. Default: ``%``
 
 The plain-English name for this device that will show up in operator
 menus and trouble reports.
-
-profile:
-~~~~~~~~
-Single value, type: ``string``. Default: ``None``
-
-The name of the :doc:`shot profile <shot_profiles>` that will be applied to all the shots
-in this shot group.
-
-+ If you’re editing a machine-wide config file , then the profile name
-  specified here will be the default profile for each shot in the group
-  any time a mode-specific config doesn't override it. (If you don’t
-  specify a profile name, MPF will assign the shot profile called
-  “default”.)
-+ If you’re in a mode configuration file , then this profile entry is
-  the name of the shot profile that will be applied to each shot in this
-  group only when this mode is active. (i.e. it’s applied when the mode
-  starts and it’s removed when the mode ends.) Like other mode-specific
-  settings, shot profiles take on the priorities of the modes they’re
-  in, so if you have a profile from a mode at priority 200 and another
-  from priority 300, the profile from the priority 300 mode will be
-  applied. If that mode stops, then the shot will get the profile from
-  the priority 200 mode.
-
-remove_active_profile_events:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-One or more sub-entries, either as a list of events, or key/value pairs of
-event names and delay times. (See the
-:doc:`/config/instructions/device_control_events` documentation for details
-on how to enter settings here.
-
-Default: ``None``
-
-Events in this list, when posted,
-
-A list of one or more events that will cause the active shot profile
-to be removed from every shot in the group, and the next-highest
-priority profile to be applied. This can be a simple list of events or
-a time-delayed list.
 
 reset_events:
 ~~~~~~~~~~~~~

--- a/config/shots.rst
+++ b/config/shots.rst
@@ -204,7 +204,7 @@ shot means that it jumps back to the first state in whatever *shot
 profile* is active at that time.
 
 restart_events:
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 One or more sub-entries, either as a list of events, or key/value pairs of
 event names and delay times. (See the
 :doc:`/config/instructions/device_control_events` documentation for details

--- a/config/shots.rst
+++ b/config/shots.rst
@@ -203,6 +203,18 @@ Events in this list, when posted, reset this shot. Resetting a
 shot means that it jumps back to the first state in whatever *shot
 profile* is active at that time.
 
+restart_events:
+~~~~~~~~~~~~~
+One or more sub-entries, either as a list of events, or key/value pairs of
+event names and delay times. (See the
+:doc:`/config/instructions/device_control_events` documentation for details
+on how to enter settings here.
+
+Default: ``None``
+
+Events in this list, when posted, restart this shot. Restarting a shot is
+equivalent to resetting and then enabling the shot, done with a single event.
+
 show_tokens:
 ~~~~~~~~~~~~
 One or more sub-entries, each in the format of type: ``str``:``str``. Default: ``None``


### PR DESCRIPTION
This PR updates the `shot_groups` documentation to indicate that shot groups are *not* valid in machine-wide configs and the profiles are no longer configurable at the shot group level.