### PR TITLE
Docs for text_ui config setting

### DIFF
--- a/config/index.rst
+++ b/config/index.rst
@@ -163,6 +163,7 @@ indicated which type of config file it's valid in.
    switches: <switches>
    system11: <system11>
    text_strings: <text_strings>
+   text_ui: <text_ui>
    tilt: <tilt>
    timed_switches: <timed_switches>
    timers: <timers>

--- a/config/text_ui.rst
+++ b/config/text_ui.rst
@@ -1,5 +1,5 @@
 text_ui:
-====
+========
 
 *Config file section*
 

--- a/config/text_ui.rst
+++ b/config/text_ui.rst
@@ -1,0 +1,46 @@
+text_ui:
+====
+
+*Config file section*
+
++----------------------------------------------------------------------------+---------+
+| Valid in :doc:`machine config files </config/instructions/machine_config>` | **YES** |
++----------------------------------------------------------------------------+---------+
+| Valid in :doc:`mode config files </config/instructions/mode_config>`       | **NO**  |
++----------------------------------------------------------------------------+---------+
+
+.. overview
+
+The ``text_ui:`` section of your config is where you configure the Text UI that appears in the console while MPF is running.
+
+The Text UI displays information about the machine and game: switch states, active modes, variable values, and game information. By
+default, it displays all machine variables and player variables.
+
+Depending on the complexity of your game and the mode you're working on, you may not want the Text UI to display *every* variable.
+In that case, you can use the ``text_ui:`` section to specify which player and machine variables you want to see.
+
+Optional settings
+-----------------
+
+The following sections are optional in the ``mpf:`` section of your config. (If you don't include them, the default will be used).
+
+machine_vars:
+~~~~~~~~~~~~~
+List of one (or more) values, each is a type: ``string``.
+
+A list of all of the machine variables to display and update in the Text UI.
+If the list is empty, no machine variables will be displayed.
+
+If the ``machine_vars:`` setting is not included in your config,
+*all* machine variables will be displayed.
+
+player_vars:
+~~~~~~~~~~~~
+List of one (or more) values, each is a type: ``string``.
+
+A list of all of the player variables to display and update in the Text UI.
+
+While a game is active, MPF will always show three player variables: player number, ball number, and player score. If the ``player_vars:`` setting is provided, the variable names listed will also be shown in the Text UI.
+
+If the ``player_vars:`` setting is not included in your config,
+*all* player variables will be displayed.


### PR DESCRIPTION
This PR adds a config reference section for the `text_ui:` config options added in https://github.com/missionpinball/mpf/pull/1406