### PR TITLE
Fixed broken link and reference to ball_locks

### DIFF
--- a/config/ball_holds.rst
+++ b/config/ball_holds.rst
@@ -16,7 +16,7 @@ The ``ball_holds:`` section of your config is used to list and configure
 
 Note that ball holds are used to temporarily hold a ball while the game is doing something
 else. (Starting a video mode, playing an intro show, etc.) If you want to hold and lock
-a ball towards multiball, use the ``ball_locks:`` section instead.
+a ball towards multiball, use the ``multiball_locks:`` section instead.
 
 Ball holds do not affect the "balls in play" count, and they are not used
 to hold balls from ball-to-ball or between players.

--- a/config/multiball_locks.rst
+++ b/config/multiball_locks.rst
@@ -24,7 +24,7 @@ which is set in ``default_source_device`` of your playfield unless the device
 that just locked it is full,
 in which case it will eject a ball from the full device. The events that
 control the ball ejections are queue events, so you can interrupt the delivery
-of a new ball with the :doc: `/config/queue_relay_player` (for example, to have
+of a new ball with the :doc:`/config/queue_relay_player` (for example, to have
 a mode selection screen before returning to play).
 
 Whenever a new ball is locked, the event *multiball_lock_<name>_locked_ball*


### PR DESCRIPTION
Documentation advised to check out ball_locks: section, but this was removed in v0.33 and replaced with multiball_locks. This has been updated. Also fixed broken link to queue_relay_player.