### PR TITLE
Fix bug when chair is never unlit

### DIFF
--- a/docs/cookbook/TAF_mansion_awards.md
+++ b/docs/cookbook/TAF_mansion_awards.md
@@ -507,6 +507,7 @@ mode:
   start_events: right_inlane_active
   stop_events: unlight_chair balldevice_electric_chair_ball_enter, balldevice_swamp_kickout_ball_enter, cancel_chair_timer
 event_player:
+  mode_chair_lit_3s_stopping: unlight_chair
   mode_chair_lit_3s_started: light_chair
   timer_unlight_chair_complete: unlight_chair
 timers:


### PR DESCRIPTION
Without this line, whair is never unlit from the chair_lit_3s mode, and this creates a number of bugs :)

This one was not easy to find ! :)