### PR TITLE
Docs for “named_colors”; example of dynamic widgets

### DIFF
--- a/config/index.rst
+++ b/config/index.rst
@@ -103,6 +103,7 @@ indicated which type of config file it's valid in.
    multiball_locks: <multiball_locks>
    multiballs: <multiballs>
    mypinballs: <mypinballs>
+   named_colors: <named_colors>
    open_pixel_control: <open_pixel_control>
    opp: <opp>
    opp_coils: <opp_coils>

--- a/config/light_player.rst
+++ b/config/light_player.rst
@@ -64,8 +64,11 @@ color:
 ~~~~~~
 Single value, type: ``string``. Default: ``white``
 
-Set a color to this light. If you apply a color to a non-RGB light it will use
-the maximum brightness of any channel.
+Set a color to this light. Color values may be a hex string (e.g. `22FFCC`), a list of RGB values 
+(e.g. `[50, 128, 206]`),or a color name (e.g. `turquoise`). MPF knows 140+ standard web color names, 
+and you can define your own custom colors in the :doc:`/config/named_colors` section of your config. 
+
+If you apply a color to a non-RGB light it will use the maximum brightness of any channel.
 
 fade:
 ~~~~~

--- a/config/lights.rst
+++ b/config/lights.rst
@@ -57,6 +57,7 @@ contain any of the ``lights`` parameters listed on this page, but at least ``num
 Note that a light must have either ``channels`` or ``number`` defined, but cannot have both.
 See :doc:`/mechs/lights/leds` for more details about how to configure channels
 for different types of LEDs.
+
 color_correction_profile:
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 Single value, type: ``string``.
@@ -71,6 +72,10 @@ Single value, type: ``color`` (*color name*, *hex*, or list of values *0*-*255*)
 
 For multi-color LEDs, the color defined here will be used when the light is enabled via "on"
 (as opposed to being enabled with a specific color). Not intended for single-color lights.
+
+Color values may be a hex string (e.g. `22FFCC`), a list of RGB values (e.g. `[50, 128, 206]`),
+or a color name (e.g. `turquoise`). MPF knows 140+ standard web color names, and you can define your
+own custom colors in the :doc:`/config/named_colors` section of your config. 
 
 fade_ms:
 ~~~~~~~~

--- a/config/named_colors.rst
+++ b/config/named_colors.rst
@@ -29,6 +29,8 @@ This is an example:
     troll_target:
       number: 10
       default_on_color: troll_green
+    l_jackpot:
+      number: 20
 
   light_player:
     trolls_disabled:

--- a/config/named_colors.rst
+++ b/config/named_colors.rst
@@ -1,0 +1,41 @@
+named_colors:
+=============
+
+*Config file section*
+
++----------------------------------------------------------------------------+---------+
+| Valid in :doc:`machine config files </config/instructions/machine_config>` | **YES** |
++----------------------------------------------------------------------------+---------+
+| Valid in :doc:`mode config files </config/instructions/mode_config>`       | **YES** |
++----------------------------------------------------------------------------+---------+
+
+.. overview
+
+The ``named_colors:`` section of your config is where you define color names that
+can be used for RGB lights throughout your machine code. Anywhere in lights: or light_player: where a color can be specified, named colors can be used.
+
+Your named colors can be an array of R/G/B values or a hex string of hex values (which can also include a brightness percentage, like all hex color strings). 
+
+This is an example:
+
+.. code-block:: mpf-config
+
+  named_colors:
+    custom_blue:      [24, 65, 226]
+    troll_green:      4a9b22
+    troll_green_dark: 4a9b22%50
+
+  lights:
+    troll_target:
+      number: 10
+      default_on_color: troll_green
+
+  light_player:
+    trolls_disabled:
+      troll_target: troll_green_dark
+    jackpot_lit:
+      l_jackpot:
+        color: custom_blue
+        fade: 10
+
+

--- a/displays/widgets/reusable_widgets.rst
+++ b/displays/widgets/reusable_widgets.rst
@@ -95,8 +95,31 @@ pretty straightforward, though you might have to play with the ``z:`` setting (t
 example, if your current slide has a full size background, you'd want to configure your widget with a ``z:`` setting
 that's a higher priority so it shows up on top of the background image.)
 
-Adding a widget to a specific slide
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Adding a widget to a specific slide (by slide)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to build a slide and include a reusable widget, you can reference the widget's name in your slide config
+by declaring ``widget:`` instead of ``type:``.
+
+.. code-block:: mpf-config
+
+   widgets:
+     jackpot_value_widget:
+       - type: text
+         text: (jackpot_total)
+         style: body_med
+
+   slides:
+     hero_hurryup:
+       - type: text
+         text: "Hurry Up!"
+       - type: text
+         text: "Jackpot:"
+       - widget: jackpot_value_widget
+
+
+Adding a widget to a specific slide (by event)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want to add your widget to a particular slide (versus whatever slide happens to be showing at the moment), you
 can do so by specifying that slide name in the ``widget_player:``. For example:
@@ -244,3 +267,65 @@ multiple displays or slides at the same time. For example:
 Note that if you do this, the structure of YAML requires that you have at least
 one setting under each widget name, so you can just add a ``target:`` or ``action: add``
 if you don't want to change or set anything else in the widget.
+
+Dynamically choosing a widget based on variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can use a placeholder widget in a slide to dynamically choose any reusable widget for
+that slide, depending on an event parameter or player variable. 
+
+To create a placeholder widget in the slide, use the ``widget:`` setting with the standard
+:doc:`dynamic text </displays/widgets/text/text_dynamic>` formatting.
+
+For example, using the player variable "hero_class" to pick an image widget:
+
+.. code-block:: mpf-config
+
+   widgets:
+     hero_portrait_rogue:
+       - type: image
+         image: portrait_rogue
+     hero_portrait_bard:
+       - type: image
+         image: portrait_bard
+     hero_portrait_mage:
+       - type: image
+         image: portrait_mage
+
+   slides:
+     hero_slide:
+       - type: text
+         text: (player|name)
+       - type: text
+         text: Level (player|level)
+       - widget: hero_portrait_(player|hero_class)
+
+You can also use the parameters of an event to determine the widget to include. In the following example
+from a game with different multiballs, the event `mball_lock_lit` might post with either "angel" or
+"demon" as the `mball_name` parameter.
+
+.. code-block:: mpf-config
+
+   slide_player:
+     mball_lock_lit: mball_lock_slide
+
+   slides:
+     mball_lock_slide:
+       widgets:
+         - type: text
+           text: Lock is Lit
+         - widget: lock_lit_(mball_name)
+
+   widgets:
+     lock_lit_angel:
+       - type: text
+         text: Angels Anarchy
+       - type: image
+         image: bg_locklit_angels
+     lock_lit_demon:
+       - type: text
+         text: Demons Derby
+       - type: image
+         image: bg_locklit_demons
+
+


### PR DESCRIPTION
This PR adds a new section for the `named_colors:` config section, which is a wonderful feature that has been hidden from view. In addition to outlining how to use named colors, the `colors:` configs on lights and light_player have been expanded.

This PR also includes examples of using dynamic text values for reusable widgets, merged as a new feature for 0.52 (https://github.com/missionpinball/mpf-mc/pull/353) and asked about in a forum query (https://groups.google.com/forum/#!topic/mpf-users/_WCjW4_9Hic)