### PR TITLE
Update colors.rst

### DIFF
--- a/config/instructions/colors.rst
+++ b/config/instructions/colors.rst
@@ -7,8 +7,10 @@ You can see a list of valid color names (and their respective colors) `here <htt
 
 In addition to the 140 standard named colors, MPF adds the following color options:
 
-* ``off`` - maps (0,0,0) which is more intuitive than "black" when you're working with LEDs.
 * ``on`` - turns on an LED with that LED's ``default_color:`` setting. (Default is "white" if you don't specify a color.)
+* ``off`` - maps (0,0,0) which is more intuitive than "black" when you're working with LEDs.
+* ``stop`` - removes the current color being displayed allowing a color from a lower priority light_player or 
+    show_player to become visible.
 
 You can also specify color by hex string. If you do this, do *NOT* put a ``#``
 in it, since YAML files use those for comments which are ignored.


### PR DESCRIPTION
documented the color stop.  It might be useful to have stop be a valid default show as in here:
shot_profiles:
  bottom_lane_profile:
    states:
      - name:
        show: stop
      - name: hit
        show: on