### PR TITLE
Update multiball_locks.md

### DIFF
--- a/docs/config/multiball_locks.md
+++ b/docs/config/multiball_locks.md
@@ -32,9 +32,9 @@ the [queue_relay_player:](queue_relay_player.md) (for
 example, to have a mode selection screen before returning to play).
 
 Whenever a new ball is locked, the event
-*multiball_lock_<name>_locked_ball* is posted with an argument
+*multiball_lock_[name]_locked_ball* is posted with an argument
 "total_balls_locked". When the lock is full, it will post
-*multiball_lock_<name>_full*, which you can use as a start event for
+*multiball_lock_[name]_full*, which you can use as a start event for
 a related [multiballs:](multiballs.md) to start
 multiball. (And since the multiball lock tracks the "virtual" ball
 lock count on a per-player basis, this will still work even if another


### PR DESCRIPTION
making it so that readers can see '<name>' as it's not displaying properly on the page, so I replaced the '<' and '>' with '[' and ']' respectively. 

this probably needs to be done in lots of places throughout the docs I would suspect tho