### PR TITLE
information on Enable pin seems incorrect

### DIFF
--- a/hardware/stepstick/index.rst
+++ b/hardware/stepstick/index.rst
@@ -22,7 +22,7 @@ Configuring your stepper
 A step stick stepper needs two or three outputs which define the hardware
 number: ``direction_output:step_output`` or
 ``direction_output:step_output:enable_output``.
-In case you omit ``enable_output`` make sure it is pulled high permanently.
+In case you omit ``enable_output`` make sure it is pulled low permanently.
 In addition, you need a ``homing_switch`` so MPF can find the ``0`` position
 of your stepper at startup.
 
@@ -47,7 +47,7 @@ This is an example:
        type: driver
 
    switches:
-     s_home:
+     s_home:``
        number: 1
 
    steppers:
@@ -73,9 +73,10 @@ Connecting your stepper driver
 
 Connect the ``DIR`` pin to your ``direction_output``, ``STP`` to your
 ``step_output`` and``GND`` to your ground.
-If use an ``enable_output`` connect it to ``EN``, ``SLP`` and ``RST``
+If use an ``enable_output`` connect it to ``SLP`` and ``RST``
 (not all driver have all of them).
-Otherwise, pull them to VDD or the driver will not work.
+Otherwise, pull them to VDD or the driver will not work.  ``EN`` is
+pulled to GND to allow the FETs to pass current. 
 In addition, you need to pull ``M0``, ``M1`` and ``M2`` to VDD or GND
 to configure the step resolution.
 Your stepper will connect to ``1A``, ``1B``, ``2A`` and ``2B``.


### PR DESCRIPTION
Looking at my easystep driver documentation showed that the enable pin has to be low for the driver to be active.  Looking at stepstick reflects the same information.