### PR TITLE
Multimorphic install issues - Python 3.8

### DIFF
--- a/install/linux/index.rst
+++ b/install/linux/index.rst
@@ -31,6 +31,32 @@ Running MPF
 
 See the :doc:`/running/index` for details and command-line options.
 
+If you see a Failed to initialize MPF exception when trying to start MPF with Multimorphic P-Roc/P3-Roc boards with Python 3.8.
+
+Example Error:
+
+Failed to initialise MPF
+Traceback (most recent call last):
+ File “/usr/local/lib/python3.8/dist-packages/mpf/platforms/p_roc_common.py”, line 31, in <module>
+  import pinproc
+ModuleNotFoundError: No module named ‘pinproc’
+During handling of the above exception, another exception occurred:
+Traceback (most recent call last):
+ File “/usr/local/lib/python3.8/dist-packages/mpf/platforms/p_roc_common.py”, line 41, in <module>
+  raise ImportError
+ImportError
+
+Try Changing:
+
+Edit install-proc:
+
+FROM:
+    cd pypinproc
+    sudo python3 setup.py install
+TO:
+   cd pypinproc
+   python3 setup.py install --user
+
 Keeping MPF up-to-date
 ----------------------
 


### PR DESCRIPTION
A Clean install of Ubuntu 20/Python 3.8 throws pinproc exceptions.