### PR TITLE
Update Mac install instructions (0.51+)

### DIFF
--- a/install/mac.rst
+++ b/install/mac.rst
@@ -150,7 +150,7 @@ password, and you're all set.
    Python 3 that you install here will happily live alongside the Python 2.x
    that your Mac already has.
 
-You can check to make sure Python 3.5 installed correctly from the Terminal
+You can check to make sure Python 3 installed correctly from the Terminal
 window. To do that, run the command:
 
 .. code-block:: console
@@ -169,9 +169,9 @@ different between the two:
 -------------------------------
 
 Python includes a utility call "virtual environment" that creates a safe,
-isolated environment to install packages and configure python. It's strongly
+isolated place to install packages and configure python. It's strongly
 recommended to install MPF in a virtual environment, so that other Python
-programs can't pollute it (and it can't pollute others).
+programs can't interfere with it (and it can't interfere with others).
 
 To create a virtual enviroment, choose a folder where you want to install
 a copy of python and keep the enviroment's packages. For this example, we'll
@@ -188,10 +188,17 @@ which one to use in the virtual environment:
 
   python3.6 -m venv ~/mpfenv
 
+.. note::
+
+  A virtual environment is recommended for any general-use computer you'll be
+  using MPF on. For a dedicated MPF machine that will have no other programs
+  installed (for example, a computer inside a pinball cabinet), a virtual 
+  environment is not recommended.
+
 5. Activate your Virtual Environment
 ------------------------------------
 
-To keep your virtual enviroment isolated, it only activates when you tell it to.
+To keep itself isolated from other programs, your virtual enviroment only activates when you tell it to.
 You can enable the virtual environment with the dot command from the terminal:
 
 .. code-block:: console
@@ -202,22 +209,29 @@ Note that the first character is a period, followed by a space, then the path
 to your virtual environment and "/bin/activate".
 
 .. note::
+
   You may want to write this step down, as you'll run it every time you open up
   a terminal window to work on MPF*
 
 You'll know you're in the virtual environment because the console prompt will include
-the name of your venv in parenthesis. Conveniently, the python you used to create
-the virtual environment will now be the default python.
+the name of your venv in parenthesis.
 
 .. code-block:: console
 
   My-Mac:~ python --version
   Python 2.7.10
   My-Mac:~ . ~/mpfenv/bin/activate
+
   (mpfenv) My-Mac:~ python --version
   Python 3.6.8
   (mpfenv) My-Mac:~ 
 
+.. note::
+  
+   The python you used to create the virtual environment will now be the 
+   default python. Outside the virtual environment "python" is Python 2 and
+   you must type "python3" to use Python 3; inside the virtual environment,
+   you can use "python" to refer to Python 3.
 
 4. Install/upgrade some Python components
 -----------------------------------------
@@ -226,18 +240,27 @@ Python includes a utility called "pip" which is the name of the Python Package
 Manager. Pip is used to install Python packages and applications from
 the web. (It's kind of like an app store for Python apps.)
 
-If you created a virtual environment using Python3, then pip will be correct.
-If you are not using a virtual environment and have both Python2 and Python3 
-on your system, you'll want to check your version:
+If you are not using a virtual environment and have both Python 2 and Python 3 
+on your system, you'll most likely need to use "pip3". Check your version to see:
 
 .. code-block:: console
   
   My-Mac:~ $ pip --version
   pip 8.0.2 from /usr/bin/pip (python 2.7)
   My-Mac:~ $ pip3 --version
-  pip 18.0.1 from /usr/bin/pip3 (python 3.6)
+  pip 16.2.1 from /usr/bin/pip3 (python 3.6)
 
-If your "pip" is for Python2, then you'll use "pip3" through the rest of this guide.
+If your "pip" is for Python 2, then you'll use "pip3" through the rest of this guide. 
+
+If you created a virtual environment using Python 3, then "pip" will be the same 
+as "pip3" and you can use them interchangably.
+
+.. code-block:: console
+  
+  (mpfenv) My-Mac:~ $ pip --version
+  pip 19.0.1 from ~/venv/lib/python3.6/site-packages/pip (python 3.6)
+  (mpfenv) My-Mac:~ $ pip3 --version
+  pip 19.0.1 from ~/venv/lib/python3.6/site-packages/pip (python 3.6)
 
 The versions of pip that come with Python aren't always the newest, so it's a
 good idea to update pip by running the following command:
@@ -250,8 +273,6 @@ The latest version of pip should now be installed.
 
 Next, we need to install and update a few other python packages required to run mpf by
 running the following command:
-
-So next run the following command:
 
 .. code-block:: console
 
@@ -279,20 +300,21 @@ Installing MPF & MC
 5.1 Install MPF & MC (Stable Release)
 -------------------------------------
 
-First, double-check you're in your virtual enviroment, if you set one up.
-
+First, double-check that you've activated your virtual enviroment, if you set one up.
 Next you can run pip again to install MPF itself, along with MPF-MC (the
-`Mission Pinball Framework Media Controller <http://docs.missionpinball.org/en/latest/start/media_controller.html>`_)
+`Mission Pinball Framework Media Controller <http://docs.missionpinball.org/en/latest/start/media_controller.html>`_).
+
 Install MPF and MC like this:
 
 .. code-block:: console
 
    pip install mpf mpf-mc
 
-If you are using High Sierra or newer, you may need to add the --user option to get
-around a specific rights problem if the above doesn't work.
+If you are using High Sierra or newer, and aren't using a virtual environment,
+you may need to add the --user option to get around a specific rights problem
+(use the following if the previous command didn't work). 
 
-.. code_block:: console
+.. code-block:: console
 
    pip install mpf mpf-mc --user
 
@@ -363,70 +385,38 @@ version is the latest.)
 
 The stable release of MPF is updated every few months, but if you always want the most up-to-date
 changes, which often fix (but sometimes cause) bugs and introduce new features, you can run MPF
-directly from the codebase.
+from the latest development build.
 
-You can use *git* to clone the MPF and MC repositories onto your computer, which will download
-the current code (instead of the latest release code, which pip downloads). Git will automatically
-create a folder in your current directory, so choose where you want them to live and run the 
-following commands:
+The installation instructions are the same, except for including "--pre" in the install command
+(for "prerelease").
 
 .. code-block:: console
 
-  My-Mac:~ $ git clone https://github.com/missionpinball/mpf.git
-  Cloning into 'mpf'...
-  Receiving objects: 100%, done.
-  Resolving deltas: 100%, done.
-  
-  My-Mac:~ $ git clone https://github.com/missionpinball/mpf-mc.git
-  Cloning into 'mpf-mc'...
-  Receiving objects: 100%, done.
-  Resolving deltas: 100%, done.
+   pip install --pre mpf mpf-mc
 
-Now we'll use pip to "install" MPF and MC, but we'll explicitly tell pip to run the code
-out of the folders we've specified (instead of downloading and caching the latest release).
-Because git automatically created the "mpf" and "mpf-mc" folders, we can use those folder names
-with the `-e` flag.
+The prereleases will have "dev" in their version number to indicate that they are under development.
 
 .. code-block:: console
 
-  pip install -e mpf
-  pip install -e mpf-mc
-
-When the installs complete, you can confirm that MPF and MC are running locally by using
-the pip list command. It should output a long list of packages that are installed, and note
-that mpf and mpf-mc have your folder in the Location column.
-
-.. code-block:: console
-
-  My-Mac:~ $ pip list
-  Package          Version     Location
-  ---------------- ----------- -------------------------
-  Cython           0.29.3
-  idna             2.8
-  Kivy             1.10
-  Kivy-Garden      0.1.4
-  mpf              0.51.3      /Users/anthony/git/mpf
-  mpf-mc           0.51.5      /Users/anthony/git/mpf-mc
-  Pillow           5.4.1
-  pip              19.0.1
-  Pygments         2.3.1
-
-.. note::
-
-  You will have many more packages in your list, the above sample is abridged for demonstration purposes.
+   My-Mac:~ $ mpf --version
+   MPF v0.52.0.dev3
 
 6. Update Kivy to 1.11
 ----------------------
 
 There is a known bug in Kivy 1.10 that causes intermittent freezing in applications, including MC.
 As of this writing (January 2019) there is no scheduled release date for Kivy 1.11 that fixes the
-bug, but we can manually install it from github.
+bug, but we can manually install it.
 
 .. code-block:: console
 
   pip install https://github.com/kivy/kivy/archive/master.zip
 
 This installation may take a couple of minutes.
+
+.. note::
+
+  To avoid dependency conflicts, it's best to install MPF & MC first, and then update Kivy.
 
 Running Pinball Games in MPF
 ============================
@@ -456,7 +446,7 @@ Running MPF
 
 See the section :doc:`/running/index` for details and command-line options.
 
-9.1 Keeping MPF up-to-date (Stable Release)
+9. Keeping MPF up-to-date
 ---------------------------------------
 
 Since MPF is a work-in-progress, you can use the *pip* command to update your
@@ -466,14 +456,10 @@ To to this, run the following:
 
 .. code-block:: console
 
-  curl -O https://bootstrap.pypa.io/get-pip.py
-  python3 get-pip.py
-  pip3 install setuptools --upgrade
-  pip3 install mpf mpf-mc --upgrade
+  pip3 install --upgrade mpf mpf-mc
 
-This will first update the required Python packages *pip* and *setuptools* and then cause
-*pip* to contact PyPI to see if there's a newer version of the MPF MC (and any of its
-requirements, like MPF). If newer versions are found, it will download and install them.
+This will trigger *pip* to contact the PyPI servers to see if there's a newer version of MPF or MC
+(and any of their requirements). If newer versions are found, pip will download and install them.
 
 .. warning::
 
@@ -482,11 +468,13 @@ requirements, like MPF). If newer versions are found, it will download and insta
    work in MPF 0.50. Please refer to :doc:`Migrating from config version 4 to 5 of MPF </install/migrate4to5>`
    for step-by-step instructions.
 
-To install the latest dev release (not generally recommended) which allows you to try bleeding-edge features run:
+The standard upgrade will only find stable releases, which are recommended for most users. 
+To install the latest development build, which may include new features and fixes (but might
+also break or have new bugs), include "--pre" in your upgrade command:
 
 .. code-block:: console
 
-  pip3 install mpf mpf-mc --pre --upgrade
+  pip3 install --upgrade --pre mpf mpf-mc 
 
 To downgrade (or install a specific release x.yy.z) run:
 
@@ -495,30 +483,6 @@ To downgrade (or install a specific release x.yy.z) run:
   pip3 install mpf=x.yy.z
   pip3 install mpf-mc=x.yy.z
 
-9.2 Keeping MPF up-to-date (Latest)
------------------------------------
-
-When you cloned the MPF and MC repositories and installed them, you saved a snapshot of MPF and MC 
-on the day you cloned them. Any time you want to fetch the latest
-updates and fixes, go to the mpf (or mpf-mc) repository folder and pull the newest code.
-
-.. code-block:: console
-
-  My-Mac:~ $ cd mpf
-  My-Mac:mpf $ git pull
-  remote: Counting objects: 12, done.
-  Unpacking objects: 100%, done.
-
-If there are any changes, they will be downloaded. You do not need to re-install or update with pip
-in any way, because you are always running the code directly out of the repository folder.
-
-If there are no changes, git will let you know.
-
-.. code-block:: console
-
-  My-Mac:~ $ cd mpf-mc
-  My-Mac:mpf-mc $ git pull
-  Already up to date.
 
 Next steps!
 ===========

--- a/install/mac.rst
+++ b/install/mac.rst
@@ -181,19 +181,15 @@ call the environment "mpfenv" and put it in our home directory (known as "~").
 
   python3 -m venv ~/mpfenv
 
-If you have multiple versions of Python3 (say, 3.4 and 3.6), you can specify
-which one to use in the virtual environment:
-
-.. code-block:: console
-
-  python3.6 -m venv ~/mpfenv
-
 .. note::
 
-  A virtual environment is recommended for any general-use computer you'll be
-  using MPF on. For a dedicated MPF machine that will have no other programs
-  installed (for example, a computer inside a pinball cabinet), a virtual 
-  environment is not recommended.
+  If you have multiple versions of Python3 (say, 3.4 and 3.6), you can specify
+  which one to use in the virtual environment: ``python3.6 -m venv ~/mpfenv``
+
+A virtual environment is recommended for any general-use computer you'll be
+using MPF on. For a dedicated MPF machine that will have no other programs
+installed (for example, a computer inside a pinball cabinet), a virtual 
+environment is not recommended.
 
 5. Activate your Virtual Environment
 ------------------------------------
@@ -211,7 +207,7 @@ to your virtual environment and "/bin/activate".
 .. note::
 
   You may want to write this step down, as you'll run it every time you open up
-  a terminal window to work on MPF*
+  a terminal window to work on MPF
 
 You'll know you're in the virtual environment because the console prompt will include
 the name of your venv in parenthesis.
@@ -233,15 +229,17 @@ the name of your venv in parenthesis.
    you must type "python3" to use Python 3; inside the virtual environment,
    you can use "python" to refer to Python 3.
 
-4. Install/upgrade some Python components
+6. Install/upgrade some Python components
 -----------------------------------------
+
+**4.1 Upgrade Pip**
 
 Python includes a utility called "pip" which is the name of the Python Package
 Manager. Pip is used to install Python packages and applications from
 the web. (It's kind of like an app store for Python apps.)
 
 If you are not using a virtual environment and have both Python 2 and Python 3 
-on your system, you'll most likely need to use "pip3". Check your version to see:
+on your system, you'll most likely need to use pip3. Check your version to see:
 
 .. code-block:: console
   
@@ -250,17 +248,17 @@ on your system, you'll most likely need to use "pip3". Check your version to see
   My-Mac:~ $ pip3 --version
   pip 16.2.1 from /usr/bin/pip3 (python 3.6)
 
-If your "pip" is for Python 2, then you'll use "pip3" through the rest of this guide. 
+If your ``pip`` is for Python 2, then you'll use ``pip3`` through the rest of this guide. 
 
-If you created a virtual environment using Python 3, then "pip" will be the same 
-as "pip3" and you can use them interchangably.
+If you created a virtual environment using Python 3, then ``pip`` will be the same 
+as ``pip3`` and you can use them interchangably.
 
 .. code-block:: console
   
   (mpfenv) My-Mac:~ $ pip --version
-  pip 19.0.1 from ~/venv/lib/python3.6/site-packages/pip (python 3.6)
+  pip 19.0.1 from ~/mpfenv/lib/python3.6/site-packages/pip (python 3.6)
   (mpfenv) My-Mac:~ $ pip3 --version
-  pip 19.0.1 from ~/venv/lib/python3.6/site-packages/pip (python 3.6)
+  pip 19.0.1 from ~/mpfenv/lib/python3.6/site-packages/pip (python 3.6)
 
 The versions of pip that come with Python aren't always the newest, so it's a
 good idea to update pip by running the following command:
@@ -270,6 +268,8 @@ good idea to update pip by running the following command:
   pip install --update pip
 
 The latest version of pip should now be installed.
+
+**4.2 Install Setuptools and Cython**
 
 Next, we need to install and update a few other python packages required to run mpf by
 running the following command:
@@ -294,25 +294,31 @@ whenever you're running this):
    Installing collected packages: setuptools, cython
    Successfully installed cython-0.25.2 setuptools-32.3.1
   
-By default, pip downloads and installs precompiled binaries. The Kivy binaries
-include frameworks that can conflict with the Mac Library frameworks, so it's
-preferred to install Kivy and build a local binary. We can tell pip to not
-download the precompiled binary:
+**4.3 Install Kivy**
+
+Finally, we need to install a graphics framework called Kivy.
+
+By default, pip will download and install precompiled binaries. The Kivy binaries
+include frameworks that can conflict with the Mac Library frameworks we
+added in step 1, so instead we want pip to download the uncompiled Kivy files 
+and make a new binary. 
+
+We can tell pip to do that with the following command:
 
 .. code-block:: console
 
   pip install kivy --no-binary :all:
 
-This installation may take a couple of minutes.
+The installation of Kivy may take a couple of minutes.
 
 Installing MPF & MC
 ===================
 
-5.1 Install MPF & MC (Stable Release)
+7. Install MPF & MC (Stable Release)
 -------------------------------------
 
 First, double-check that you've activated your virtual enviroment, if you set one up.
-Next you can run pip again to install MPF itself, along with MPF-MC (the
+Next you can run pip to install MPF itself, along with MPF-MC (the
 `Mission Pinball Framework Media Controller <http://docs.missionpinball.org/en/latest/start/media_controller.html>`_).
 
 Install MPF and MC like this:
@@ -321,22 +327,16 @@ Install MPF and MC like this:
 
    pip install mpf mpf-mc
 
-If you are using High Sierra or newer, and aren't using a virtual environment,
-you may need to add the --user option to get around a specific rights problem
-(use the following if the previous command didn't work). 
 
-.. code-block:: console
+.. note::
 
-   pip install mpf mpf-mc --user
+  If you are using High Sierra or newer and aren't using a virtual environment,
+  you may encounter a permissions error. If so, add ``--user`` to the end of the 
+  above command.
 
 Your results should look something like the results below. The MPF install will
 download and install several other packages which what all these other things
 are.
-
-.. note::
-
-   The "kivy" component will take awhile to install. Maybe a minute or two
-   where it looks like it's not doing anything, but it's fine.
 
 .. code-block:: console
 
@@ -391,19 +391,21 @@ this:
 (Note that the actual version number of your MPF installation will be whatever
 version is the latest.)
 
-5.2 Install MPF & MC (Development Build)
+7.2 Install MPF & MC (Development Build)
 ----------------------------------------
 
 The stable release of MPF is updated every few months, after being tested and used
 by the development team. If you want to play with the most up-to-date changes, 
-you can run MPF from the latest development build. This is not recommended for most
-users.
+you can run MPF from the latest development build. 
+*This is not recommended for most users.*
 
-The development builds may include new features in progress, changes to behavior,
-and bugs. Running the development builds is recommended for people who want to
-actively participate in the development and testing of MPF.
+.. note::
 
-The installation instructions are the same, except for including "--pre" in the install command
+  The development builds may include new features in progress, changes to behavior,
+  and bugs. Running the development builds is recommended for people who want to
+  actively participate in the development and testing of MPF.
+
+The installation instructions are the same, except for including ``--pre`` in the install command
 (for "prerelease").
 
 .. code-block:: console
@@ -418,7 +420,7 @@ The prereleases will have "dev" in their version number to indicate that they ar
    MPF v0.52.0.dev3
 
 If you want to switch from the development build back to the stable release, uninstall
-and run the install command without the "--pre".
+and run the install command without ``--pre``.
 
 .. code-block:: console
 
@@ -428,7 +430,7 @@ and run the install command without the "--pre".
 Running Pinball Games in MPF
 ============================
 
-6. Download & run the "Demo Man" example game
+8. Download & run the "Demo Man" example game
 ---------------------------------------------
 
 Now that you have MPF installed, you probably want to see it in action. The easiest way to do that is
@@ -439,7 +441,7 @@ There's another example project you can also check out if you want called the "M
 that lets you step through a bunch of example display things (slides, widgets, sounds, videos, etc).
 Instructions for running the MC Demo are :doc:`here </example_games/mc_demo>`.
 
-7. Install whatever drivers your hardware controller needs
+9. Install whatever drivers your hardware controller needs
 ----------------------------------------------------------
 
 If you're using MPF with a physical machine, then there will be some specific
@@ -453,7 +455,7 @@ Running MPF
 
 See the section :doc:`/running/index` for details and command-line options.
 
-8. Keeping MPF up-to-date
+10. Keeping MPF up-to-date
 ---------------------------------------
 
 Since MPF is a work-in-progress, you can use the *pip* command to update your

--- a/install/mac.rst
+++ b/install/mac.rst
@@ -39,6 +39,9 @@ To remove the old MPF Mac installation:
 If you don't know how to find your ``/usr/local/bin`` folder, you can use
 the "Go to Folder" technique shown in Step 1.
 
+Prerequisites and Python Environment
+====================================
+
 1. Download the Mac Multimedia Frameworks
 -----------------------------------------
 
@@ -111,7 +114,7 @@ Click the "Install" button here to get just the command line tools. The
 
 The download will be about 150 MB, and the total install will be about 1.1 GB.
 
-After the installation of the tools you need to accept the license agreeement from Apple.
+After the installation of the tools you may need to accept the license agreeement from Apple.
 The following command starts that process in the Terminal, just follow the instructions provided:
 
 ::
@@ -121,18 +124,18 @@ The following command starts that process in the Terminal, just follow the instr
 If you already have the command line tools installed, that's fine. You'll get
 some kind of error saying they're already installed and you can move on.
 
-3. Install Python 3.5 or 3.6
+3. Install Python 3.5+
 ----------------------------
 
 MPF is written in a computer language called "Python". This means you have to install Python
 first before you can use MPF. Luckily this is just a one-time install, and you don't have to
 install it again if you update MPF later.
 
-On Mac platforms, MPF requires Python 3.5 or never. We lately tested Python 3.6 and it can be used.
+On Mac platforms, MPF requires Python 3.5 or newer. It is well-tested on 3.6 and somewhat tested on 3.7.
 
-You can download Python 3.6 directly via `this link <https://www.python.org/ftp/python/3.6.5/python-3.6.5-macosx10.9.pkg>`_.
+You can download Python 3.6 directly via `this link <https://www.python.org/ftp/python/3.6.8/python-3.6.8-macosx10.9.pkg>`_.
 (Note that the final digit in the Python version number is the "patch" number,
-so 3.6.5 is the latest version of Python 3.6 as of the time this document was last updated.)
+so 3.6.8 is the latest version of Python 3.6 as of the time this document was last updated.)
 
 .. image:: images/mac_install_python_1.jpg
 
@@ -162,6 +165,60 @@ different between the two:
 
 .. image:: images/mac_python_versions.jpg
 
+4. Create a Virtual Environment
+-------------------------------
+
+Python includes a utility call "virtual environment" that creates a safe,
+isolated environment to install packages and configure python. It's strongly
+recommended to install MPF in a virtual environment, so that other Python
+programs can't pollute it (and it can't pollute others).
+
+To create a virtual enviroment, choose a folder where you want to install
+a copy of python and keep the enviroment's packages. For this example, we'll
+call the environment "mpfenv" and put it in our home directory (known as "~").
+
+.. code-block:: console
+
+  python3 -m venv ~/mpfenv
+
+If you have multiple versions of Python3 (say, 3.4 and 3.6), you can specify
+which one to use in the virtual environment:
+
+.. code-block:: console
+
+  python3.6 -m venv ~/mpfenv
+
+5. Activate your Virtual Environment
+------------------------------------
+
+To keep your virtual enviroment isolated, it only activates when you tell it to.
+You can enable the virtual environment with the dot command from the terminal:
+
+.. code-block:: console
+
+  . ~/mpfenv/bin/activate
+
+Note that the first character is a period, followed by a space, then the path
+to your virtual environment and "/bin/activate".
+
+.. note::
+  You may want to write this step down, as you'll run it every time you open up
+  a terminal window to work on MPF*
+
+You'll know you're in the virtual environment because the console prompt will include
+the name of your venv in parenthesis. Conveniently, the python you used to create
+the virtual environment will now be the default python.
+
+.. code-block:: console
+
+  My-Mac:~ python --version
+  Python 2.7.10
+  My-Mac:~ . ~/mpfenv/bin/activate
+  (mpfenv) My-Mac:~ python --version
+  Python 3.6.8
+  (mpfenv) My-Mac:~ 
+
+
 4. Install/upgrade some Python components
 -----------------------------------------
 
@@ -169,18 +226,27 @@ Python includes a utility called "pip" which is the name of the Python Package
 Manager. Pip is used to install Python packages and applications from
 the web. (It's kind of like an app store for Python apps.)
 
-Due to a bug in versions of pip older than 9.0.2 on the Mac, we cannot update *pip*
-using *pip*. So the next step is to download and run a special Python script to install
-the latest version of pip.
+If you created a virtual environment using Python3, then pip will be correct.
+If you are not using a virtual environment and have both Python2 and Python3 
+on your system, you'll want to check your version:
 
-Update pip by running the following command:
+.. code-block:: console
+  
+  My-Mac:~ $ pip --version
+  pip 8.0.2 from /usr/bin/pip (python 2.7)
+  My-Mac:~ $ pip3 --version
+  pip 18.0.1 from /usr/bin/pip3 (python 3.6)
+
+If your "pip" is for Python2, then you'll use "pip3" through the rest of this guide.
+
+The versions of pip that come with Python aren't always the newest, so it's a
+good idea to update pip by running the following command:
 
 .. code-block:: console
 
-    curl -O https://bootstrap.pypa.io/get-pip.py
-    python3 get-pip.py
+  pip install --update pip
 
-The latest version of pip should now be installed (9.0.3 or newer).
+The latest version of pip should now be installed.
 
 Next, we need to install and update a few other python packages required to run mpf by
 running the following command:
@@ -189,12 +255,12 @@ So next run the following command:
 
 .. code-block:: console
 
-    pip3 install setuptools cython==0.25.2 --upgrade
+    pip install --upgrade setuptools cython
 
 This command will download and install the latest versions of the *setuptools*
-package, as well as version 0.25.2 of a package called *cython*. The results will
-look something like this (though the exact version numbers might be different
-depending on what's the latest whenever you're running this):
+and *cython* packages. The results will look something like this (though the 
+exact version numbers might be different depending on what's the latest 
+whenever you're running this):
 
 .. code-block:: console
 
@@ -206,38 +272,29 @@ depending on what's the latest whenever you're running this):
        100% |################################| 3.8MB 7.6MB/s
    Installing collected packages: setuptools, cython
    Successfully installed cython-0.25.2 setuptools-32.3.1
-   
-We recommend to stick to the specific cython Version, as others broke our installation process while testing the installation on different Macs.
+  
+Installing MPF & MC
+===================
 
-5. Install MPF
---------------
+5.1 Install MPF & MC (Stable Release)
+-------------------------------------
 
-Next you can run pip again to install MPF itself. Technically what you're
-installing is "mpf-mc", which is the
-`Mission Pinball Framework Media Controller <http://docs.missionpinball.org/en/latest/start/media_controller.html>`_
-package, but that package will also install the MPF game engine. Install MPF
-like this:
+First, double-check you're in your virtual enviroment, if you set one up.
+
+Next you can run pip again to install MPF itself, along with MPF-MC (the
+`Mission Pinball Framework Media Controller <http://docs.missionpinball.org/en/latest/start/media_controller.html>`_)
+Install MPF and MC like this:
 
 .. code-block:: console
 
-   pip3 install mpf-mc --pre
+   pip install mpf mpf-mc
 
-.. note::
+If you are using High Sierra or newer, you may need to add the --user option to get
+around a specific rights problem if the above doesn't work.
 
-   Since MPF 0.50 is not yet released, the command you need to run is
-   "pip install mpf-mc --pre" to get the latest "pre-release" version, so that MPF runs under Mac.
-   
-   If you Upgrade your installation add --upgrade to the call like this:   
+.. code_block:: console
 
-::
-
-   pip3 install mpf-mc --pre --upgrade
-   
-If you are using High Sierra please add the --user option to get around a specific rights problem:
-
-::
-
-   pip3 install mpf-mc --pre --upgrade --user
+   pip install mpf mpf-mc --user
 
 Your results should look something like the results below. The MPF install will
 download and install several other packages which what all these other things
@@ -250,7 +307,7 @@ are.
 
 .. code-block:: console
 
-   Brians-Mac:~ brian$ pip3 install mpf-mc
+   My-Mac:~ $ pip3 install mpf-mc
    Collecting mpf-mc
      Downloading mpf-mc-0.32.12.tar.gz (11.1MB)
        100% |################################| 11.1MB 29.6MB/s
@@ -282,22 +339,9 @@ are.
      Running setup.py install for kivy ... done
      Running setup.py install for mpf-mc ... done
    Successfully installed Kivy-Garden-0.1.4 kivy-1.9.1 mpf-0.32.6 mpf-mc-0.32.12 pyserial-3.2.1 pyserial-asyncio-0.3 requests-2.12.4 ruamel.base-1.0.0 ruamel.yaml-0.10.23
-   Brians-Mac:~ brian$
+   My-Mac:~ $
    
-Now you will have to install PyQt5 to get the rest of the system running later on:
-
-::
-
-   sudo pip3 install PyQt5
-   
-Patch your Terminal undr High Sierra, so that it can show the UI correctely (otherwise it produces an error in "curs_set()"):
-
-::
-
-    export TERM=xterm-256color
-    
-
-If you want to make sure that MPF was installed, quit the Terminal app and restart it, and then run:
+If you want to make sure that MPF was installed, run:
 
 .. code-block:: console
 
@@ -308,13 +352,86 @@ this:
 
 .. code-block:: console
 
-   Brians-Mac:~ brian$ mpf --version
-   MPF v0.50.82
+   My-Mac:~ $ mpf --version
+   MPF v0.51.3
 
 (Note that the actual version number of your MPF installation will be whatever
 version is the latest.)
 
-6. Download & run the "Demo Man" example game
+5.2 Install MPF & MC (Latest)
+-----------------------------
+
+The stable release of MPF is updated every few months, but if you always want the most up-to-date
+changes, which often fix (but sometimes cause) bugs and introduce new features, you can run MPF
+directly from the codebase.
+
+You can use *git* to clone the MPF and MC repositories onto your computer, which will download
+the current code (instead of the latest release code, which pip downloads). Git will automatically
+create a folder in your current directory, so choose where you want them to live and run the 
+following commands:
+
+.. code-block:: console
+
+  My-Mac:~ $ git clone https://github.com/missionpinball/mpf.git
+  Cloning into 'mpf'...
+  Receiving objects: 100%, done.
+  Resolving deltas: 100%, done.
+  
+  My-Mac:~ $ git clone https://github.com/missionpinball/mpf-mc.git
+  Cloning into 'mpf-mc'...
+  Receiving objects: 100%, done.
+  Resolving deltas: 100%, done.
+
+Now we'll use pip to "install" MPF and MC, but we'll explicitly tell pip to run the code
+out of the folders we've specified (instead of downloading and caching the latest release).
+Because git automatically created the "mpf" and "mpf-mc" folders, we can use those folder names
+with the `-e` flag.
+
+.. code-block:: console
+
+  pip install -e mpf
+  pip install -e mpf-mc
+
+When the installs complete, you can confirm that MPF and MC are running locally by using
+the pip list command. It should output a long list of packages that are installed, and note
+that mpf and mpf-mc have your folder in the Location column.
+
+.. code-block:: console
+
+  My-Mac:~ $ pip list
+  Package          Version     Location
+  ---------------- ----------- -------------------------
+  Cython           0.29.3
+  idna             2.8
+  Kivy             1.10
+  Kivy-Garden      0.1.4
+  mpf              0.51.3      /Users/anthony/git/mpf
+  mpf-mc           0.51.5      /Users/anthony/git/mpf-mc
+  Pillow           5.4.1
+  pip              19.0.1
+  Pygments         2.3.1
+
+.. note::
+
+  You will have many more packages in your list, the above sample is abridged for demonstration purposes.
+
+6. Update Kivy to 1.11
+----------------------
+
+There is a known bug in Kivy 1.10 that causes intermittent freezing in applications, including MC.
+As of this writing (January 2019) there is no scheduled release date for Kivy 1.11 that fixes the
+bug, but we can manually install it from github.
+
+.. code-block:: console
+
+  pip install https://github.com/kivy/kivy/archive/master.zip
+
+This installation may take a couple of minutes.
+
+Running Pinball Games in MPF
+============================
+
+7. Download & run the "Demo Man" example game
 ---------------------------------------------
 
 Now that you have MPF installed, you probably want to see it in action. The easiest way to do that is
@@ -325,7 +442,7 @@ There's another example project you can also check out if you want called the "M
 that lets you step through a bunch of example display things (slides, widgets, sounds, videos, etc).
 Instructions for running the MC Demo are :doc:`here </example_games/mc_demo>`.
 
-7. Install whatever drivers your hardware controller needs
+8. Install whatever drivers your hardware controller needs
 ----------------------------------------------------------
 
 If you're using MPF with a physical machine, then there will be some specific
@@ -335,12 +452,12 @@ documentation for details. (You don't have to worry about that now if you just
 want to play with MPF first.)
 
 Running MPF
------------
+===========
 
 See the section :doc:`/running/index` for details and command-line options.
 
-Keeping MPF up-to-date
-----------------------
+9.1 Keeping MPF up-to-date (Stable Release)
+---------------------------------------
 
 Since MPF is a work-in-progress, you can use the *pip* command to update your
 MPF installation.
@@ -378,8 +495,33 @@ To downgrade (or install a specific release x.yy.z) run:
   pip3 install mpf=x.yy.z
   pip3 install mpf-mc=x.yy.z
 
+9.2 Keeping MPF up-to-date (Latest)
+-----------------------------------
+
+When you cloned the MPF and MC repositories and installed them, you saved a snapshot of MPF and MC 
+on the day you cloned them. Any time you want to fetch the latest
+updates and fixes, go to the mpf (or mpf-mc) repository folder and pull the newest code.
+
+.. code-block:: console
+
+  My-Mac:~ $ cd mpf
+  My-Mac:mpf $ git pull
+  remote: Counting objects: 12, done.
+  Unpacking objects: 100%, done.
+
+If there are any changes, they will be downloaded. You do not need to re-install or update with pip
+in any way, because you are always running the code directly out of the repository folder.
+
+If there are no changes, git will let you know.
+
+.. code-block:: console
+
+  My-Mac:~ $ cd mpf-mc
+  My-Mac:mpf-mc $ git pull
+  Already up to date.
+
 Next steps!
------------
+===========
 
 Now that MPF is installed, you can follow our
 :doc:`step-by-step tutorial </tutorial/index>` which will show you how to start

--- a/install/mac.rst
+++ b/install/mac.rst
@@ -294,6 +294,17 @@ whenever you're running this):
    Installing collected packages: setuptools, cython
    Successfully installed cython-0.25.2 setuptools-32.3.1
   
+By default, pip downloads and installs precompiled binaries. The Kivy binaries
+include frameworks that can conflict with the Mac Library frameworks, so it's
+preferred to install Kivy and build a local binary. We can tell pip to not
+download the precompiled binary:
+
+.. code-block:: console
+
+  pip install kivy --no-binary :all:
+
+This installation may take a couple of minutes.
+
 Installing MPF & MC
 ===================
 
@@ -380,19 +391,24 @@ this:
 (Note that the actual version number of your MPF installation will be whatever
 version is the latest.)
 
-5.2 Install MPF & MC (Latest)
------------------------------
+5.2 Install MPF & MC (Development Build)
+----------------------------------------
 
-The stable release of MPF is updated every few months, but if you always want the most up-to-date
-changes, which often fix (but sometimes cause) bugs and introduce new features, you can run MPF
-from the latest development build.
+The stable release of MPF is updated every few months, after being tested and used
+by the development team. If you want to play with the most up-to-date changes, 
+you can run MPF from the latest development build. This is not recommended for most
+users.
+
+The development builds may include new features in progress, changes to behavior,
+and bugs. Running the development builds is recommended for people who want to
+actively participate in the development and testing of MPF.
 
 The installation instructions are the same, except for including "--pre" in the install command
 (for "prerelease").
 
 .. code-block:: console
 
-   pip install --pre mpf mpf-mc
+   pip install --upgrade --pre mpf mpf-mc
 
 The prereleases will have "dev" in their version number to indicate that they are under development.
 
@@ -401,27 +417,18 @@ The prereleases will have "dev" in their version number to indicate that they ar
    My-Mac:~ $ mpf --version
    MPF v0.52.0.dev3
 
-6. Update Kivy to 1.11
-----------------------
-
-There is a known bug in Kivy 1.10 that causes intermittent freezing in applications, including MC.
-As of this writing (January 2019) there is no scheduled release date for Kivy 1.11 that fixes the
-bug, but we can manually install it.
+If you want to switch from the development build back to the stable release, uninstall
+and run the install command without the "--pre".
 
 .. code-block:: console
 
-  pip install https://github.com/kivy/kivy/archive/master.zip
-
-This installation may take a couple of minutes.
-
-.. note::
-
-  To avoid dependency conflicts, it's best to install MPF & MC first, and then update Kivy.
+  pip uninstall mpf mpf-mc
+  pip install mpf mpf-mc
 
 Running Pinball Games in MPF
 ============================
 
-7. Download & run the "Demo Man" example game
+6. Download & run the "Demo Man" example game
 ---------------------------------------------
 
 Now that you have MPF installed, you probably want to see it in action. The easiest way to do that is
@@ -432,7 +439,7 @@ There's another example project you can also check out if you want called the "M
 that lets you step through a bunch of example display things (slides, widgets, sounds, videos, etc).
 Instructions for running the MC Demo are :doc:`here </example_games/mc_demo>`.
 
-8. Install whatever drivers your hardware controller needs
+7. Install whatever drivers your hardware controller needs
 ----------------------------------------------------------
 
 If you're using MPF with a physical machine, then there will be some specific
@@ -446,7 +453,7 @@ Running MPF
 
 See the section :doc:`/running/index` for details and command-line options.
 
-9. Keeping MPF up-to-date
+8. Keeping MPF up-to-date
 ---------------------------------------
 
 Since MPF is a work-in-progress, you can use the *pip* command to update your

--- a/tools/monitor/installation.rst
+++ b/tools/monitor/installation.rst
@@ -4,8 +4,11 @@ Installing the MPF Monitor
 Here's how you install the MPF Monitor. These instructions are a bit rough
 since MPF Monitor is an early prototype.
 
-Windows
--------
+Windows and Mac
+---------------
+
+MPF Monitor has dependencies on MPF and should be run in the same environment.
+If you use a virtual environment for MPF, activate it before proceeding.
 
 1. Install PyQt5.  Open a command prompt and run:
 
@@ -39,25 +42,6 @@ Note that since MPF Monitor is a separate app from MPF and MPF-MC, the version
 numbers of the Monitor and MPF are not the same. (For example, the same version
 of MPF Monitor can work across several versions of MPF.)
 
-Mac
----
-
-Open a terminal window and run the following command: (You can run this from
-any folder)
-
-.. code-block:: console
-
-   pip3 install mpf-monitor
-
-To update MPF Monitor to the latest version at any time, run:
-
-.. code-block:: console
-
-   pip3 install mpf-monitor --upgrade
-
-Note that since MPF Monitor is a separate app from MPF and MPF-MC, the version
-numbers of the Monitor and MPF are not the same. (For example, the same version
-of MPF Monitor can work across several versions of MPF.)
 
 Linux
 -----

--- a/tutorial/1_install_mpf.rst
+++ b/tutorial/1_install_mpf.rst
@@ -55,9 +55,9 @@ command:
 
    mpf --version
 
-That command should print something like ``MPF v0.33.12``. Note that the version is three numbers, ``x.y.z``.
+That command should print something like ``MPF v0.51.3``. Note that the version is three numbers, ``x.y.z``.
 The last number (the "z") is the patch number and doesn't have any functional changes. (In other words, MPF
-0.30.0 and 0.30.2 and 0.30.56 have the same functions and features.)
+0.51.0 and 0.51.2 and 0.51.56 have the same functions and features.)
 
 .. tip::
 


### PR DESCRIPTION
This PR renovates the installation instructions for Mac, cleaning up some legacy workarounds and eliminating some steps. The steps were written based on a fresh wipe/install of High Sierra. I made (at least) two test runs each of latest release (`pip install mpf`), dev release (`--pre`), and dev local (`-e`) on Python 3.6 and 3.7. 

A few questions and notes about the changes:

* The new instructions are based on using virtual environments, which are included in Python 3. I believe as a result of the virtual environments some of the sudo elevations are no longer necessary

* Pip is included in Python 3 and its virtual environments, so the manual pip installation is removed

* As of 0.51, `setuptools` and `cython` seem to play nice without explicit versioning.

* What does `PyQt5` do? I didn't install it on any of my test runs and all is working well.

* I didn't find the Terminal patch necessary, as the UI rendered properly in both native Terminal and iTerm.

* I found the best success doing the MPF/MC install and _then_ updating Kivy from 1.10 to 1.11. Trying to do Kivy first led to grossness.


When I was playing around with installation steps and particularly Kivy, I would sometimes get the SDL `One of the two will be used. Which one is undefined.` warnings. But when I do fresh virtual environments following the final version of the instructions, I don't. So... that's good?
