### PR TITLE
Fix pip install command for MPF-MC 0.57

### DIFF
--- a/docs/install/0.57.md
+++ b/docs/install/0.57.md
@@ -45,7 +45,7 @@ pip3 install mpf-monitor --pre
 You can install the latest version of MPF-MC from the dev branch as well. (It's also 0.57.0.devXX.)
 
 ``` {.bash .copy}
-pip3 install mpc-mc --pre
+pip3 install mpf-mc --pre
 ```
 
 We had some issues with audio in earlier builds of MPF-MC 0.57, but we think those are resolved? Open an Issue on


### PR DESCRIPTION
The documentation for installing MPF-MC 0.57 said: `pip3 install mpc-mc --pre` whereas `pip3 install mpf-mc --pre` would be the correct command.