### PR TITLE
numbers don't match

### DIFF
--- a/tutorial/9_start_button.rst
+++ b/tutorial/9_start_button.rst
@@ -38,7 +38,7 @@ want act as the start button. So now your start switch in your
 
    switches:
         s_start:
-            number: 11
+            number: 10
             tags: start
 
 3. Add keyboard entries for your start switch


### PR DESCRIPTION
In the top section it sets s_start to "number: 10" but right after that it shows it as "number: 11". Since this is early on in the tutorial it probably makes more sense just to have them match? Either both 10 or both 11?