### PR TITLE
Update Complete_Events for clarity RE state order

### DIFF
--- a/config/achievements.rst
+++ b/config/achievements.rst
@@ -214,9 +214,10 @@ on how to enter settings here.
 Default: ``None``
 
 Events in this list, when posted, cause this achievement to switch to its
-"completed" state. These events will also cause the achievement to play the
-show defined in the ``show_when_completed:`` setting and to emit (post) events
-in the ``events_when_completed:`` setting.
+"completed" state. This must be in the "started" state in order to be moved
+to the "completed" state when these events post.   These events will also
+cause the achievement to play the show defined in the ``show_when_completed:``
+setting and to emit (post) events in the ``events_when_completed:`` setting.
 
 disable_events:
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Added notes starting at 216 to clarify that the achievement must be in started state to move to completed state.  I struggled with this for a couple hours because I couldn't get my start_events to post a correct show upon ball ending.  I removed that line, and it broke complete functionality.  Figured out that was it, and wanted to add to save someone issues down the road.