### PR TITLE
Update leds.rst

### DIFF
--- a/hardware/fast/leds.rst
+++ b/hardware/fast/leds.rst
@@ -36,8 +36,8 @@ Channel and Number Syntax
 FAST assumes RGB lights by default.
 For everything else (i.e. RGBW) you have to use channels.
 
-The FAST Nano supports 256 LEDs on four chains.
-LEDs 0-63 are on chain 0, 64-127 on chain 1, 128-195 on chain 2 and 196-255 on chain 3.
+The FAST Nano supports 256 LEDs across four chains (listed as "CH 1" - "CH 4" on the Nano).
+LEDs 0-63 are on chain 1, 64-127 on chain 2, 128-191 on chain 3 and 192-255 on chain 4 (please note that FAST diagrams label these 4 headers as "channels" but we are using the term "chains" to avoid confusion with the non-RGB "Channels" section below).
 
 Light Numbers
 ^^^^^^^^^^^^^


### PR DESCRIPTION
The math is a bit off here I think (I just tested it on my FAST Nano). The last chain should be 192-255 (not 196-255). Additionally, while I know a lot of programming things start with "0" as the first group, the Nano circuit board and diagrams are printed as CH1, CH2, CH3, CH4. FAST also labels the headers as "Channels" not "Chains" but I think that could get confusing since the "Channels" section is right after this in the documentation (and is not referring to the 4 headers but the non-RGB LED type channels).