### PR TITLE
Add no-eject-on-ballsearch to ball device docs

### DIFF
--- a/config/ball_devices.rst
+++ b/config/ball_devices.rst
@@ -562,6 +562,9 @@ Special-purpose tags for ball devices include:
   have two devices under the apron, with a "drain" device receiving
   balls from the playfield which it then immediately kicks over to a
   "trough" device which holds the balls that are not in play.
+  + ``no-eject-on-ballsearch`` - Specifies that this device should never
+  attempt to eject a ball as a result of ball search, even when idle and
+  containing no balls.
 
 The use of ``ball_add_live`` is discontinued. Use ``default_source_device`` in
 your :doc:`playfield </config/playfields>` instead.


### PR DESCRIPTION
Added the ball device specific tag no-eject-on-ballsearch to the ball_device documentation. Since the pull corresponding pull request for mpf was merged.