### PR TITLE
Fix up install specific version steps

### DIFF
--- a/install/windows.rst
+++ b/install/windows.rst
@@ -328,8 +328,8 @@ To downgrade (or install a specific release x.yy.z) run:
 
 .. code-block:: doscon
 
-  pip install mpf=x.yy.z
-  pip install mpf-mc=x.yy.z
+  pip install mpf==x.yy.z
+  pip install mpf-mc==x.yy.z
 
 Next steps!
 -----------


### PR DESCRIPTION
The step was missing a '=' sign in the commands to run.