### PR TITLE
Update widget docs for multiple styles; clarify dmd performance

### DIFF
--- a/config/widget_styles.rst
+++ b/config/widget_styles.rst
@@ -32,7 +32,8 @@ For instance, a default style for all
 Specifying widget styles
 ------------------------
 
-You can also specify a style for a certain widget.
+You can also specify re-usable styles and apply them to widgets. In the following
+example, the text "HELLO" will render at font size 100:
 
 .. code-block:: mpf-config
 
@@ -45,3 +46,32 @@ You can also specify a style for a certain widget.
        - type: text
          text: HELLO
          style: big_style
+
+You can supply multiple styles to a single widget, and they will be applied in
+the order given.
+
+.. code-block:: mpf-config
+
+  widget_styles:
+    warning_text:
+      font_size: 12
+      color: yellow
+    bottom_left:
+      anchor_x: left
+      anchor_y: bottom
+      x: 5
+      y: 5
+    hurryup:
+      color: red
+
+  widgets:
+    timer_runout:
+      - type: text
+        text: Hurry!
+        style: warning_text, bottom_left, hurryup
+
+In the above example, the text "Hurry!" will be anchored in the lower-left of
+the display and rendered at size 12 and color red. Notice that the color from
+the *hurryup* style overwrites the color from *warning_text* style, because of
+the order the styles are listed in the widget.
+

--- a/displays/display/index.rst
+++ b/displays/display/index.rst
@@ -87,3 +87,21 @@ display type you want to use in your machine.
    adding_dot_look_to_lcd
    alpha_numeric
    multiple_screens
+
+.. rubric:: A note on performance with "displays" and "dmds"
+
+If you have a physical DMD defined (in the :doc:`dmds: </config/dmds>` or
+:doc:`rgb_dmds: </config/rgb_dmds>` of your machine config) and are emulating
+the DMD's slides and widgets in your window, be aware that the MPF media
+controller will process the graphics data for the physical DMD *even when MPF
+is running in "virtual" mode*.
+
+Although that graphics data will not be sent to a physical DMD, processing it
+provides a more realistic MPF experience because of the considerable CPU power
+required to convert on-screen graphics to DMD data.
+
+If you are planning to use a physical DMD at some point on your project, it's
+recommended to configure one *before* you start designing your slides and widgets.
+Especially if you will be running virtually for the bulk of your early game design:
+you don't want to spend time designing intricate slides and high-resolution
+graphics only to find your CPU crumble when you finally attach a physical DMD.

--- a/displays/widgets/common_settings.rst
+++ b/displays/widgets/common_settings.rst
@@ -168,11 +168,15 @@ The default value is ``ffffffff`` which is white at 100% opacity.
 style:
 ~~~~~~
 
-The name of the style you want to apply to this widget. Note that styles must
-be previously defined someone in your config in order to use them. Also you can
-override any setting from the style by also manually including it in the
-widget config. See the :doc:`style documentation </displays/widgets/styles>`
+The name of the style (or styles) you want to apply to this widget. Note that
+styles must be previously defined someone in your config in order to use them.
+Also you can override any setting from the style by also manually including it
+in the widget config. See the :doc:`style documentation </displays/widgets/styles>`
 for details.
+
+*New in MPF 0.51:* Multiple style names can be provided for this setting, and
+the corresponding styles will be applied to the widget sequentially. As a result,
+individual style names cannot have spaces in them.
 
 The default value is ``None`` which means no style is used.
 


### PR DESCRIPTION
This PR updates the documentation for Widgets to expose the new `style:` behavior allowing multiple styles.

It also clarifies some underlying MC behavior that impacts performance, which I discovered today when some UX changes crippled my gameplay. I was playing with some slides for an LCD display on my game instead of the existing DMD, and even at a modest 1280x480 resolution the runtime speed was unplayable (on virtual platform, no less).

After profiling MC and debugging the devices, I determined that the root cause was MC's DMD handling. Because MC has no knowledge of "virtual" platform, it will *always* render bytestream data for slides and widgets attached to `dmd` or `rgb_dmd` devices... even if MPF throws away the data because of the virtual platform.

I wrote an initial fix to prevent the DMD rendering on virtual platform, but after thinking about it I opted to provide documentation instead of a fix. The unusable performance I encountered was my fault for making a "hacky" fix, and I think there's value in having MC working under a realistic CPU load during virtualization. This allows designers to catch DMD-overload sooner in the process, which I think is a good thing!