### PR TITLE
Recipes: Skillshots with lane change and auto-rotate, Sequential drop banks

### DIFF
--- a/cookbook/index.rst
+++ b/cookbook/index.rst
@@ -11,6 +11,9 @@ Here are the recipes that are done:
 * :doc:`Indiana Jones: Rollover Lanes (with Lane Change) <rollover_lanes_with_lane_change>`
 * :doc:`Batman 66: Gadgets Targets <B66_gadget>`
 * :doc:`Modifying the Game mode: Dual launch devices <dual_launch>`
+* :doc:`Skillshots with Lane Change <skillshot_with_lane_change>`
+* :doc:`Skillshots with Auto-Rotate <skillshot_with_auto_rotate>`
+* :doc:`Sequential Drop Bank Targets <sequential_drop_banks>`
 
 If you've ever played a game and wondered, "How would I do that?" then let us
 know and we'll write a recipe for it! And here's what's on our to-do list:
@@ -31,3 +34,6 @@ know and we'll write a recipe for it! And here's what's on our to-do list:
    Indiana Jones: Rollover Lanes <rollover_lanes_with_lane_change>
    Batman 66: Gadgets Targets <B66_gadget>
    Modifying the Game mode: Dual launch devices <dual_launch>
+   Sequential Drop Banks <sequential_drop_banks>
+   Skillshots with Lane Change <skillshot_with_lane_change>
+   Skillshots with Auto-Rotate <skillshot_with_auto_rotate>

--- a/cookbook/rollover_lanes_with_lane_change.rst
+++ b/cookbook/rollover_lanes_with_lane_change.rst
@@ -1,7 +1,7 @@
 Recipe: Rollover Lanes (with Lane Change)
 ==============================================
 
-This guide shows you how to build an MPF config for rotating rollaver lanes,
+This guide shows you how to build an MPF config for rotating rollover lanes,
 as found in *Indiana Jones*, *Attack From Mars*, *Medieval Madness*,
 and many, many more.
 

--- a/cookbook/sequential_drop_banks.rst
+++ b/cookbook/sequential_drop_banks.rst
@@ -1,0 +1,270 @@
+Recipe: Sequential Drop Target Banks
+========================================
+
+This guide shows you how to build an MPF config for a drop target bank with
+targets that must be hit in a specific order.
+
+The mode starts with one target flashing as the correct target to hit, and all
+the rest off. Hitting the correct target will keep the hit target down, hold the
+light on, and flash the next target. Hitting an incorrect target will reset that
+target's coil and keep the light off.
+
+
+Step 1. Create a skillshot mode and lane shots
+----------------------------------------------
+
+We'll create a separate mode to manage the sequential drops, to keep the code
+clean and make it easy to turn the sequence on and off.
+
+The first thing our mode needs is :doc:`/config/shots`. Each drop target will be
+a shot (in this example, we'll have four). Each shot has a switch, a light, and
+a shot profile to track its state.
+
+Each shot will also have unique ``advance_events`` configured, which will
+advance the shot (from "off" to "lit") when its predecessor is hit, and again
+advance the shot (from "lit" to "down") when it is hit. The final shot does not
+need to advance from "lit" to "down" because the sequence resets when it's hit.
+
+Each shot also has ``reset_events`` configured, so that the entire sequence can
+be reset after completion.
+
+
+.. code-block:: mpf-config
+
+  #! switches:
+  #!   s_drop_1:
+  #!     number: 1
+  #!   s_drop_2:
+  #!     number: 2
+  #!   s_drop_3
+  #!     number: 3
+  #!   s_drop_4:
+  #!     number: 4
+  #! lights:
+  #!   l_drop_1:
+  #!     number: 1
+  #!   l_drop_2:
+  #!     number: 2
+  #!   l_drop_3
+  #!     number: 3
+  #!   l_drop_4:
+  #!     number: 4
+  #! shot_profiles:
+  #!   skillshot_profile:
+  #!     states:
+  #!       - name: off
+  #!       - name: lit
+  #!       - name: down
+  ##! mode: sequential_drops
+
+  mode:
+    start_events: start_mode_sequential_drops
+    stop_events: stop_mode_sequential_drops
+    priority: 200
+
+  shots:
+    drop_1:
+      advance_events: advance_drop_1, drop_1_lit_hit
+      reset_events: reset_drop_sequence
+      switch: s_drop_1
+      profile: drop_sequence
+      show_tokens:
+        led: l_drop_1
+    drop_2:
+      advance_events: drop_1_lit_hit, drop_2_lit_hit
+      reset_events: reset_drop_sequence
+      switch: s_drop_2
+      profile: drop_sequence
+      show_tokens:
+        led: l_drop_2
+    drop_3:
+      advance_events: drop_2_lit_hit, drop_3_lit_hit
+      reset_events: reset_drop_sequence
+      switch: s_drop_3
+      profile: drop_sequence
+      show_tokens:
+        led: l_drop_3
+    drop_4:
+      advance_events: drop_3_lit_hit
+      reset_events: reset_drop_sequence
+      switch: s_drop_4
+      profile: drop_sequence
+      show_tokens:
+        led: l_drop_4
+
+
+Step 2. Create a profile for the targets
+------------------------------------------
+
+We can create a :doc:`shot_profile</config/shot_profiles>` for the targets that
+starts with the light off, flashes it after one advancement, and keeps the light
+on solid after a second advancement. By default, a shot will advance its profile
+when the shot is hit, but we don't want that here so we'll set
+``advance_on_hit: false``.
+
+.. code-block:: mpf-config
+
+  ##! mode: skillshot
+  drop_sequence:
+    advance_on_hit: false
+    states:
+      - name: off
+        show: off
+      - name: lit
+        show: flash
+      - name: down
+        show: on
+
+Step 3. Create a Sequence Logic Block to track the progression
+--------------------------------------------------------------
+
+MPF includes a number of convenient ways for tracking progress called Logic
+Blocks, including the :doc:`sequence</config/sequences>` that we can use to
+require a series of events to occur in a specific order.
+
+The below sequence requires all four drop target shots to be hit, but only
+registers a hit if the shot is in the "lit" state. This allows us to track where
+we are in the sequence without having to monitor each shot individually.
+
+The sequence also has ``restart_events`` so we can restart when the mode starts
+and when the sequence completes. All logicblocks have a default completion event
+called *logicblock_(name)_complete* so we don't need to explicitly define any
+completion event.
+
+.. code-block:: mpf-config
+
+  ##! mode: sequential_drops
+
+  sequences:
+    drop_sequence:
+      restart_events: reset_drop_sequence
+      events:
+        - drop_1_lit_hit
+        - drop_2_lit_hit
+        - drop_3_lit_hit
+        - drop_4_lit_hit
+
+
+Step 4. Start, advance, and reset the shots
+-------------------------------------------
+
+We will use events to manage the behavior of the shots and the drop targets. The
+first step is to identify all the rules of how the sequence and shots behave.
+
+* Rule 1: When the mode starts, reset the drop sequence
+* Rule 2: When the sequence is completed, reset the drop sequence
+
+On a reset, all of the shots will be in their "off" state. We need the first
+target to be "lit" in order for the sequence to start.
+
+* Rule 3: When the sequence resets, advance the first target from "off" to "lit"
+
+When a shot is in the "off" state and gets hit, we want to fire the reset coil
+for the target so that the target stays up.
+
+* Rule 4: When an "off" shot is hit, reset its coil
+
+We can apply all of these rules based on the corresponding events, like follows.
+
+
+.. code-block:: mpf-config
+
+  ##! mode: sequential_drops
+
+  event_player:
+    # When the mode starts, reset the drop sequence
+    mode_sequential_drops_started: reset_drop_sequence
+
+    # When the sequence is completed, reset the drop sequence
+    logicblock_drop_sequence_complete: reset_drop_sequence
+
+    # When the sequence resets, advance the first target
+    reset_drop_sequence: advance_drop_1
+
+    # When an "off" shot is hit, reset its coil
+    drop_1_off_hit: reset_drop_1
+    drop_2_off_hit: reset_drop_2
+    drop_3_off_hit: reset_drop_3
+    drop_4_off_hit: reset_drop_4
+
+The above configuration requires that each drop target coil has the
+corresponding reset events, as configured below.
+
+.. code-block:: mpf-config
+
+  #! switches:
+  #!   s_drop_1:
+  #!     number: 1
+  #!   s_drop_2:
+  #!     number: 2
+  #!   s_drop_3
+  #!     number: 3
+  #!   s_drop_4:
+  #!     number: 4
+  #! coils:
+  #!   c_drop_1:
+  #!     number: 1
+  #!   c_drop_2:
+  #!     number: 2
+  #!   c_drop_3
+  #!     number: 3
+  #!   c_drop_4:
+  #!     number: 4
+  ##! machine config.yaml
+
+  drop_targets:
+    drop_1:
+      switch: s_drop_1
+      reset_coil: c_drop_1
+      reset_events: ball_starting, machine_reset_phase_3, reset_drop_1
+    drop_2:
+      switch: s_drop_1
+      reset_coil: c_drop_1
+      reset_events: ball_starting, machine_reset_phase_3, reset_drop_2
+    drop_3:
+      switch: s_drop_1
+      reset_coil: c_drop_1
+      reset_events: ball_starting, machine_reset_phase_3, reset_drop_3
+    drop_4:
+      switch: s_drop_1
+      reset_coil: c_drop_1
+      reset_events: ball_starting, machine_reset_phase_3, reset_drop_4
+
+
+Step 5. Rewards for progression and completion
+----------------------------------------------
+
+When a drop target is hit, The sequence logic block keeps track of whether it is
+the part of the sequence or not. We can easily award points for progression with
+the *logicblock_(name)_hit* event (when a lit target is hit) and the
+*logicblock_(name)_complete* event (when the full sequence is completed).
+
+
+.. code-block:: mpf-config
+
+  ##! mode: sequential_drops
+
+  variable_player:
+    logicblock_drop_sequence_hit:
+      score: 1000
+    logicblock_drop_sequence_complete:
+      score: 50_000
+
+
+Full Example Code
+-----------------
+
+The full code from this example can be found as a fully-working game template in
+the MPF Examples repository.
+
+https://github.com/missionpinball/mpf-examples/tree/dev/cookbook/sequential_drop_banks
+
+
+Related Docs
+------------
+
+* :doc:`/config/shots`
+* :doc:`/config/shot_groups`
+* :doc:`/config/shot_profiles`
+* :doc:`/config/sequences`
+* :doc:`/config/variable_player`

--- a/cookbook/sequential_drop_banks.rst
+++ b/cookbook/sequential_drop_banks.rst
@@ -37,7 +37,7 @@ be reset after completion.
   #!     number: 1
   #!   s_drop_2:
   #!     number: 2
-  #!   s_drop_3
+  #!   s_drop_3:
   #!     number: 3
   #!   s_drop_4:
   #!     number: 4
@@ -46,7 +46,7 @@ be reset after completion.
   #!     number: 1
   #!   l_drop_2:
   #!     number: 2
-  #!   l_drop_3
+  #!   l_drop_3:
   #!     number: 3
   #!   l_drop_4:
   #!     number: 4

--- a/cookbook/sequential_drop_banks.rst
+++ b/cookbook/sequential_drop_banks.rst
@@ -107,15 +107,16 @@ when the shot is hit, but we don't want that here so we'll set
 
   ##! mode: sequential_drops
 
-  drop_sequence:
-    advance_on_hit: false
-    states:
-      - name: off
-        show: off
-      - name: lit
-        show: flash
-      - name: down
-        show: on
+  shot_profiles:
+    drop_sequence:
+      advance_on_hit: false
+      states:
+        - name: off
+          show: off
+        - name: lit
+          show: flash
+        - name: down
+          show: on
 
 Step 3. Create a Sequence Logic Block to track the progression
 --------------------------------------------------------------

--- a/cookbook/sequential_drop_banks.rst
+++ b/cookbook/sequential_drop_banks.rst
@@ -11,7 +11,7 @@ target's coil and keep the light off.
 
 
 Step 1. Create a sequential_drops mode and lane shots
-----------------------------------------------
+-----------------------------------------------------
 
 We'll create a separate mode called *sequential_drops* to manage the game logic.
 Separate modes keep the code clean and make it easy to turn the drop sequence on

--- a/cookbook/sequential_drop_banks.rst
+++ b/cookbook/sequential_drop_banks.rst
@@ -200,7 +200,7 @@ corresponding reset events, as configured below.
   #!     number: 1
   #!   s_drop_2:
   #!     number: 2
-  #!   s_drop_3
+  #!   s_drop_3:
   #!     number: 3
   #!   s_drop_4:
   #!     number: 4
@@ -209,11 +209,10 @@ corresponding reset events, as configured below.
   #!     number: 1
   #!   c_drop_2:
   #!     number: 2
-  #!   c_drop_3
+  #!   c_drop_3:
   #!     number: 3
   #!   c_drop_4:
   #!     number: 4
-  ##! machine config.yaml
 
   drop_targets:
     drop_1:

--- a/cookbook/sequential_drop_banks.rst
+++ b/cookbook/sequential_drop_banks.rst
@@ -10,11 +10,12 @@ light on, and flash the next target. Hitting an incorrect target will reset that
 target's coil and keep the light off.
 
 
-Step 1. Create a skillshot mode and lane shots
+Step 1. Create a sequential_drops mode and lane shots
 ----------------------------------------------
 
-We'll create a separate mode to manage the sequential drops, to keep the code
-clean and make it easy to turn the sequence on and off.
+We'll create a separate mode called *sequential_drops* to manage the game logic.
+Separate modes keep the code clean and make it easy to turn the drop sequence on
+and off as needed (e.g. during a multiball or wizard mode).
 
 The first thing our mode needs is :doc:`/config/shots`. Each drop target will be
 a shot (in this example, we'll have four). Each shot has a switch, a light, and
@@ -50,7 +51,7 @@ be reset after completion.
   #!   l_drop_4:
   #!     number: 4
   #! shot_profiles:
-  #!   skillshot_profile:
+  #!   drop_sequence:
   #!     states:
   #!       - name: off
   #!       - name: lit
@@ -104,7 +105,8 @@ when the shot is hit, but we don't want that here so we'll set
 
 .. code-block:: mpf-config
 
-  ##! mode: skillshot
+  ##! mode: sequential_drops
+
   drop_sequence:
     advance_on_hit: false
     states:

--- a/cookbook/skillshot_with_auto_rotate.rst
+++ b/cookbook/skillshot_with_auto_rotate.rst
@@ -14,11 +14,11 @@ Skillshots are a self-contained set of rules, so it's wise to create a separate
 mode that can be started when a player's ball starts and ended after the
 skillshot is hit (or missed).
 
-.. code-block:: mpf-config
+.. code-block:: yaml
+
   #config_version=5
   modes:
     - skillshot_with_auto_rotate
-    -
   switches:
     s_dropbank_1:
       number: 1
@@ -41,18 +41,6 @@ skillshot is hit (or missed).
       number: 4
     l_dropbank_5:
       number: 5
-
-  ##! mode: skillshot_with_auto_rotate
-  #! mode:
-  #!   start_events: start_mode_skillshot_with_auto_rotate
-  #!   stop_events: stop_mode_skillshot_with_auto_rotate
-  #!   priority: 1000
-  #! shot_profiles:
-  #!   skillshot_profile:
-  #!     states:
-  #!       - name: off
-  #!       - name: on
-
 
 The first thing our mode needs is :doc:`/config/shots`. Each possible target
 will be a shot (in this example, we'll have five). Each shot has a switch,

--- a/cookbook/skillshot_with_auto_rotate.rst
+++ b/cookbook/skillshot_with_auto_rotate.rst
@@ -14,7 +14,7 @@ Skillshots are a self-contained set of rules, so it's wise to create a separate
 mode that can be started when a player's ball starts and ended after the
 skillshot is hit (or missed).
 
-.. code-block:: yaml
+.. code-block:: mpf-config
 
   #config_version=5
   modes:
@@ -42,6 +42,9 @@ skillshot is hit (or missed).
     l_dropbank_5:
       number: 5
 
+  ##! mode: skillshot_with_auto_rotate
+  # mode will be defined below
+
 The first thing our mode needs is :doc:`/config/shots`. Each possible target
 will be a shot (in this example, we'll have five). Each shot has a switch,
 a light, and a shot profile to track its state. The sample code below uses
@@ -56,6 +59,10 @@ automatically light when the mode starts, as the first shot in the rotation.
 .. code-block:: mpf-config
 
   ##! mode: skillshot_with_auto_rotate
+  #! shot_profiles:
+  #!   skillshot_profile
+  #!     states:
+  #!       - name: off
   mode:
     start_events: start_mode_skillshot_with_auto_rotate
     stop_events: stop_mode_skillshot_with_auto_rotate
@@ -142,6 +149,17 @@ half-second.
 .. code-block:: mpf-config
 
   ##! mode: skillshot_with_auto_rotate
+  #! shots:
+  #!   skillshot_drop_1:
+  #!     number:
+  #!   skillshot_drop_2:
+  #!     number:
+  #!   skillshot_drop_3:
+  #!     number:
+  #!   skillshot_drop_4:
+  #!     number:
+  #!   skillshot_drop_5:
+  #!     number:
 
   shot_groups:
     skillshot:

--- a/cookbook/skillshot_with_auto_rotate.rst
+++ b/cookbook/skillshot_with_auto_rotate.rst
@@ -58,6 +58,17 @@ automatically light when the mode starts, as the first shot in the rotation.
 
 .. code-block:: mpf-config
 
+  #! switches:
+  #!   s_dropbank_1:
+  #!     number: 1
+  #!   s_dropbank_2:
+  #!     number: 2
+  #!   s_dropbank_3:
+  #!     number: 3
+  #!   s_dropbank_4:
+  #!     number: 4
+  #!   s_dropbank_5:
+  #!     number: 5
   ##! mode: skillshot_with_auto_rotate
   #! shot_profiles:
   #!   skillshot_profile:

--- a/cookbook/skillshot_with_auto_rotate.rst
+++ b/cookbook/skillshot_with_auto_rotate.rst
@@ -24,7 +24,7 @@ skillshot is hit (or missed).
       number: 1
     s_dropbank_2:
       number: 2
-    s_dropbank_3
+    s_dropbank_3:
       number: 3
     s_dropbank_4:
       number: 4
@@ -35,7 +35,7 @@ skillshot is hit (or missed).
       number: 1
     l_dropbank_2:
       number: 2
-    l_dropbank_3
+    l_dropbank_3:
       number: 3
     l_dropbank_4:
       number: 4
@@ -60,7 +60,7 @@ automatically light when the mode starts, as the first shot in the rotation.
 
   ##! mode: skillshot_with_auto_rotate
   #! shot_profiles:
-  #!   skillshot_profile
+  #!   skillshot_profile:
   #!     states:
   #!       - name: off
   mode:
@@ -148,18 +148,29 @@ half-second.
 
 .. code-block:: mpf-config
 
+  #! switches:
+  #!   s_dropbank_1:
+  #!     number: 1
+  #!   s_dropbank_2:
+  #!     number: 2
+  #!   s_dropbank_3:
+  #!     number: 3
+  #!   s_dropbank_4:
+  #!     number: 4
+  #!   s_dropbank_5:
+  #!     number: 5
   ##! mode: skillshot_with_auto_rotate
   #! shots:
   #!   skillshot_drop_1:
-  #!     number:
+  #!     switch: s_dropbank_1
   #!   skillshot_drop_2:
-  #!     number:
+  #!     switch: s_dropbank_2
   #!   skillshot_drop_3:
-  #!     number:
+  #!     switch: s_dropbank_3
   #!   skillshot_drop_4:
-  #!     number:
+  #!     switch: s_dropbank_4
   #!   skillshot_drop_5:
-  #!     number:
+  #!     switch: s_dropbank_5
 
   shot_groups:
     skillshot:

--- a/cookbook/skillshot_with_auto_rotate.rst
+++ b/cookbook/skillshot_with_auto_rotate.rst
@@ -1,0 +1,310 @@
+Recipe: Skillshot (with Auto-Rotate)
+==============================================
+
+This guide shows you how to build an MPF config for a skillshot with
+automatically-rotating targets. When the player's turn starts the target shots
+will rotate one "lit" shot rapidly, and when the ball is plunged the rotation
+will stop and the lit shot will flash as the skillshot target.
+
+
+Step 1. Create a skillshot mode and shots
+------------------------------------------
+
+Skillshots are a self-contained set of rules, so it's wise to create a separate
+mode that can be started when a player's ball starts and ended after the
+skillshot is hit (or missed).
+
+The first thing our mode needs is :doc:`/config/shots`. Each possible target
+will be a shot (in this example, we'll have five). Each shot has a switch,
+a light, and a shot profile to track its state. The sample code below uses
+dropbank switches for the skillshot, but you are free to use any switches you
+like.
+
+Each shot will also have unique ``advance_events`` configured, which will be
+explained in detail in section 4. What's important to note now is that the first
+shot includes ``advance_events: mode_skillshot_started`` so that this shot will
+automatically light when the mode starts, as the first shot in the rotation.
+
+.. code-block:: mpf-config
+
+  #! switches:
+  #!   s_dropbank_1:
+  #!     number: 1
+  #!   s_dropbank_2:
+  #!     number: 2
+  #!   s_dropbank_3
+  #!     number: 3
+  #!   s_dropbank_4:
+  #!     number: 4
+  #!   s_dropbank_5:
+  #!     number: 5
+  #! lights:
+  #!   l_dropbank_1:
+  #!     number: 1
+  #!   l_dropbank_2:
+  #!     number: 2
+  #!   l_dropbank_3
+  #!     number: 3
+  #!   l_dropbank_4:
+  #!     number: 4
+  #!   l_dropbank_5:
+  #!     number: 5
+  #! shot_profiles:
+  #!   skillshot_profile:
+  #!     states:
+  #!       - name: off
+  #!       - name: on
+  ##! mode: skillshot
+
+  mode:
+    start_events: start_mode_skillshot
+    stop_events: stop_mode_skillshot
+    priority: 1000
+
+  shots:
+    skillshot_drop_1:
+      switch: s_dropbank_1
+      advance_events: mode_skillshot_started, advance_skillshot_1
+      profile: skillshot_profile
+      show_tokens:
+        leds: l_dropbank_1
+    skillshot_drop_2:
+      switch: s_dropbank_2
+      advance_events: advance_skillshot_2
+      profile: skillshot_profile
+      show_tokens:
+        leds: l_dropbank_2
+    skillshot_drop_3:
+      switch: s_dropbank_3
+      advance_events: advance_skillshot_3
+      profile: skillshot_profile
+      show_tokens:
+        leds: l_dropbank_3
+    skillshot_drop_4:
+      switch: s_dropbank_4
+      advance_events: advance_skillshot_4
+      profile: skillshot_profile
+      show_tokens:
+        leds: l_dropbank_4
+    skillshot_drop_5:
+      switch: s_dropbank_5
+      advance_events: advance_skillshot_5
+      profile: skillshot_profile
+      show_tokens:
+        leds: l_dropbank_5
+
+
+Step 2. Create a profile for the targets
+------------------------------------------
+
+We can create a :doc:`shot_profile</config/shot_profiles>` for the targets that
+starts with the light off, lights it solid after one advancement, and makes it
+flash after a second advancement. By default, a shot will advance its profile
+when the shot is hit, but we don't want that here so we'll set
+``advance_on_hit: false``.
+
+When the mode starts, all shots will be in the first profile state "off". The
+first shot will immediately advance to the "on" state (from the
+``advance_events: mode_skillshot_started`` noted above). Every time the shot
+group rotates, the next shot in sequence will shift to "on". This creates the
+rotation effect of the lit shot moving across the targets.
+
+When the ball is plunged, whichever shot is in the "on" state will be advanced
+to the "lit" state and its light will flash. When any shot is hit, we'll check
+whether it is "lit" or not to know whether the skillshot should be awarded.
+
+.. code-block:: mpf-config
+
+  ##! mode: skillshot
+  shot_profiles:
+    skillshot_profile:
+      advance_on_hit: false
+      states:
+        - name: off
+          show: off
+        - name: on
+          show: on
+        - name: lit
+          show: flash
+
+
+Step 3. Create a shot_group for the lanes, and a rotation timer
+----------------------------------------------------------------
+
+To tell MPF that the five shots are related to each other, we create a
+:doc:`shot_group</config/shot_groups>` with all the shots in it.
+
+Shot groups are powerful because they control behavior of all the shots
+together. In this case, we'll use our shot group control the rotation of the
+shots, and a :doc:`timer</config/timers>` to trigger a rotation every
+half-second.
+
+.. code-block:: mpf-config
+
+  #! switches:
+  #!   s_dropbank_1:
+  #!     number: 1
+  #!   s_dropbank_2:
+  #!     number: 2
+  #!   s_dropbank_3
+  #!     number: 3
+  #!   s_dropbank_4:
+  #!     number: 4
+  #!   s_dropbank_5:
+  #!     number: 5
+  #! lights:
+  #!   l_dropbank_1:
+  #!     number: 1
+  #!   l_dropbank_2:
+  #!     number: 2
+  #!   l_dropbank_3
+  #!     number: 3
+  #!   l_dropbank_4:
+  #!     number: 4
+  #!   l_dropbank_5:
+  #!     number: 5
+  #! shot_profiles:
+  #!   skillshot_profile:
+  #!     states:
+  #!       - name: off
+  #!       - name: on
+  #!       - name: lit
+  #! shots:
+  #!   skillshot_left:
+  #!     switch: s_lane_left
+  #!     profile: skillshot_profile
+  #!     show_tokens:
+  #!       led: l_lane_left
+  #!   skillshot_middle:
+  #!     switch: s_lane_middle
+  #!     profile: skillshot_profile
+  #!     show_tokens:
+  #!       led: l_lane_middle
+  #!   skillshot_right:
+  #!     switch: s_lane_right
+  #!     profile: skillshot_profile
+  #!     show_tokens:
+  #!       led: l_lane_right
+  #!
+  #! shot_profiles:
+  #!  shot_profiles:
+  #!    skillshot_profile:
+  #!      advance_on_hit: false
+  #!      states:
+  #!        - name: off
+  #!          show: off
+  #!        - name: lit
+  #!          show: flash
+  ##! mode: skillshot
+
+  shot_groups:
+    skillshot:
+      shots:
+        - skillshot_drop_1
+        - skillshot_drop_2
+        - skillshot_drop_3
+        - skillshot_drop_4
+        - skillshot_drop_5
+      rotate_events: timer_skillshot_rotate_tick
+
+  timers:
+    skillshot_rotate:
+      tick_interval: 500ms
+      start_running: true
+      control_events:
+        - event: s_plunger_lane_inactive
+          action: stop
+
+The ``rotate_events`` will move the state of the shots each time the
+timer ticks, and the ball leaving the plunger lane will stop the timer
+and thus stop the rotation.
+
+
+Step 4. Flash the lit shot when the rotation stops
+--------------------------------------------------
+
+When the timer stops, one of the shots will be in the "on" state. Whichever
+shot this is should be advanced to the "lit" state so the light is flashing,
+and we can use conditional events to listen for the timer stop and advance
+*only* the lit shot.
+
+Shot profile states are numbered starting with zero, so our "off" state is
+number 0 and the "on" state is number 1. The following code will only post the
+advance event for a shot if that shot is in state number 1, a.k.a. "on".
+
+.. code-block:: mpf-config
+
+  #! mode: skillshot
+  event_player:
+    timer_skillshot_rotate_stopped:
+      - advance_skillshot_1{device.shots.skillshot_drop_1.state==1}
+      - advance_skillshot_2{device.shots.skillshot_drop_2.state==1}
+      - advance_skillshot_3{device.shots.skillshot_drop_3.state==1}
+      - advance_skillshot_4{device.shots.skillshot_drop_4.state==1}
+      - advance_skillshot_5{device.shots.skillshot_drop_5.state==1}
+
+
+Each shot configured in step 1 above has ``advance_events`` that correspond to
+its shot number, so the above event player will trigger the correct shot to
+advance to its "lit" state.
+
+
+Step 5. Rewards for skillshot
+-----------------------------
+
+When the player hits the lit shot, they get an award of points. We can use the
+:doc:`/config/variable_player` for this.
+
+When a shot in a shot group is hit, the shot group will post an event with
+the state name of the shot that was hit. This way, we can check when *any* shot
+is hit rather than having to check each shot individually.
+
+.. code-block:: mpf-config
+
+  #! mode: skillshot
+  variable_player:
+    skillshot_lit_hit:
+      score: 20_000
+
+
+Step 6. End the mode on skillshot hit, or any other hit
+----------------------------------------------------------
+
+After any skillshot shot is hit, the skillshot mode should end. We can again
+use the shot group to detect *any* shot being hit, but we'll use a hit event
+*without* a state name because it doesn't matter whether the shot was lit or
+not.
+
+We also want to end the skillshot mode if any other switch on the playfield
+was hit, which we can detect from the *playfield_active* event. However, when
+the skillshot is hit the *playfield_active* event will post before the
+*skillshot_lit_hit* event, so if we end the mode immediately then no score will
+be awarded. Instead, we add a 1 second delay after playfield activation before
+ending the mode.
+
+.. code-block:: mpf-config
+
+  #! mode: skillshot
+  event_player:
+    # Add these lines after timer_skillshot_rotate_stopped (defined above)
+    skillshot_hit: stop_mode_skillshot
+    playfield_active: stop_mode_skillshot|1s
+
+
+Full Example Code
+-----------------
+
+The full code from this example can be found as a fully-working game template in the
+MPF Examples repository.
+
+https://github.com/missionpinball/mpf-examples/tree/dev/cookbook/skillshot_with_auto_rotate
+
+
+Related Docs
+------------
+
+* :doc:`/config/shots`
+* :doc:`/config/shot_groups`
+* :doc:`/config/shot_profiles`
+* :doc:`/config/timers`
+* :doc:`/config/variable_player`

--- a/cookbook/skillshot_with_auto_rotate.rst
+++ b/cookbook/skillshot_with_auto_rotate.rst
@@ -14,6 +14,46 @@ Skillshots are a self-contained set of rules, so it's wise to create a separate
 mode that can be started when a player's ball starts and ended after the
 skillshot is hit (or missed).
 
+.. code-block:: mpf-config
+  #config_version=5
+  modes:
+    - skillshot_with_auto_rotate
+    -
+  switches:
+    s_dropbank_1:
+      number: 1
+    s_dropbank_2:
+      number: 2
+    s_dropbank_3
+      number: 3
+    s_dropbank_4:
+      number: 4
+    s_dropbank_5:
+      number: 5
+  lights:
+    l_dropbank_1:
+      number: 1
+    l_dropbank_2:
+      number: 2
+    l_dropbank_3
+      number: 3
+    l_dropbank_4:
+      number: 4
+    l_dropbank_5:
+      number: 5
+
+  ##! mode: skillshot_with_auto_rotate
+  #! mode:
+  #!   start_events: start_mode_skillshot_with_auto_rotate
+  #!   stop_events: stop_mode_skillshot_with_auto_rotate
+  #!   priority: 1000
+  #! shot_profiles:
+  #!   skillshot_profile:
+  #!     states:
+  #!       - name: off
+  #!       - name: on
+
+
 The first thing our mode needs is :doc:`/config/shots`. Each possible target
 will be a shot (in this example, we'll have five). Each shot has a switch,
 a light, and a shot profile to track its state. The sample code below uses
@@ -27,44 +67,16 @@ automatically light when the mode starts, as the first shot in the rotation.
 
 .. code-block:: mpf-config
 
-  #! switches:
-  #!   s_dropbank_1:
-  #!     number: 1
-  #!   s_dropbank_2:
-  #!     number: 2
-  #!   s_dropbank_3
-  #!     number: 3
-  #!   s_dropbank_4:
-  #!     number: 4
-  #!   s_dropbank_5:
-  #!     number: 5
-  #! lights:
-  #!   l_dropbank_1:
-  #!     number: 1
-  #!   l_dropbank_2:
-  #!     number: 2
-  #!   l_dropbank_3
-  #!     number: 3
-  #!   l_dropbank_4:
-  #!     number: 4
-  #!   l_dropbank_5:
-  #!     number: 5
-  #! shot_profiles:
-  #!   skillshot_profile:
-  #!     states:
-  #!       - name: off
-  #!       - name: on
-  ##! mode: skillshot
-
+  ##! mode: skillshot_with_auto_rotate
   mode:
-    start_events: start_mode_skillshot
-    stop_events: stop_mode_skillshot
+    start_events: start_mode_skillshot_with_auto_rotate
+    stop_events: stop_mode_skillshot_with_auto_rotate
     priority: 1000
 
   shots:
     skillshot_drop_1:
       switch: s_dropbank_1
-      advance_events: mode_skillshot_started, advance_skillshot_1
+      advance_events: mode_skillshot_with_auto_rotate_started, advance_skillshot_1
       profile: skillshot_profile
       show_tokens:
         leds: l_dropbank_1
@@ -105,9 +117,9 @@ when the shot is hit, but we don't want that here so we'll set
 
 When the mode starts, all shots will be in the first profile state "off". The
 first shot will immediately advance to the "on" state (from the
-``advance_events: mode_skillshot_started`` noted above). Every time the shot
-group rotates, the next shot in sequence will shift to "on". This creates the
-rotation effect of the lit shot moving across the targets.
+``advance_events: mode_skillshot_with_auto_rotate_started`` noted above). Every
+time the shot group rotates, the next shot in sequence will shift to "on". This
+creates the rotation effect of the lit shot moving across the targets.
 
 When the ball is plunged, whichever shot is in the "on" state will be advanced
 to the "lit" state and its light will flash. When any shot is hit, we'll check
@@ -115,7 +127,7 @@ whether it is "lit" or not to know whether the skillshot should be awarded.
 
 .. code-block:: mpf-config
 
-  ##! mode: skillshot
+  ##! mode: skillshot_with_auto_rotate
   shot_profiles:
     skillshot_profile:
       advance_on_hit: false
@@ -141,61 +153,7 @@ half-second.
 
 .. code-block:: mpf-config
 
-  #! switches:
-  #!   s_dropbank_1:
-  #!     number: 1
-  #!   s_dropbank_2:
-  #!     number: 2
-  #!   s_dropbank_3
-  #!     number: 3
-  #!   s_dropbank_4:
-  #!     number: 4
-  #!   s_dropbank_5:
-  #!     number: 5
-  #! lights:
-  #!   l_dropbank_1:
-  #!     number: 1
-  #!   l_dropbank_2:
-  #!     number: 2
-  #!   l_dropbank_3
-  #!     number: 3
-  #!   l_dropbank_4:
-  #!     number: 4
-  #!   l_dropbank_5:
-  #!     number: 5
-  #! shot_profiles:
-  #!   skillshot_profile:
-  #!     states:
-  #!       - name: off
-  #!       - name: on
-  #!       - name: lit
-  #! shots:
-  #!   skillshot_left:
-  #!     switch: s_lane_left
-  #!     profile: skillshot_profile
-  #!     show_tokens:
-  #!       led: l_lane_left
-  #!   skillshot_middle:
-  #!     switch: s_lane_middle
-  #!     profile: skillshot_profile
-  #!     show_tokens:
-  #!       led: l_lane_middle
-  #!   skillshot_right:
-  #!     switch: s_lane_right
-  #!     profile: skillshot_profile
-  #!     show_tokens:
-  #!       led: l_lane_right
-  #!
-  #! shot_profiles:
-  #!  shot_profiles:
-  #!    skillshot_profile:
-  #!      advance_on_hit: false
-  #!      states:
-  #!        - name: off
-  #!          show: off
-  #!        - name: lit
-  #!          show: flash
-  ##! mode: skillshot
+  ##! mode: skillshot_with_auto_rotate
 
   shot_groups:
     skillshot:
@@ -234,7 +192,7 @@ advance event for a shot if that shot is in state number 1, a.k.a. "on".
 
 .. code-block:: mpf-config
 
-  #! mode: skillshot
+  ##! mode: skillshot_with_auto_rotate
   event_player:
     timer_skillshot_rotate_stopped:
       - advance_skillshot_1{device.shots.skillshot_drop_1.state==1}
@@ -261,7 +219,7 @@ is hit rather than having to check each shot individually.
 
 .. code-block:: mpf-config
 
-  #! mode: skillshot
+  ##! mode: skillshot_with_auto_rotate
   variable_player:
     skillshot_lit_hit:
       score: 20_000
@@ -284,7 +242,7 @@ ending the mode.
 
 .. code-block:: mpf-config
 
-  #! mode: skillshot
+  ##! mode: skillshot_with_auto_rotate
   event_player:
     # Add these lines after timer_skillshot_rotate_stopped (defined above)
     skillshot_hit: stop_mode_skillshot

--- a/cookbook/skillshot_with_lane_change.rst
+++ b/cookbook/skillshot_with_lane_change.rst
@@ -1,0 +1,241 @@
+Recipe: Skillshot (with Lane Change)
+==============================================
+
+This guide shows you how to build an MPF config for a skillshot with rotating
+rollover lanes (a.k.a "lane change").
+
+For a description of rollover lanes, see
+:doc:`Rollover Lanes with Lane Change <rollover_lanes_with_lane_change>`
+
+
+Step 1. Create a skillshot mode and lane shots
+----------------------------------------------
+
+Skillshots are a self-contained set of rules, so it's wise to create a separate
+mode that can be started when a player's ball starts and ended after the
+skillshot is hit (or missed).
+
+The first thing our mode needs is :doc:`/config/shots`. Each lane will count as
+a shot, and for this example we'll have three lanes "left", "middle", and
+"right". We'll assume that the machine has switches defined in the ``switches:``
+config section for each of the lanes, called ``s_lane_left``, ``s_lane_middle``,
+and ``s_lane_right``. We'll also use corresponding lights ``l_lane_left`` etc.
+to indicate which lane is lit.
+
+
+.. code-block:: mpf-config
+
+  #! switches:
+  #!   s_lane_left:
+  #!     number: 1
+  #!   s_lane_middle:
+  #!     number: 2
+  #!   s_lane_right:
+  #!     number: 3
+  #! lights:
+  #!   l_lane_left:
+  #!     number: 1
+  #!   l_lane_middle:
+  #!     number: 2
+  #!   l_lane_right:
+  #!     number: 3
+  #! shot_profiles:
+  #!   skillshot_profile:
+  #!     states:
+  #!       - name: off
+  #!       - name: on
+  ##! mode: skillshot
+
+  mode:
+    start_events: start_mode_skillshot
+    stop_events: stop_mode_skillshot
+    priority: 1000
+
+  shots:
+    skillshot_left:
+      advance_events: advance_skillshot_left
+      profile: skillshot_profile
+      switch: s_lane_left
+      show_tokens:
+        led: l_lane_left
+    skillshot_middle:
+      advance_events: advance_skillshot_middle
+      profile: skillshot_profile
+      switch: s_lane_middle
+      show_tokens:
+        led: l_lane_middle
+    skillshot_right:
+      advance_events: advance_skillshot_right
+      profile: skillshot_profile
+      switch: s_lane_right
+      show_tokens:
+        led: l_lane_right
+
+
+Step 2. Creating a profile for the lanes
+----------------------------------------
+
+We can create a :doc:`shot_profile</config/shot_profiles>` for the lanes that
+starts with the light off and makes it flash if that lane is lit for the
+skillshot.
+
+By default, a shot will advance its profile when the shot is hit, but we don't
+want that here so we'll set ``advance_on_hit: false``. Instead, we have explicit
+``advance_events`` set on the shots so we can advance them for the lane change.
+
+.. code-block:: mpf-config
+
+  ##! mode: skillshot
+  shot_profiles:
+    skillshot_profile:
+      advance_on_hit: false
+      states:
+        - name: off
+          show: off
+        - name: lit
+          show: flash
+
+
+Step 3. Creating a shot_group for the lanes
+-------------------------------------------
+
+To tell MPF that the lane shots are related to each other, we create a
+:doc:`shot_group</config/shot_groups>` with all the shots in it.
+
+Shot groups are powerful because they control behavior of all the shots
+together. In this case, we'll use our shot group to rotate the lit shots.
+
+.. code-block:: mpf-config
+
+  #! switches:
+  #!   s_lane_left:
+  #!     number: 1
+  #!   s_lane_middle:
+  #!     number: 2
+  #!   s_lane_right:
+  #!     number: 3
+  #! lights:
+  #!   l_lane_left:
+  #!     number: 1
+  #!   l_lane_middle:
+  #!     number: 2
+  #!   l_lane_right:
+  #!     number: 3
+  #! mode: skillshot
+  #! shots:
+  #!   skillshot_left:
+  #!     switch: s_lane_left
+  #!     profile: skillshot_profile
+  #!     show_tokens:
+  #!       led: l_lane_left
+  #!   skillshot_middle:
+  #!     switch: s_lane_middle
+  #!     profile: skillshot_profile
+  #!     show_tokens:
+  #!       led: l_lane_middle
+  #!   skillshot_right:
+  #!     switch: s_lane_right
+  #!     profile: skillshot_profile
+  #!     show_tokens:
+  #!       led: l_lane_right
+  #!
+  #! shot_profiles:
+  #!  shot_profiles:
+  #!    skillshot_profile:
+  #!      advance_on_hit: false
+  #!      states:
+  #!        - name: off
+  #!          show: off
+  #!        - name: lit
+  #!          show: flash
+  shot_groups:
+    skillshot:
+      shots: skillshot_left, skillshot_middle, skillshot_right
+      disable_rotation_events: s_plunger_lane_inactive
+      rotate_left_events: s_flipper_left_active
+      rotate_right_events: s_flipper_right_active
+
+
+The ``rotate_left_events`` and ``rotate_right_events`` trigger the lane changes
+based on the flipper events. The ``disable_rotation_events`` will prevent the
+player from changing lanes after they plunge the ball, for a true "skill" shot.
+(If you want to allow lane changes after plunge, just remove that line.)
+
+
+Step 4. Light a random shot when the mode starts
+------------------------------------------------
+
+The starting state of the shot profile is "off", so we need to pick one
+shot at random and advance it to its "lit" state. We'll use the
+:doc:`/config/random_event_player` for this.
+
+.. code-block:: mpf-config
+
+  #! mode: skillshot
+  random_event_player:
+    mode_skillshot_started:
+      events:
+        - advance_skillshot_left
+        - advance_skillshot_middle
+        - advance_skillshot_right
+
+
+
+Step 5. Rewards for Skillshot
+-----------------------------
+
+When the player hits the lit skillshot shot, they get an award of points.
+We can use the :doc:`/config/variable_player` for this.
+
+When a shot in a shot group is hit, the shot group will post an event with
+the state name of the shot that was hit. By using the shot group events, we can
+check when *any* shot is hit, rather than having to check each shot in the group
+individually.
+
+.. code-block:: mpf-config
+
+  #! mode: skillshot
+  variable_player:
+    skillshot_lit_hit:
+      score: 20_000
+
+
+Step 6. Ending the mode on skillshot hit, or any other hit
+----------------------------------------------------------
+
+After any skillshot lane is hit, the skillshot mode should end. We can again
+use the shot group to detect *any* shot being hit, but we'll use a hit event
+*without* any state because it doesn't matter whether the shot was lit or not.
+
+We also want to end the skillshot mode if any other switch on the playfield
+was hit, which we can detect from the *playfield_active* event. However, when
+the skillshot is hit the *playfield_active* event will post before the
+*skillshot_lit_hit* event, so if we end the mode immediately then no score will
+be awarded. Instead, we add a 1 second delay after playfield activation before
+ending the mode.
+
+.. code-block:: mpf-config
+
+  #! mode: skillshot
+  event_player:
+    skillshot_hit: stop_mode_skillshot
+    playfield_active: stop_mode_skillshot|1s
+
+
+Full Example Code
+-----------------
+
+The full code from this example can be found as a fully-working game template in
+the MPF Examples repository.
+
+https://github.com/missionpinball/mpf-examples/tree/dev/cookbook/skillshot_with_lane_change
+
+
+Related Docs
+------------
+
+* :doc:`/config/random_event_player`
+* :doc:`/config/shots`
+* :doc:`/config/shot_groups`
+* :doc:`/config/shot_profiles`
+* :doc:`/config/variable_player`

--- a/cookbook/skillshot_with_lane_change.rst
+++ b/cookbook/skillshot_with_lane_change.rst
@@ -121,7 +121,8 @@ together. In this case, we'll use our shot group to rotate the lit shots.
   #!     number: 2
   #!   l_lane_right:
   #!     number: 3
-  #! mode: skillshot
+  #!
+  ##! mode: skillshot
   #! shots:
   #!   skillshot_left:
   #!     switch: s_lane_left
@@ -171,7 +172,7 @@ shot at random and advance it to its "lit" state. We'll use the
 
 .. code-block:: mpf-config
 
-  #! mode: skillshot
+  ##! mode: skillshot
   random_event_player:
     mode_skillshot_started:
       events:
@@ -194,7 +195,7 @@ individually.
 
 .. code-block:: mpf-config
 
-  #! mode: skillshot
+  ##! mode: skillshot
   variable_player:
     skillshot_lit_hit:
       score: 20_000
@@ -216,7 +217,7 @@ ending the mode.
 
 .. code-block:: mpf-config
 
-  #! mode: skillshot
+  ##! mode: skillshot
   event_player:
     skillshot_hit: stop_mode_skillshot
     playfield_active: stop_mode_skillshot|1s

--- a/cookbook/skillshot_with_lane_change.rst
+++ b/cookbook/skillshot_with_lane_change.rst
@@ -59,10 +59,11 @@ a shot, and for this example we'll have three lanes "left", "middle", and
 .. code-block:: mpf-config
 
   ##! mode: skillshot_with_lane_change
-  #!  shot_profiles:
-  #!    skillshot_profile:
-  #!      states:
-  #!        - name: off
+  #! shot_profiles:
+  #!   skillshot_profile:
+  #!     states:
+  #!       - name: off
+  #!
 
   mode:
     start_events: start_mode_skillshot_with_lane_change
@@ -125,14 +126,21 @@ together. In this case, we'll use our shot group to rotate the lit shots.
 
 .. code-block:: mpf-config
 
+  #! switches:
+  #!   s_lane_left:
+  #!     number: 1
+  #!   s_lane_middle:
+  #!     number: 2
+  #!   s_lane_right:
+  #!     number: 3
   ##! mode: skillshot_with_lane_change
-  #!  shots:
-  #!    skillshot_left:
-  #!      number:
-  #!    skillshot_middle:
-  #!      number:
-  #!    skillshot_right:
-  #!      number:
+  #! shots:
+  #!   skillshot_left:
+  #!     switch: s_lane_left
+  #!   skillshot_middle:
+  #!     switch: s_lane_middle
+  #!   skillshot_right:
+  #!     switch: s_lane_right
 
   shot_groups:
     skillshot:

--- a/cookbook/skillshot_with_lane_change.rst
+++ b/cookbook/skillshot_with_lane_change.rst
@@ -59,6 +59,11 @@ a shot, and for this example we'll have three lanes "left", "middle", and
 .. code-block:: mpf-config
 
   ##! mode: skillshot_with_lane_change
+  #!  shot_profiles:
+  #!    skillshot_profile:
+  #!      states:
+  #!        - name: off
+
   mode:
     start_events: start_mode_skillshot_with_lane_change
     stop_events: stop_mode_skillshot_with_lane_change
@@ -121,6 +126,14 @@ together. In this case, we'll use our shot group to rotate the lit shots.
 .. code-block:: mpf-config
 
   ##! mode: skillshot_with_lane_change
+  #!  shots:
+  #!    skillshot_left:
+  #!      number:
+  #!    skillshot_middle:
+  #!      number:
+  #!    skillshot_right:
+  #!      number:
+
   shot_groups:
     skillshot:
       shots: skillshot_left, skillshot_middle, skillshot_right

--- a/cookbook/skillshot_with_lane_change.rst
+++ b/cookbook/skillshot_with_lane_change.rst
@@ -58,6 +58,13 @@ a shot, and for this example we'll have three lanes "left", "middle", and
 
 .. code-block:: mpf-config
 
+  #! switches:
+  #!   s_lane_left:
+  #!     number: 1
+  #!   s_lane_middle:
+  #!     number: 2
+  #!   s_lane_right:
+  #!     number: 3
   ##! mode: skillshot_with_lane_change
   #! shot_profiles:
   #!   skillshot_profile:

--- a/cookbook/skillshot_with_lane_change.rst
+++ b/cookbook/skillshot_with_lane_change.rst
@@ -15,9 +15,7 @@ Skillshots are a self-contained set of rules, so it's wise to create a separate
 mode that can be started when a player's ball starts and ended after the
 skillshot is hit (or missed).
 
-The first thing our mode needs is :doc:`/config/shots`. Each lane will count as
-a shot, and for this example we'll have three lanes "left", "middle", and
-"right". We'll assume that the machine has switches defined in the ``switches:``
+We'll assume that the machine has switches defined in the ``switches:``
 config section for each of the lanes, called ``s_lane_left``, ``s_lane_middle``,
 and ``s_lane_right``. We'll also use corresponding lights ``l_lane_left`` etc.
 to indicate which lane is lit.
@@ -25,30 +23,45 @@ to indicate which lane is lit.
 
 .. code-block:: mpf-config
 
-  #! switches:
-  #!   s_lane_left:
-  #!     number: 1
-  #!   s_lane_middle:
-  #!     number: 2
-  #!   s_lane_right:
-  #!     number: 3
-  #! lights:
-  #!   l_lane_left:
-  #!     number: 1
-  #!   l_lane_middle:
-  #!     number: 2
-  #!   l_lane_right:
-  #!     number: 3
-  #! shot_profiles:
-  #!   skillshot_profile:
-  #!     states:
-  #!       - name: off
-  #!       - name: on
-  ##! mode: skillshot
+  #config_version=5
+  modes:
+    - skillshot_with_lane_change
+  switches:
+    s_lane_left:
+      number: 1
+    s_lane_middle:
+      number: 2
+    s_lane_right:
+      number: 3
+  lights:
+    l_lane_left:
+      number: 1
+    l_lane_middle:
+      number: 2
+    l_lane_right:
+      number: 3
+  shot_profiles:
+    skillshot_profile:
+      states:
+        - name: off
+        - name: on
 
+  ##! mode: skillshot_with_lane_change
+  #! mode:
+  #!   start_events: start_mode_skillshot_with_lane_change
+  #!   stop_events: stop_mode_skillshot_with_lane_change
+  #!   priority: 1000
+
+The first thing our mode needs is :doc:`/config/shots`. Each lane will count as
+a shot, and for this example we'll have three lanes "left", "middle", and
+"right".
+
+.. code-block:: mpf-config
+
+  ##! mode: skillshot_with_lane_change
   mode:
-    start_events: start_mode_skillshot
-    stop_events: stop_mode_skillshot
+    start_events: start_mode_skillshot_with_lane_change
+    stop_events: stop_mode_skillshot_with_lane_change
     priority: 1000
 
   shots:
@@ -85,7 +98,7 @@ want that here so we'll set ``advance_on_hit: false``. Instead, we have explicit
 
 .. code-block:: mpf-config
 
-  ##! mode: skillshot
+  ##! mode: skillshot_with_lane_change
   shot_profiles:
     skillshot_profile:
       advance_on_hit: false
@@ -107,48 +120,7 @@ together. In this case, we'll use our shot group to rotate the lit shots.
 
 .. code-block:: mpf-config
 
-  #! switches:
-  #!   s_lane_left:
-  #!     number: 1
-  #!   s_lane_middle:
-  #!     number: 2
-  #!   s_lane_right:
-  #!     number: 3
-  #! lights:
-  #!   l_lane_left:
-  #!     number: 1
-  #!   l_lane_middle:
-  #!     number: 2
-  #!   l_lane_right:
-  #!     number: 3
-  #!
-  ##! mode: skillshot
-  #! shots:
-  #!   skillshot_left:
-  #!     switch: s_lane_left
-  #!     profile: skillshot_profile
-  #!     show_tokens:
-  #!       led: l_lane_left
-  #!   skillshot_middle:
-  #!     switch: s_lane_middle
-  #!     profile: skillshot_profile
-  #!     show_tokens:
-  #!       led: l_lane_middle
-  #!   skillshot_right:
-  #!     switch: s_lane_right
-  #!     profile: skillshot_profile
-  #!     show_tokens:
-  #!       led: l_lane_right
-  #!
-  #! shot_profiles:
-  #!  shot_profiles:
-  #!    skillshot_profile:
-  #!      advance_on_hit: false
-  #!      states:
-  #!        - name: off
-  #!          show: off
-  #!        - name: lit
-  #!          show: flash
+  ##! mode: skillshot_with_lane_change
   shot_groups:
     skillshot:
       shots: skillshot_left, skillshot_middle, skillshot_right
@@ -172,7 +144,7 @@ shot at random and advance it to its "lit" state. We'll use the
 
 .. code-block:: mpf-config
 
-  ##! mode: skillshot
+  ##! mode: skillshot_with_lane_change
   random_event_player:
     mode_skillshot_started:
       events:
@@ -195,7 +167,7 @@ individually.
 
 .. code-block:: mpf-config
 
-  ##! mode: skillshot
+  ##! mode: skillshot_with_lane_change
   variable_player:
     skillshot_lit_hit:
       score: 20_000
@@ -217,7 +189,7 @@ ending the mode.
 
 .. code-block:: mpf-config
 
-  ##! mode: skillshot
+  ##! mode: skillshot_with_lane_change
   event_player:
     skillshot_hit: stop_mode_skillshot
     playfield_active: stop_mode_skillshot|1s

--- a/game_design/game_modes/fake_ball_save.rst
+++ b/game_design/game_modes/fake_ball_save.rst
@@ -134,7 +134,7 @@ When this mode is ending you should enable the coils you disabled.
         - enable_Lower_Left_pop_bumper
         - enable_Lower_Right_pop_bumper
         - enable_sling
-        - start_<another_mode>
+        - start_another_mode
 
     queue_event_player:
       mode_end_<mode_name>_started:

--- a/game_logic/multiballs/multiball_with_traditional_ball_lock.rst
+++ b/game_logic/multiballs/multiball_with_traditional_ball_lock.rst
@@ -106,6 +106,8 @@ multiball.
    #! assert_balls_in_play 1
    #! assert_int_condition 1 current_player.ball
    #! assert_int_condition 0 device.multiball_locks.madnesslock.locked_balls
+   #! # The ball device should be empty now
+   #! assert_int_condition 0 device.ball_devices.lockdevice.balls
    #! # second try. mb should start again
    #! mock_event multiball_lock_madnesslock_full
    #! add_ball_to_device lockdevice

--- a/game_logic/multiballs/multiball_with_traditional_ball_lock.rst
+++ b/game_logic/multiballs/multiball_with_traditional_ball_lock.rst
@@ -66,6 +66,8 @@ multiball.
    #!     number:
    #!   s_ball2:
    #!     number:
+   #!   s_target:
+   #!     number:
    #! coils:
    #!   c_eject:
    #!     number:
@@ -98,6 +100,11 @@ multiball.
    #! add_ball_to_device lockdevice
    #! advance_time_and_run 1
    #! assert_event_called multiball_lock_madnesslock_full
+   #! # release the ball device switches to confirm the locked balls ejected
+   #! advance_time_and_run 1
+   #! release_switch s_ball2
+   #! advance_time_and_run 1
+   #! release_switch s_ball1
    #! advance_time_and_run 40
    #! assert_balls_in_play 3
    #! drain_one_ball


### PR DESCRIPTION
This PR adds three new cookbook recipes to the docs repo. It is the corresponding PR to https://github.com/missionpinball/mpf-examples/pull/16, which adds these recipes as sample projects in the MPF Examples repo.

**Skillshot with lane change** describes how to use multiple lane rollovers to light a skillshot and the flippers to lane change which lane is lit with the skillshot.

**Skillshot with auto-rotate** describes how to rotate a lit shot along a bank of shots, and to "lock" the lit shot as the skillshot when the ball is plunged.

**Sequential drop banks** describes how to define a set of drop targets with a specific hit order and auto-reset targets that are hit out-of-sequence.