### PR TITLE
add debug: yes

### DIFF
--- a/tutorial/7_trough.rst
+++ b/tutorial/7_trough.rst
@@ -86,6 +86,7 @@ add the debug setting like this:
            tags: trough, home, drain
            jam_switch: s_trough_jam
            eject_coil_jam_pulse: 15ms
+           debug: yes
 
 4. Don't test yet
 -----------------


### PR DESCRIPTION
NOTE: I am not sure if the way I wrote that was correct since I am going through the tutorial for the first time but the sentence says "For example, if you have a modern style trough with a jam switch, you'd add the debug setting like this:" and then doesn't show debug: yes in the code block? So I think that needs to be added? So I just guessed that it should come after the "eject_coil_jam_pulse: 15ms" line?