### PR TITLE
Reset when complete

### DIFF
--- a/game_logic/logic_blocks/common_problems.rst
+++ b/game_logic/logic_blocks/common_problems.rst
@@ -8,11 +8,12 @@ My block only works once. Why?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This is the default configuration of all logic blocks.
-To change it you first need to set ``reset_when_complete`` to ``True``.
+To change it you first need to set ``reset_on_complete`` to ``True``.
 As a result you blocks will reset when they reach the final step.
 However, that will not be enough in most cases because ``disable_on_complete``
 is ``True`` by default.
-Unless you got some enable logic you probably want to set that to ``False``.
+Unless you have some enable logic to re-enable the block later,
+you probably want to set ``disable_on_complete`` to ``False``.
 
 When should I used logic blocks and when should I use shots/show_groups?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -23,7 +24,7 @@ Shots and shot_groups serve a very specific usecase.
 Basically, they implement a sequences of switch hits which trigger lights along
 the way.
 If you want to stay within that specific usecase then go with shots because it
-will be more convinient.
+will be more convenient.
 If you plan to extend your mode to use more advanced features then go with
 logic blocks.
 For instance if you got conditions in your logic (i.e. on how many balls are


### PR DESCRIPTION
This PR corrects the docs in one place where logic blocks refer to the config setting `reset_when_complete` when it should be `reset_on_complete`.

Looking deeper into this, the general trend seems to be that Events and Shows use `_when_complete(d)` while device behaviors like reset, disable, and restart use `_on_complete`. That's a reasonable enough differentiation.

The part that's less friendly is some events use `complete` and others use `completed`. They make sense in relative context: 
* On achievements for example, `events_when_completed` sits next to `events_when_enabled`, `events_when_started`, and `events_when_stopped`. All verbs in the past tense. 
* In contrast, logicblocks use `events_when_complete` alongside `reset_on_complete` and `disable_on_complete`. All adjectives.

Part of me is considering extending the `when_completed` devices to support `when_complete` so we can gradually phase out the former... or even extending all `_when_<verb>` settings to be `_on_<adjective>` so we can gradually consolidate *all* callbacks. But... probably not worth it?