### PR TITLE
Specify P3ROC default_pulse_power/default_hold_power limitations

### DIFF
--- a/hardware/multimorphic/drivers.rst
+++ b/hardware/multimorphic/drivers.rst
@@ -129,7 +129,7 @@ You can also set the power of pulses on your coil:
         default_pulse_power: 0.5
 
 See the hold power section below for internal details about PWM times.
-With the P-Roc it is not possible to use ``default_hold_power`` and
+With the P-Roc and P3-Roc it is not possible to use ``default_hold_power`` and
 ``default_pulse_power`` at the same time.
 
 Hold Power


### PR DESCRIPTION
Judging from your comment in the slack it sounded like this limitation applied to the P3-ROC as well.  If that's the case I think this doc section should mention it specifcally.