### PR TITLE
Fix up install specific version of mpf for osx

### DIFF
--- a/install/mac.rst
+++ b/install/mac.rst
@@ -489,8 +489,8 @@ To downgrade (or install a specific release x.yy.z) run:
 
 .. code-block:: console
 
-  pip3 install mpf=x.yy.z
-  pip3 install mpf-mc=x.yy.z
+  pip3 install mpf==x.yy.z
+  pip3 install mpf-mc==x.yy.z
 
 
 Next steps!


### PR DESCRIPTION
Commands are missing a '=' sign.