### PR TITLE
Update 18_shots.rst

### DIFF
--- a/tutorial/18_shots.rst
+++ b/tutorial/18_shots.rst
@@ -28,11 +28,11 @@ the ``base`` mode which is usually active all the time.
 
 .. note::
 
-   Before 0.30 you could define shots per machine-wide. This cause very complex
+   Before 0.30 you could define shots per machine-wide. This caused very complex
    configs and is no longer supported. You can put shots into your base mode
    if you want them to be active all the time during a game.
 
-Let's start by creating our first shot in the base mode.
+Let's start by creating our first shot in the base mode's config file (base.yaml).
 
 .. code-block:: mpf-config
 
@@ -52,10 +52,7 @@ Also, to make following the tutorial easier, go ahead and call this
 shot "my_first_shot" even if you're using a different switch name. You
 can change the name of the shot to something more meaningful later.
 
-Next, open the mode config file for your base mode, which is
-``<your_machine>/modes/base/config/base.yaml``
-
-Find the ``variable_player:`` section that you added in Step 15, and change the
+Next, find the ``variable_player:`` section that you added in Step 15, and change the
 first entry from ``s_right_inlane_active:`` to ``my_first_shot_hit``,
 like this:
 
@@ -85,7 +82,7 @@ an event is posted with the name of the shot plus "_hit" added onto it.
 So in this case, the shot "my_first_shot" will post then event
 "my_first_shot_hit" whenever that shot is made.
 
-If you save your two changed config files and run MPF again, start a game
+If you save your changed config file and run MPF again, start a game
 with the ``S`` key, then hit the right inlane switch with the ``Q`` key,
 you should see the player's score increase by 100 points.
 
@@ -117,7 +114,7 @@ the default profile (which is built-in to MPF) has two states:
 
 When a new game starts, the shots in MPF start at the first step of
 the profile. In other words, the shot called "my_first_shot" starts
-in the "unlit" state. Then when the shot is hit, the profile is
+in the "unlit" state. Then, when the shot is hit, the profile is
 advanced to the next step. (So when "my_first_shot" is hit, that shot
 advances from the "unlit" to the "lit" state.)
 
@@ -147,7 +144,7 @@ Let's do that now.
 3a. Associate a light/led with your shot
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To do this, go back to the machine-wide config (where you defined the shot)
+To do this, go back to the mode config where you defined the shot (base.yaml)
 and change the ``shots:`` section.
 
 If you have LEDs in your machine, change it to this:
@@ -202,9 +199,9 @@ isn't configured to go back to the first step when it gets to the last step.
 Next, let's create a custom shot profile that has more than the "lit" and
 "unlit" steps.
 
-To do this, we'll again use the machine-wide config file and add a section
+To do this, we'll add a section to the mode's config file (base.yaml)
 called ``shot_profiles:``. Create that section now, and define a shot
-profile called "my_first_profile" with the following settings
+profile called "my_first_profile" with the following settings:
 
 .. code-block:: mpf-config
 
@@ -309,7 +306,7 @@ points.
 That scoring entry is based on the ``my_first_shot_hit``, which is generated
 every time that shot is hit since shots make events in the form ``<shot_name>_hit``.
 
-However, each time a shot is hit, there's are two ADDITIONAL events posted which
+However, each time a shot is hit, there's two ADDITIONAL events posted which
 are ``<shot_name>_<profile>_hit`` and ``<shot_name>_<profile>_<state>_hit``.
 
 For example, when you start a new game with the shot and shot profile we've
@@ -396,7 +393,7 @@ hit): 100, 1100, 1100, 1200, 2200, 2200, 2300, 3300, 3300...
 --------------------------------------------------
 
 One of the most powerful features of shot profiles is that shots can have
-multiple profiles defined at the same time, (with each active mode having
+multiple profiles defined at the same time (with each active mode having
 the ability to apply its own profile).
 
 To illustrate this, we're going to create a new mode, called "mode2". So
@@ -587,7 +584,7 @@ to it, like this:
      my_first_shot:
        profile: mode2
 
-However, unlike the "my_first_shot" entry in the machine-wide config, in the mode
+However, unlike the "my_first_shot" entry in the base mode config, in the mode2
 config we did NOT redefine the ``switch:`` or ``show_tokens:`` entries. Instead,
 we just added the ``profile:`` setting and told it to use a profile called ``mode2``.
 
@@ -616,12 +613,11 @@ In this case, we defined a profile called ``mode2`` which has two states: "flash
 state names could be whatever you want, "incomplete" and "complete" or whatever.) Note also that we added
 ``speed: 5`` to the flashing step. That setting will be applied to the "flash" show when it's played, and
 you can use any of the :doc:`/config/show_player` settings there. In this case that will play the show
-at 5x speed, so we'll see a fasting flashing.
+at 5x speed, so we'll see a very fast flashing.
 
 Also note that we added ``block: yes`` to this profile. That means that when this profile is active, any
 shot profiles from lower priority modes will be disabled. Since mode2 runs at priority 200, the profile
-"my_first_profile" which we assigned in the machine-wide config will be blocked. (Machine-wide config
-items run at priority 0.)
+"my_first_profile" which we assigned in the base mode config (base.yaml) will be blocked.
 
 And, since the variable_player events in the base mode are based on the shot being hit with the "my_first_profile"
 applied, this is why when mode2 is running, we don't get the variable_player events from the base mode. Those


### PR DESCRIPTION
A couple grammar fixes but mostly suggesting changes based on the confusion created by this page originally referencing the machine-wide config and many of those things still existing (instead of referencing base.yaml which is the new way of doing things). I found myself confused several times going through this page of the tutorial because it would keep saying "machine-wide config" when it meant "base.yaml". So I've made suggestions to update it all and get it in line with the base.yaml approach. Here are some examples:

Around line 55 it says to "open the base.yaml" file but you are already in that file since the tutorial no longer has you working in the machine-wide config.

Around line 85 it references two config files but in the current way of doing things you would only have one file (base.yaml) needing to be saved.

Around line 587 it references machine-wide config file but you're actually working in base.yaml here.

Around line 620 it makes reference to the priority level of the machine-wide config file and this is a tad confusing as you're not working in that file anymore (you're working in base.yaml). So that statement kind of conflicts with the previous sentence in the tutorial (which is about base.yaml). And, while it's good to know that the machine-wide config runs at a priority of 0, that is covered in the Modes section previously so I think it's better to just remove it?

I know that some of these writings are to be able to support people working on multiple versions but I think if we no longer support shot definition in the machine-wide config we should make this section as modern and connected as possible. For me, this was the first time in the tutorial I felt a bit confused and/or frustrated and since it's such an important topic I think this tutorial page has to be really dialed in.