### PR TITLE
Docs for spinners and other config additions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ services:
   - docker
 
 before_install:
-  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin;
+  - if [ ! -z "${DOCKER_PASSWORD}" ]; then
+      echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin;
+    fi;
   - git clone --recursive --branch dev https://github.com/missionpinball/mpf.git _mpf;
   - git clone --recursive --branch dev https://github.com/missionpinball/mpf-mc.git _mpf-mc
   - git clone --branch dev https://github.com/missionpinball/mpf-debian-installer.git _mpf_installer;

--- a/config/bonus.rst
+++ b/config/bonus.rst
@@ -144,6 +144,14 @@ If this is true/yes, then the bonus mode will reset the ``player_score_entry:`` 
 This is just a convenience thing for simpler bonus calculations that need to be reset per ball. You don't have to use
 it can could also reset the player variable some other way.
 
+skip_if_negative:
+~~~~~~~~~~~~~~~~~
+
+Boolean (True/False or Yes/No). Default is ``False``.
+
+If this is True/Yes and if the score calculation for this bonus entry is less than 0, the event for this
+bonus entry is not posted *and* the value is not subtracted from the player's score.
+
 skip_if_zero:
 ~~~~~~~~~~~~~
 

--- a/config/displays.rst
+++ b/config/displays.rst
@@ -65,6 +65,14 @@ Single value, type: ``boolean`` (``true``/``false``). Default: ``false``
 Specifies that this display is the default, meaning it's the display that's used if you show a slide without specifying
 a target for that slide. If you only have one display, it will be the default automatically.
 
+enabled:
+~~~~~~~~
+
+Single value, type: ``boolean`` (``true``/``false``). Default: ``true``
+
+Whether this display is enabled. If false, all slide and widget player calls
+targeting this display will be ignored.
+
 height:
 ~~~~~~~
 Single value, type: ``integer``. Default: ``600``

--- a/config/flasher_player.rst
+++ b/config/flasher_player.rst
@@ -24,6 +24,23 @@ Optional settings
 
 The following sections are optional in the ``flasher_player:`` section of your config. (If you don't include them, the default will be used).
 
+
+color:
+~~~~~~
+Single value, type: ``string``. Default: ``on``
+
+Set a color for flashing, if the flasher supports RGB coloring.
+
+Color values may be a hex string (e.g. ``22FFCC``),
+a list of RGB values (e.g. ``[50, 128, 206]``), a color name (e.g.
+``turquoise``), or a brightness value (i.e. ``AA`` or ``120``).
+MPF knows 140+ standard web color names, and you can define your own custom
+colors in the :doc:`/config/named_colors` section of your config.
+If you use brightness on an RGB light MPF will use the brightness for every
+channel.
+For instance brigness ``AA`` will result in color ``AAAAAA``.
+
+
 ms:
 ~~~
 Single value, type: ms_or_token. Default: ``100ms``

--- a/config/sound_player.rst
+++ b/config/sound_player.rst
@@ -118,6 +118,14 @@ There is also a shorthand way (express config format):
    sound_player:
      sw_jet_bumper_active: super_jet_bumper_sound|block
 
+
+delay:
+~~~~~~
+Single value, type: ``time string (secs)`` (:doc:`Instructions for entering time strings </config/instructions/time_strings>`). Defaults to empty.
+
+When the triggering event occurs, delay for a certain amount of time before playing
+the sound.
+
 events_when_about_to_finish:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 List of one (or more) events. Those will be posted by the device. Default: ``use_sound_setting``

--- a/config/spinners.rst
+++ b/config/spinners.rst
@@ -1,0 +1,174 @@
+spinners:
+=============
+
+*Config file section*
+
++----------------------------------------------------------------------------+---------+
+| Valid in :doc:`machine config files </config/instructions/machine_config>` | **YES** |
++----------------------------------------------------------------------------+---------+
+| Valid in :doc:`mode config files </config/instructions/mode_config>`       | **NO**  |
++----------------------------------------------------------------------------+---------+
+
+.. overview
+
+Spinner devices provide accruals for switches that are hit in rapid succession,
+and post events based on timeouts after switch hits.
+
+.. code-block:: mpf-config
+
+   #! switches:
+   #!   s_orbit_spinner:
+   #!     number:
+   #!   s_top_loop_left:
+   #!     number:
+   #!   s_top_loop_right:
+   #!     number:
+   spinners:
+     basic_spinner:
+       switch: s_orbit_spinner
+       active_ms: 500
+     dual_spinner:
+       switches: s_top_loop_left, s_top_loop_right
+       switch_tags: left, right
+       active_ms: 1200
+       idle_ms: 2400
+
+A spinner becomes "active" when a ``switch:`` or ``switches:`` is hit, and
+remains active as long as switch hits continue. The time specified by
+``active_ms:`` determines how long the spinner will wait after the last hit
+before it is no longer active.
+
+If an ``idle_ms:`` time is specified, the spinner will move from "active" to "inactive"
+for that duration, before finally settling on "idle". If a switch is hit while
+idle, the spinner will become active again. If no ``idle_ms:`` time is specified,
+the spinner will go directly from active to idle.
+
+The basic flow:
+
+    1. Spinner sits in idle state
+    2. A spinner switch is hit
+        i. The spinner becomes "active" and sets a timeout for ``active_ms:`` duration
+        ii. The spinner posts *spinner_<name>_active* event
+        iii. The spinner posts *spinner_<name>_hit* event
+    3. Additional switch hits occur
+        i. The spinner resets the timeout for another ``active_ms:`` duration
+        ii. The spinner posts a *spinner_<name>_hit* event for each hit
+    4. Switch hits stop and the active delay timer expires
+        i. The spinner switches to "inactive" state
+        ii. The spinner posts *spinner_<name>_inactive* event
+        iii. (Optional) If ``idle_ms:`` is defined, the spinner sets a timeout for idle_ms duration
+    5. (Optional) No switch hits occur and the idle delay timer expires
+        i. The spinner posts *spinner_<name>_idle* event
+        ii. The spinner switches to "idle" state
+
+.. config
+
+
+Optional settings
+-----------------
+
+The following sections are optional in the ``spinners:`` section of your config. (If you don't include them, the default will be used).
+
+
+active_ms:
+~~~~~~~~~~
+Single value, type: ``time string (ms)`` (:doc:`Instructions for entering time strings </config/instructions/time_strings>`). Default: ``1000ms``
+
+How long the spinner should stay active after the last switch hit. The hit count
+resets each time the spinner becomes active, so this value determines when one group
+of spins ends and the next begins.
+
+disable_events:
+~~~~~~~~~~~~~~~
+List of one (or more) device control events (:doc:`Instructions for entering device control events </config/instructions/device_control_events>`). Defaults to empty.
+
+Default: ``None``
+
+Events in this list, when posted, disable this spinner. If a spinner is
+disabled, then hits to it have no effect.
+
+enable_events:
+~~~~~~~~~~~~~~
+List of one (or more) device control events (:doc:`Instructions for entering device control events </config/instructions/device_control_events>`). Defaults to empty.
+
+Default: ``None``
+
+Events in this list, when posted, enable this spinner. If a spinner is
+not enabled, then hits to it have no effect.
+
+
+idle_ms:
+~~~~~~~~
+Single value, type: ``time string (ms)`` (:doc:`Instructions for entering time strings </config/instructions/time_strings>`). Default: ``None``
+
+How long the spinner should stay inactive before going idle. This time is counted
+*after* the ``active_ms:`` has expired, and is useful for displaying slides or
+widgets for a while after switch hits stop.
+
+labels:
+~~~~~~~
+List of one (or more) values, each is a type: ``string``. Defaults to empty.
+
+A list of labels to apply to the switches in the spinner. If used, the
+number of labels should equal the number of switches.
+
+When a spinner switch is hit and ``labels:`` are defined, additional events will
+be posted with *spinner_<name>_<label>_active* and *spinner_<name>_<label>_hit*.
+This allows the game to trigger different behavior based on which spinner switch
+is hit first or spins more times.
+
+switch:
+~~~~~~~
+List of one (or more) values, each is a type: string name of a :doc:`switches <switches>` device. Defaults to empty.
+
+The name of the switch (or a list of switches) for this spinner. You can
+use multiple switches if the playfield has a series of spinners that work
+together (for example at both ends of a horseshoe loop).
+
+switches:
+~~~~~~~~~
+List of one (or more) values, each is a type: string name of a :doc:`switches <switches>` device. Defaults to empty.
+
+This setting is the same as the ``switch:`` setting above. You can technically
+enter a single switch or a list of switches in either the ``switch:`` setting
+or the ``switches:`` setting, but we include both since it was confusing to
+be able to enter multiple switches for a singlular "switch" setting and vice
+versa.
+
+playfield:
+~~~~~~~~~~
+Single value, type: string name of a :doc:`playfields <playfields>` device. Default: ``playfield``
+
+The name of the playfield that this spinner is on. The default setting is "playfield", so you only have to
+change this value if you have more than one playfield and you're managing them separately.
+
+reset_when_inactive:
+~~~~~~~~~~~~~~~~~~~~
+Single value, type: ``boolean`` (``true``/``false``). Default: ``true``
+
+When true, the spinners ``hit`` count will reset when the spinner goes inactive
+(after the ``active_ms:`` expires).
+
+When false, the spinner's ``hit`` count will reset when the spinner goes idle
+(after the ``idle_ms:`` expires)
+
+This value has no effect if ``idle_ms:`` is not set.
+
+console_log:
+~~~~~~~~~~~~
+Single value, type: one of the following options: none, basic, full. Default: ``basic``
+
+Log level for the console log for this device.
+
+debug:
+~~~~~~
+Single value, type: ``boolean`` (``true``/``false``). Default: ``false``
+
+See the :doc:`documentation on the debug setting </config/instructions/debug>`
+for details.
+
+file_log:
+~~~~~~~~~
+Single value, type: one of the following options: none, basic, full. Default: ``basic``
+
+Log level for the file log for this device.

--- a/displays/widgets/image/index.rst
+++ b/displays/widgets/image/index.rst
@@ -63,3 +63,14 @@ start_frame:
 Single value, type: ``integer``. Default: ``0``.
 
 Which start frame to use for animated images.
+
+persist_frame:
+~~~~~~~~~~~~~~
+
+Single value, type: ``boolean`` (``true``/``false``). Default: ``false``
+
+When true, the animated image widget will remember the frame the
+it was on when it was last used, and restore that frame when the widget is
+next used.
+
+By default, an animated image will reset itself each time it is added to a slide.

--- a/sound/basic_setup.rst
+++ b/sound/basic_setup.rst
@@ -103,7 +103,27 @@ voice callouts in the ``voice`` folder, and all other sound effects in the ``sfx
 are welcome to create any sub-folders you desire and put sounds in them to help keep things
 organized.
 
-4. Additional configuration for selected sounds
+4. Setting the default master volume level
+------------------------------------------
+
+The master volume (applied to all tracks in the sound system) can be adjusted from
+the service switches or custom events. MPF stores the master volume level as a machine
+variable, so the selected volume will persist each time the game boots up.
+
+The master volume ranges from 0.0 (silent) to 1.0 (full), and defaults to 0.5 (50%).
+You can set your own default volume by overriding the machine variable settings in
+your machine config file.
+
+.. code-block:: mpf-config
+
+    machine_vars:
+      master_volume:
+        initial_value: 0.25   # Set this to any value you want
+        value_type: float
+        persist: true         # If false, the volume will reset to default
+                              # each time the machine boots up
+
+5. Additional configuration for selected sounds
 -----------------------------------------------
 
 Now when you start your machine you will have some sounds available (assuming you placed some
@@ -138,8 +158,8 @@ That simple configuration change will allow the sound as to be referred to as ``
 you refer to that sound in other configuration locations. *Note*: be sure to include the complete
 file name, including the extension when using the ``file:`` setting.
 
-Setting the volume of a sound
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Setting the volume of a specific sound
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A very common adjustment to make is to set the volume for each and every sound you load in your
 machine.  This allows you to balance out sounds from various sources rather than trying to adjust
@@ -215,7 +235,7 @@ Example ``sounds:`` configuration demonstrating most common settings:
         about_to_finish_time: 2s
         events_when_about_to_finish: song_01_about_to_finish
 
-5. Hooking up an MPF event to play a sound
+6. Hooking up an MPF event to play a sound
 ------------------------------------------
 
 Now that your sounds have been setup and are available in your machine, the next step is to


### PR DESCRIPTION
Looking through the PRs that have gone in since 0.54 release, this PR has some documentation updates.

* Spinner devices: all new!
* Displays: add `enabled` setting
* Image widgets: add `persist_frame` setting
* Flasher player: add `color` setting
* Sound player: add `delay` setting
* Bonus mode: add `skip_if_negative` setting
* Sound system: how to customize `master_volume` default