### PR TITLE
removed typo; please add explantion for platform_settings

### DIFF
--- a/config/switches.rst
+++ b/config/switches.rst
@@ -106,7 +106,7 @@ or sling shots.
 when rules are configured. Therefore, you usually can leave this at ``auto``.
 
 Switch debouncing is somewhat different from debouncing in other domains since
-the switch has to be active for the whole period of debouncing (ot at least
+the switch has to be active for the whole period of debouncing (at least
 during sampling).
 It could also be referred as "minimum activation time" (as one discipline of
 debouncing).


### PR DESCRIPTION
remove typo

Explanation missing. Please add something with a link to a better understanding.
platform_settings:
~~~~~~~~~~~~~~~~~~
Single value, type: dict.

What does dict. mean?
What ist it?