### PR TITLE
corrected :doc: definition

### DIFF
--- a/cookbook/rollover_lanes_with_lane_change.rst
+++ b/cookbook/rollover_lanes_with_lane_change.rst
@@ -78,7 +78,7 @@ Step 2. Creating a profile for the lanes
 ----------------------------------------
 
 
-We can create a :doc`shot_profile</config/shot_profiles>` for the top lanes that starts with the
+We can create a :doc:`shot_profile</config/shot_profiles>` for the top lanes that starts with the
 light on, and turns it off after the shot is hit.
 
 .. code-block:: mpf-config


### PR DESCRIPTION
Definition was missing a ":" Note: I don't know how to test these links and am assuming it is correct - please check