### PR TITLE
Update index.rst

### DIFF
--- a/mechs/troughs/index.rst
+++ b/mechs/troughs/index.rst
@@ -61,6 +61,7 @@ Common parts include:
 
 * Williams: A-16809
 * Mantis Trough
+* Stern 500-9820-00
 
 If you have a modern trough with opto sensors, read the :doc:`modern_opto`
 guide to continue.


### PR DESCRIPTION
Adding the modern Stern all-opto trough as an example device. This is the trough in modern Stern games and is available for purchase from Marco so people might use it.

Also, I'm not sure how to include images but maybe throw this image in where it says "TODO: insert image of all-opto tough"

![Stern_500-9820-00](https://user-images.githubusercontent.com/8710222/62811075-399dca80-bab5-11e9-8155-982034592024.png)
