### PR TITLE
Fix incorrect syntax for shot control event

### DIFF
--- a/config/shots.rst
+++ b/config/shots.rst
@@ -125,7 +125,7 @@ which is the second state:
      shot_with_control_events:
        control_events:
          - events: set_state_one
-           value: 1
+           state: 1
 
 delay_switch:
 ~~~~~~~~~~~~~


### PR DESCRIPTION
shot_control_events use state instead of value for passing the parameter from shots.

The current syntax will error:

mpf.exceptions.config_file_error.ConfigFileError: Config File Error in ConfigValidator: Your config contains a value for the setting "shot_left_orbit:control_events:value", but this is not a valid setting name.