### PR TITLE
Add Documentation Export Plugin

### DIFF
--- a/docs/about/authors.md
+++ b/docs/about/authors.md
@@ -30,6 +30,7 @@ This MPF documentation was written by:
 * Dave Ensminger
 * Matt Kemp (<matt@blz.co>)
 * Charles Duncan (nullbuilds)
+* Holden Oullette (houllette)
 
 Want to help with the docs? See our
 [Contributing to MPF's Documentation](help_docs.md) page for

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ edit_uri: blob/main/docs/
 
 plugins:
   - search                # https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/
+  - print-site            # https://timvink.github.io/mkdocs-print-site-plugin/index.html
 
 extra_css:
   - stylesheets/mpf.css     # Sets our custom colors

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs-material
+mkdocs-print-site-plugin


### PR DESCRIPTION
While tinkering around with the documentation site, I wanted to see if I could bundle up all the MPF docs into a digestible format (PDF) for LLMs to better process the information so I could create a MPF GPT to assist in code creation. 

Feel free to close if you don't think it's useful 🙂 