### PR TITLE
Blinkenlights documentation

### DIFF
--- a/config/blinkenlight_player.rst
+++ b/config/blinkenlight_player.rst
@@ -36,7 +36,7 @@ In the example above, when the event called ``some_event`` is posted,
 the color red will be added to my_blinkenlight1's list of colors (this will
 cause the light to immediately start flashing if it wasn't already).  The new
 color will have the key ``mykey1``.  The key is used like a name of the color,
-so that it can be removed later.
+so that it can be removed later using that key.
 When the event ``some_other_event`` is posted, the red color (key ``mykey1``) will be
 removed from the blinkenlight.
 
@@ -56,10 +56,7 @@ Example blinkenlight player from a show:
 The first example shows the full config, while the second shows the
 "express" config. (What's an "express config?" Details :doc:`here </config/instructions/express_config>`.
 
-The blinkenlight player's express config is the "add" action.  Note that the
-express config uses a random key, so there's no way for you to remove this
-color with the ``remove`` action if you use this config. However, all colors added
-to a blinkenlight by any mode are removed automatically when the mode ends.
+The blinkenlight player's express config is the "add" action.
 
 See :doc:`/config_players/blinkenlight_player` for details.
 
@@ -77,8 +74,7 @@ action:
 Single value, type: one of the following options: add, remove, remove_mode, remove_all.
 Default: ``add``
 
-What action the blinkenlight should perform. The ``add`` and ``remove`` actions
-require a ``key`` to know which color to add or remove.  The ``remove_all``
+What action the blinkenlight should perform. The ``remove_all``
 action will remove all the colors from the blinkenlight, effectively turning it
 off.  The ``remove_mode`` action will remove all the colors that were added by
 the mode that the ``remove_mode`` action is coming from (remember that a
@@ -105,7 +101,9 @@ Single valid, type: ``string``. Defaults to empty.
 
 You can think of this value as a name for the color you're adding or removing
 from the blinkenlight.  If you add a color, then the key allows you to remove
-the color later using the key to specify which color to remove.
+the color later using the key to specify which color to remove.  If you don't
+specify a key, then the color is considered "keyless" (see
+:doc:`/config_players/blinkenlight_player` for more information about keyless colors).
 
 Related How To guides
 ---------------------

--- a/config/blinkenlights.rst
+++ b/config/blinkenlights.rst
@@ -13,8 +13,8 @@ blinkenlights:
 
 The ``blinkenlights:`` section of your config file is used
 to define lights on your pinball machine that can be shared by
-multiple different modes at the same time.  Blinkenlights must
-be RGB LEDs, because each mode that uses a blinkenlight can
+multiple different modes at the same time.  Blinkenlights work best with
+RGB LEDs, because each mode that uses a blinkenlight can
 specify a color that the blinkenlight should flash for that mode.
 The blinkenlight will then flash each of its colors in a cycle according to
 a given schedule.

--- a/config_players/blinkenlight_player.rst
+++ b/config_players/blinkenlight_player.rst
@@ -204,8 +204,8 @@ Usage in shows
 
 In shows, the blinkenlight player is used via the ``blinkenlights:`` section of a step.
 
-Express Config
---------------
+Express Config and Keyless Colors
+---------------------------------
 
 As mentioned above, the express config for ``blinkenlight_player`` performs the ``add`` action. So,
 the color you specify as the express config value will be the color to add to
@@ -232,6 +232,11 @@ the ``some_other_event`` event is posted, the ``remove``
 action is performed.  Since this ``remove`` action also didn't specify a ``key`` value, then
 MPF will look for a keyless color and remove that color from the blinkenlight.
 In this case, the color red will be removed.
+
+Note that keyless colors are only valid within the context of the mode or show
+that is performing the keyless action.  So, a ``remove`` action from ``mode1`` will
+not remove the keyless color that was added by ``mode2``.  It will only remove the 
+keyless color added by ``mode1``.
 
 There's a special value you can use in the express config to remove a keyless
 color.  Instead of using the full config and specifying an ``action: remove`` as


### PR DESCRIPTION
This PR updates the documentation for blinkenlights: and blinkenlight_player:.  Specifically, information about what happens when a key is not specified in blinkenlight_player.