### PR TITLE
Update case_insensitivity.rst

### DIFF
--- a/config/instructions/case_insensitivity.rst
+++ b/config/instructions/case_insensitivity.rst
@@ -3,5 +3,8 @@ Case insensitivity in config files
 
 Setting names config files are case sensitive (starting with 0.50).
 In 0.17 to 0.33 settings were case insensitive but it caused many
-problems and thus has been dropped.
+problems and thus has been dropped. Generally, a safe approach is to 
+use only lower case in config files, though, it is fine to use upper
+case in slides.  Using lower case is recommended for naming 
+modes, devices, timers, etc....
 


### PR DESCRIPTION
Using lower case is recommended for naming 
modes, devices, timers, etc....