### PR TITLE
fixed typo (machine instead of maschine)

### DIFF
--- a/config/instructions/dynamic_values.rst
+++ b/config/instructions/dynamic_values.rst
@@ -61,7 +61,7 @@ You would have this instead:
 
 .. code-block:: mpf-config
 
-   # in your maschine config
+   # in your machine config
    settings:
       warnings_to_tilt:
          label: Number of tilt warnings


### PR DESCRIPTION
fixed a typo in the documentation 