### PR TITLE
Solved issue : mansion not initializing

### DIFF
--- a/docs/cookbook/TAF_mansion_awards.md
+++ b/docs/cookbook/TAF_mansion_awards.md
@@ -571,7 +571,7 @@ Here's the config for this mode:
 #config_version=5
 mode:
   priority: 102
-  start_events: center_ramp_active, ball_starting
+  start_events: center_ramp_active, mode_mansion_awards_started
   stop_events: balldevice_electric_chair_ball_enter, balldevice_swamp_kickout_ball_enter
 event_player:
   mode_chair_lit_stopping: unlight_chair


### PR DESCRIPTION
chair_lit mode must not start on ball_starting, but on mode_mansion_awards_started. Because chair_lit mode is activated after ball_starting, so it can never see this event and the mansion is never initialized