### PR TITLE
mpf-config consistency change

### DIFF
--- a/tutorial/14_add_a_mode.rst
+++ b/tutorial/14_add_a_mode.rst
@@ -60,7 +60,7 @@ available if no other higher-priority modes are running. To create the
 base game mode:
 
 #. Create a folder called ``modes`` in your machine's folder.
-#. Create a subfolder your ``modes`` folder called ``base``. (You will
+#. Create a subfolder in your ``modes`` folder called ``base``. (You will
    ultimately create one subfolder for each mode you have, and the name of
    the folder controls the name of the mode.)
 #. Inside your ``base`` folder, create a folder called ``config``. (This
@@ -94,10 +94,10 @@ like this:
 
 .. code-block:: mpf-config
 
-   ##! mode: my_mode
    #config_version=5
+   ##! mode: my_mode
    mode:
-     start_events: ball_started
+     start_events: ball_starting
      priority: 100
 
 There are lots more settings besides ``start_events`` and ``priority``
@@ -157,7 +157,7 @@ Note that it's very important that you put dashes in front of each
 mode in this list? Why? Because with dashes, MPF will be able to
 combine settings together in this list from different config files.
 
-For modes that important, because MPF has several built-in modes it
+For modes that is important, because MPF has several built-in modes it
 uses for its own things. (For example, "attract" and "game" are both
 modes, and we'll be creating future ones that you might want to use
 too for tilt, volume control, game statistics, high score entry,


### PR DESCRIPTION
Changed mpf-config to match text
   mpf-config was: start_events: ball_started
   mpf-config is: start_events: ball_starting

Changed mpf-config by moving ##! mode: my_mode to after the #config_version=5 line because with ##! mode before #config caused mpf 0.55.0 to crash

minor grammar edits