### PR TITLE
Adding note to vpx docs (windows only)

### DIFF
--- a/hardware/virtual/virtual_pinball_vpx.rst
+++ b/hardware/virtual/virtual_pinball_vpx.rst
@@ -8,10 +8,11 @@ The Virtual Pinball (VPX) Platform
 +------------------------------------------------------------------------------+
 
 
-VPX can be used to emulate the hardware of a pinball machine to test your
-game without real hardware.
+`VPX <https://en.wikipedia.org/wiki/Visual_Pinball>`_ can be used (on Windows) to emulate the hardware of a pinball machine to test your
+game without real hardware. For instructions to download and install Visual Pinball please see `here <https://www.vpforums.org/index.php?app=tutorials&article=1>`_.
+
 This can be useful for software and hardware development.
-To use the VPX platform you need to install the
+To use the VPX platform you need to install it, along with the
 `MPF-VPX bridge <https://github.com/missionpinball/mpf-vpcom-bridge>`_ and
 add some VPX scripts to your VPX table.
 


### PR DESCRIPTION
VPX is Visual Pinball X right? 
I was/am mildly unclear so please reject or correct me if I'm way off base, but the difference in word choice ie virtual vs visual made this a bit difficult to track down ...  but just trying to add some annotation that it is windows only software and outgoing link to explain what the third party software is.  

I think ideally going in and changing the platform from `platform: virtual_pinball` to clarify vpx in the code/config might help as well but that is a much larger change. Additionally I see that there are `virtual`, `smart_virtual` and `virtual_pinball` which are all the modes for running without physical devices, and they all have the virtual keyword which makes sense. 
Not trying to overstep, just adding something that would have helped me a day ago.