### PR TITLE
Replace name placeholder carets with parens, escape all non-code

### DIFF
--- a/docs/config/accruals.md
+++ b/docs/config/accruals.md
@@ -225,7 +225,7 @@ Boolean setting (yes/no or true/false) which controls whether this logic
 block remembers where it was from ball-to-ball. If `False`, then this
 logic block will reset itself whenever a new ball starts. If `True`,
 then this logic block will be saved to the player variable
-*<logic_block_name>_state*.
+*\(logic_block_name\)_state*.
 
 Note that logic block state is reset on mode end when this is `False`
 and, as normal modes stop at the end of a ball, the state is always

--- a/docs/config/ball_saves.md
+++ b/docs/config/ball_saves.md
@@ -127,7 +127,7 @@ Single value, type: `time string (ms)`
 ([Instructions for entering time strings](instructions/time_strings.md)). Default: `0`
 
 The time before the ball save ends (in MPF time string format) that will
-cause the *ball_save_<name>_hurry_up* event to be posted. Use this
+cause the *ball_save_\(name\)_hurry_up* event to be posted. Use this
 to change the script for the light or trigger other effect. Default is
 *0*.
 

--- a/docs/config/counters.md
+++ b/docs/config/counters.md
@@ -252,7 +252,7 @@ Boolean setting (yes/no or true/false) which controls whether this logic
 block remembers where it was from ball-to-ball. If `False`, then this
 logic block will reset itself whenever a new ball starts. If `True`,
 then this logic block will be saved to the player variable
-*<logic_block_name>_state*.
+*\(logic_block_name\)_state*.
 
 Note that logic block state is reset on mode end when this is `False`
 and, as normal modes stop at the end of a ball, the state is always

--- a/docs/config/light_stripes.md
+++ b/docs/config/light_stripes.md
@@ -20,7 +20,7 @@ applied to all LEDs. The only difference between
 [light_rings](light_rings.md) is how
 the x/y coordinates are computed.
 
-In order to access single light in your strip you can use the following syntax schema `<light_strip_name>_light_<light_number>`. Where `<light_strip_name>` is the name you have choosen for your light strip and `<light_number>` is the number of the light in the stip, keep in mind the numbering starts with 0 and not 1.
+In order to access single light in your strip you can use the following syntax schema `(light_strip_name)_light_(light_number)`. Where `(light_strip_name)` is the name you have choosen for your light strip and `(light_number)` is the number of the light in the stip, keep in mind the numbering starts with 0 and not 1.
 
 ## Required settings
 

--- a/docs/config/logic_blocks_common.md
+++ b/docs/config/logic_blocks_common.md
@@ -59,7 +59,7 @@ Boolean setting (yes/no or true/false) which controls whether this logic
 block remembers where it was from ball-to-ball. If `False`, then this
 logic block will reset itself whenever a new ball starts. If `True`,
 then this logic block will be saved to the player variable
-*<logic_block_name>_state*.
+*\(logic_block_name\)_state*.
 
 Note that logic block state is reset on mode end when this is `False`
 and, as normal modes stop at the end of a ball, the state is always

--- a/docs/config/multiball_locks.md
+++ b/docs/config/multiball_locks.md
@@ -32,9 +32,9 @@ the [queue_relay_player:](queue_relay_player.md) (for
 example, to have a mode selection screen before returning to play).
 
 Whenever a new ball is locked, the event
-*multiball_lock_<name>_locked_ball* is posted with an argument
+*multiball_lock_\(name\)_locked_ball* is posted with an argument
 "total_balls_locked". When the lock is full, it will post
-*multiball_lock_<name>_full*, which you can use as a start event for
+*multiball_lock_\(name\)_full*, which you can use as a start event for
 a related [multiballs:](multiballs.md) to start
 multiball. (And since the multiball lock tracks the "virtual" ball
 lock count on a per-player basis, this will still work even if another

--- a/docs/config/multiballs.md
+++ b/docs/config/multiballs.md
@@ -122,7 +122,7 @@ Single value, type: `time string (ms) or template`
 [Instructions for entering templates](instructions/dynamic_values.md)). Default: `0`
 
 The time before the add-a-ball ball save ends (in MPF time string
-format) that will cause the [multiball](../index.md)<name>_hurry_up event to be
+format) that will cause the [multiball](../index.md)_\(name\)_hurry_up event to be
 posted. Use this to change the script for the light or trigger other
 effect.
 
@@ -217,7 +217,7 @@ Single value, type: `time string (ms) or template`
 [Instructions for entering templates](instructions/dynamic_values.md)). Default: `0`
 
 The time before the ball save ends (in MPF time string format) that will
-cause the [multiball](../index.md)<name>_hurry_up event to be posted. Use this
+cause the [multiball](../index.md)_\(name\)_hurry_up event to be posted. Use this
 to change the script for the light or trigger other effect.
 
 ### replace_balls_in_play:

--- a/docs/config/sequences.md
+++ b/docs/config/sequences.md
@@ -205,7 +205,7 @@ Boolean setting (yes/no or true/false) which controls whether this logic
 block remembers where it was from ball-to-ball. If `False`, then this
 logic block will reset itself whenever a new ball starts. If `True`,
 then this logic block will be saved to the player variable
-*<logic_block_name>_state*.
+*\(logic_block_name\)_state*.
 
 Note that logic block state is reset on mode end when this is `False`
 and, as normal modes stop at the end of a ball, the state is always

--- a/docs/config/shot_groups.md
+++ b/docs/config/shot_groups.md
@@ -66,18 +66,18 @@ Creating a shot group has several advantages, including:
 * Any time the state of a member shot in a group changes, MPF will
     check to see what all the other shots' states are. If they are all
     the same, it will post a "complete" event (in the form of
-    *<shot_group_name>_<active_profile_name>_<profile_state_name>_complete*)
+    *\(shot_group_name\)_\(active_profile_name\)_\(profile_state_name\)_complete*)
     which you can use to trigger scores based on complete, light shows,
     shot group resets, etc.
 * Any time a member shot is hit, MPF will post an event (in the form
-    of <shot_group_name> _ <profile_name_of_shot_that_was_hit> _ <profile_state_name_of_shot_that_was_hit> _ hit).
+    of \(shot_group_name\) _ \(profile_name_of_shot_that_was_hit\) _ \(profile_state_name_of_shot_that_was_hit\) _ hit).
     You can use this to tie scoring, sounds, or logic blocks to any shot
     being hit in a group, which can be easier than creating entries for
     each individual shot.
 * Any time a member shot is hit, MPF will post an event (in the form
-    of <shot_group_name> _ <profile_name_of_shot_that_was_hit> _ hit)
+    of \(shot_group_name\) _ \(profile_name_of_shot_that_was_hit\) _ hit)
 * Any time a member shot is hit, MPF will post an event (in the form
-    of <shot_group_name> _ hit)
+    of \(shot_group_name\) _ hit)
 
 At first all these events might seem confusing, but really they all
 exist to give you the most flexibility when looking to trigger different

--- a/docs/config/shot_profiles.md
+++ b/docs/config/shot_profiles.md
@@ -29,7 +29,7 @@ shot_profiles:
         show: "on"
 ```
 
-## <name>:
+## \(name\):
 
 This is the name of the shot profile, which is how you'll refer to it
 elsewhere in your config files when you apply it to shots. The sample
@@ -112,7 +112,7 @@ Single value, type: `string`. Default: `None`
 This is a profile setting that lets you specify the name of the player
 variable that will be used to track the status of this shot when this
 profile is applied. If you don't specify the name of a player variable,
-it will automatically use *<shot_name>_<profile_name>* as the
+it will automatically use *\(shot_name\)_\(profile_name\)* as the
 player variable.
 
 ### rotation_pattern:

--- a/docs/config/spinners.md
+++ b/docs/config/spinners.md
@@ -52,23 +52,23 @@ The basic flow:
 2. A spinner switch is hit
         i.  The spinner becomes "active" and sets a timeout for
             `active_ms:` duration
-        ii. The spinner posts *spinner_<name>_active* event
-        iii. The spinner posts *spinner_<name>_hit* event
+        ii. The spinner posts *spinner_\(name\)_active* event
+        iii. The spinner posts *spinner_\(name\)_hit* event
 
 3. Additional switch hits occur
         i.  The spinner resets the timeout for another `active_ms:`
             duration
-        ii. The spinner posts a *spinner_<name>_hit* event for
+        ii. The spinner posts a *spinner_\(name\)_hit* event for
             each hit
 
 4. Switch hits stop and the active delay timer expires
         i.  The spinner switches to "inactive" state
-        ii. The spinner posts *spinner_<name>_inactive* event
+        ii. The spinner posts *spinner_\(name\)_inactive* event
         iii. (Optional) If `idle_ms:` is defined, the spinner sets a
              timeout for idle_ms duration
 
 5. (Optional) No switch hits occur and the idle delay timer expires
-        i.  The spinner posts *spinner_<name>_idle* event
+        i.  The spinner posts *spinner_\(name\)_idle* event
         ii. The spinner switches to "idle" state
 
 ## Optional settings
@@ -123,8 +123,8 @@ A list of labels to apply to the switches in the spinner. If used, the
 number of labels should equal the number of switches.
 
 When a spinner switch is hit and `labels:` are defined, additional
-events will be posted with *spinner_<name>_<label>_active* and
-*spinner_<name>_<label>_hit*. This allows the game to trigger
+events will be posted with *spinner_\(name\)_\(label\)_active* and
+*spinner_\(name\)_\(label\)_hit*. This allows the game to trigger
 different behavior based on which spinner switch is hit first or spins
 more times.
 

--- a/docs/config/switches.md
+++ b/docs/config/switches.md
@@ -287,7 +287,7 @@ Special-purpose tags for switches include:
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the syntax for switches is `device.switches.<name>.state`.
+[conditional events](../../events/overview/conditional.md), the syntax for switches is `device.switches.(name).state`.
 Though uncommon, it is possible to query the current state of a switch in this way.
 
 ## Related How To guides

--- a/docs/config/timed_switches.md
+++ b/docs/config/timed_switches.md
@@ -63,7 +63,7 @@ List of one (or more) events. Those will be posted by the device.
 Defaults to empty.
 
 If you don't enter any events here, an event will automatically be
-posted in the format *<name_of_this_timed_switch>_active*. In other
+posted in the format *\(name_of_this_timed_switch\)_active*. In other
 words, in the example at the top of this page, the timed switch entry is
 called "flipper_cradle", so the automatically-created event would be
 called *flipper_cradle_active*, but since that config has an

--- a/docs/config/timer_control_events.md
+++ b/docs/config/timer_control_events.md
@@ -65,7 +65,7 @@ with control events:
 :   Adds the time (specified in the `value:` setting) to the timer. If
     the value would be higher than the timer's `max_value:` setting,
     then the value is set to the max value. Posts the
-    *timer_<name>_time_added* event.
+    *timer_\(name\)_time_added* event.
 
     This action does not change the timer's running state.
 
@@ -77,7 +77,7 @@ with control events:
 `subtract`
 
 :   Subtracts time (specified in the `value:` setting) from the timer.
-    Posts the *timer_<name>_time_subtracted* event and checks to see
+    Posts the *timer_\(name\)_time_subtracted* event and checks to see
     if the timer is complete.
 
 `jump`
@@ -88,11 +88,11 @@ with control events:
 `start`
 
 :   Starts the timer if it's not running. Does nothing if the timer is
-    already running. Posts the *timer_<name>_started* event.
+    already running. Posts the *timer_\(name\)_started* event.
 
 `stop`
 
-:   Stops the timer and posts the *timer_<name>_stopped* event.
+:   Stops the timer and posts the *timer_\(name\)_stopped* event.
     Removes any outstanding "pause" delays.
 
 `reset`
@@ -110,7 +110,7 @@ with control events:
     the timer pause value is real world seconds and does not take the
     timers tick interval into consideration. If the pause value is 0,
     the timer is paused indefinitely. Posts the
-    *timer_<name>_paused* event.
+    *timer_\(name\)_paused* event.
 
 `set_tick_interval`
 

--- a/docs/config/timers.md
+++ b/docs/config/timers.md
@@ -135,7 +135,7 @@ Single value, type: `integer` or `template`
 Specifies what the final value for this timer will be. When the timer
 value equals or exceeds this (for timers counting up), or when it equals
 or is lower than this (for timers counting down), the
-*timer_<name>_complete* event is posted and the timer is stopped.
+*timer_\(name\)_complete* event is posted and the timer is stopped.
 (If the `restart_on_complete:` setting is true, then the timer is also
 reset back to its `start_value:` and started again.)
 

--- a/docs/config_players/index.md
+++ b/docs/config_players/index.md
@@ -16,9 +16,9 @@ Config players are used in both the machine-wide and mode-specific
 config files, and also in show steps.
 
 * In a config file, the config players are setup via the
-    `<config_player_name>_player:` section of the file.
+    `(config_player_name)_player:` section of the file.
 * In show steps, config players are accessed via the
-    `<config_player_name>s:` setting.
+    `(config_player_name)s:` setting.
 
 Some examples:
 

--- a/docs/cookbook/carousel.md
+++ b/docs/cookbook/carousel.md
@@ -59,13 +59,13 @@ release_events: both_flippers_inactive
 
 There are two events of importance here:
 
-* [carousel](#carousel)<item>_highlighted
-* [carousel](#carousel)<item>_selected
+* [carousel](#carousel)_\(item\)_highlighted
+* [carousel](#carousel)_\(item\)_selected
 
-You can use the [carousel](#carousel)<item>_highlighted event to
+You can use the [carousel](#carousel)_\(item\)_highlighted event to
 display a slide showing the name of the mode to the player.
 
-You can then use the [carousel](#carousel)<item>_selected event to
+You can then use the [carousel](#carousel)_\(item\)_selected event to
 start the mode that was selected by the player.
 
 ``` mpf-mc-config

--- a/docs/cookbook/fake_ball_save.md
+++ b/docs/cookbook/fake_ball_save.md
@@ -52,7 +52,7 @@ you want it to, mode start or when a shot is hit, etc.
 ball_saves:
   fake_MODE_NAME_ball_save:
     enable_events:
-      - multiball_<multiball_name>_ended
+      - multiball_(multiball_name)_ended
     auto_launch: false
     balls_to_save: 1
     debug: true

--- a/docs/flowcharts/mode_start.md
+++ b/docs/flowcharts/mode_start.md
@@ -34,14 +34,14 @@ Here's what happens when a mode starts:
 
 6.  Any device control_events from the mode config are registered
 
-7.  A queue event is posted called *mode_<mode_name>_starting* .
+7.  A queue event is posted called *mode_\(mode_name\)_starting* .
 
 8.  The mode's `_started()` method is the callback for the starting
     queue event and is called when that event is complete.
 
 9.  Mode timers are started.
 
-10. An event *mode_<mode_name>_started* is posted.
+10. An event *mode_\(mode_name\)_started* is posted.
 
 11. The mode's `_mode_started_callback()` method is the callback for
     the started event, so it's called once that event is complete.

--- a/docs/flowcharts/mode_stop.md
+++ b/docs/flowcharts/mode_stop.md
@@ -22,7 +22,7 @@ Here's what happens behind-the-scenes when a mode stops.
 
 5.  Delays set in that mode are cleared.
 
-6.  An queue event is posted: *mode_<mode_name>_stopping*.
+6.  An queue event is posted: *mode_\(mode_name\)_stopping*.
 
 7.  Once that queue is clear, the mode's `_stopped()` method is called.
 
@@ -31,7 +31,7 @@ Here's what happens behind-the-scenes when a mode stops.
     returned from the call to the mode's start_methods when the mode
     starts).
 
-9.  An event *mode_<mode_name>_stopped* is posted.
+9.  An event *mode_\(mode_name\)_stopped* is posted.
 
 10. Once any handlers for that event have finished, the mode's
     `_mode_stopped_callback()` method is called.

--- a/docs/game_logic/achievements/achievement_groups.md
+++ b/docs/game_logic/achievements/achievement_groups.md
@@ -54,7 +54,7 @@ achievements in the group. For example:
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
 [conditional events](../../events/overview/conditional.md), the prefix for achievement groups is
-`device.achievement_groups.<name>`.
+`device.achievement_groups.(name)`.
 
 *enabled*
 

--- a/docs/game_logic/ball_holds.md
+++ b/docs/game_logic/ball_holds.md
@@ -34,7 +34,7 @@ Video about ball locks and multiballs:
 
 For
 [dynamic values](../config/instructions/dynamic_values.md) and
-[conditional events](../events/overview/conditional.md), the prefix for ball holds is `device.ball_holds.<name>`.
+[conditional events](../events/overview/conditional.md), the prefix for ball holds is `device.ball_holds.(name)`.
 
 *balls_held*
 

--- a/docs/game_logic/combo_switches.md
+++ b/docs/game_logic/combo_switches.md
@@ -108,7 +108,7 @@ buttons are pressed which will cancel the show.
 For
 [dynamic values](../config/instructions/dynamic_values.md) and
 [conditional events](../events/overview/conditional.md), the prefix for combo switches is
-`device.combo_switches.<name>`.
+`device.combo_switches.(name)`.
 
 *state*
 

--- a/docs/game_logic/logic_blocks/accruals.md
+++ b/docs/game_logic/logic_blocks/accruals.md
@@ -67,7 +67,7 @@ that it was hit.
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for accruals is `device.accruals.<name>`.
+[conditional events](../../events/overview/conditional.md), the prefix for accruals is `device.accruals.(name)`.
 
 *value*
 

--- a/docs/game_logic/logic_blocks/counters.md
+++ b/docs/game_logic/logic_blocks/counters.md
@@ -68,7 +68,7 @@ counters:
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for ball holds is `device.counters.<name>`.
+[conditional events](../../events/overview/conditional.md), the prefix for ball holds is `device.counters.(name)`.
 
 *value*
 

--- a/docs/game_logic/logic_blocks/sequences.md
+++ b/docs/game_logic/logic_blocks/sequences.md
@@ -61,7 +61,7 @@ or whatever you want.
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for sequences is `device.sequences.<name>`.
+[conditional events](../../events/overview/conditional.md), the prefix for sequences is `device.sequences.(name)`.
 
 *value*
 

--- a/docs/game_logic/logic_blocks/state_machines.md
+++ b/docs/game_logic/logic_blocks/state_machines.md
@@ -142,7 +142,7 @@ variable_player:
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
 [conditional events](../../events/overview/conditional.md), the prefix for state machines is
-`device.state_machines.<name>`.
+`device.state_machines.(name)`.
 
 *state*
 

--- a/docs/game_logic/multiballs/index.md
+++ b/docs/game_logic/multiballs/index.md
@@ -48,7 +48,7 @@ timeout passed (`eject timeouts in ball_devices </config/ball_devices>`) which d
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for multiballs is `device.multiballs.<name>`.
+[conditional events](../../events/overview/conditional.md), the prefix for multiballs is `device.multiballs.(name)`.
 
 *balls_added_live*
 

--- a/docs/game_logic/multiballs/multiball_locks.md
+++ b/docs/game_logic/multiballs/multiball_locks.md
@@ -83,7 +83,7 @@ of your [playfield](../../config/playfields.md).
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
 [conditional events](../../events/overview/conditional.md), the prefix for multiball locks is
-`device.multiball_locks.<name>`.
+`device.multiball_locks.(name)`.
 
 *enabled*
 

--- a/docs/game_logic/shots/index.md
+++ b/docs/game_logic/shots/index.md
@@ -102,7 +102,7 @@ the shot.
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for multiballs is `device.shots.<name>`.
+[conditional events](../../events/overview/conditional.md), the prefix for multiballs is `device.shots.(name)`.
 
 *state*
 

--- a/docs/game_logic/shots/shot_group.md
+++ b/docs/game_logic/shots/shot_group.md
@@ -57,7 +57,7 @@ shot_groups:
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for shot groups is `device.shot_groups.<name>`.
+[conditional events](../../events/overview/conditional.md), the prefix for shot groups is `device.shot_groups.(name)`.
 
 *common_state*
 

--- a/docs/hardware/opp/switches.md
+++ b/docs/hardware/opp/switches.md
@@ -98,9 +98,9 @@ window in the monitor to view the events. Now you can press and release
 the switch and monitor the events being posted. When pressing the switch
 you should be able to see the following events:
 
-* `my_test_switch_active` based on the switch <switch_name>_active
-* `sw_switch_tag1` based on the tags [sw](../../index.md)<tag_name>
-* `sw_switch_tag1_active` based on the tags [sw](../../index.md)<tag_name>_active
+* `my_test_switch_active` based on the switch \(switch_name\)_active
+* `sw_switch_tag1` based on the tags [sw](../../index.md)_\(tag_name\)
+* `sw_switch_tag1_active` based on the tags [sw](../../index.md)_\(tag_name\)_active
 * Same as the last two, just for the second tag `switch_tag2`
 * `active_event1` based on the configuration `events_when_activated`
 * `active_event2` based on the configuration `events_when_activated`
@@ -108,16 +108,16 @@ you should be able to see the following events:
 Once you release the switch again some events are being fired:
 
 * `my_test_switch_inactive` based on the switch
-    <switch_name>_active
+    \(switch_name\)_active
 * `sw_switch_tag1_inactive` based on the tags
-    [sw](../../index.md)<tag_name>_active
+    [sw](../../index.md)_\(tag_name\)_active
 * `sw_switch_tag2_inactive` based on the tags
-    [sw](../../index.md)<tag_name>_active
+    [sw](../../index.md)_\(tag_name\)_active
 * `inactive_event1` based on the configuration `events_when_activated`
 
 Please obey the difference in activating and releasing a switch in terms
 of what events are being fired. When activating a switch the event
-`sw_<tag_name>` is being fired, there is no corresponding event when a
+`sw_(tag_name)` is being fired, there is no corresponding event when a
 switch goes inactive. See as well the [Events](../../events/index.md) reference.
 
 ### What if it did not work?

--- a/docs/mechs/accelerometers.md
+++ b/docs/mechs/accelerometers.md
@@ -30,7 +30,7 @@ Learn more at: <https://en.wikipedia.org/wiki/Accelerometer>
 For
 [dynamic values](../config/instructions/dynamic_values.md) and
 [conditional events](../events/overview/conditional.md), the prefix for accelerometers is
-`device.accelerometers.<name>`.
+`device.accelerometers.(name)`.
 
 *value*
 

--- a/docs/mechs/autofire_coils.md
+++ b/docs/mechs/autofire_coils.md
@@ -205,7 +205,7 @@ You can overwrite both settings using `switch_overwrite` and/or
 
 For
 [dynamic values](../config/instructions/dynamic_values.md) and
-[conditional events](../events/overview/conditional.md), the prefix for autofire coils is `device.autofires.<name>`.
+[conditional events](../events/overview/conditional.md), the prefix for autofire coils is `device.autofires.(name)`.
 
 *enabled*
 

--- a/docs/mechs/ball_devices/index.md
+++ b/docs/mechs/ball_devices/index.md
@@ -214,7 +214,7 @@ Video on ball tracking in MPF:
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
 [conditional events](../../events/overview/conditional.md), the prefix for ball devices is
-`device.ball_devices.<name>`.
+`device.ball_devices.(name)`.
 
 *available_balls*
 

--- a/docs/mechs/diverters/index.md
+++ b/docs/mechs/diverters/index.md
@@ -174,7 +174,7 @@ Hopefully that makes sense? :)
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for diverters is `device.diverters.<name>`.
+[conditional events](../../events/overview/conditional.md), the prefix for diverters is `device.diverters.(name)`.
 
 *active*
 

--- a/docs/mechs/flippers/index.md
+++ b/docs/mechs/flippers/index.md
@@ -95,7 +95,7 @@ player cradles a ball for 3s. Later it will post
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for flippers is `device.flippers.<name>`.
+[conditional events](../../events/overview/conditional.md), the prefix for flippers is `device.flippers.(name)`.
 
 *enabled*
 

--- a/docs/mechs/kickbacks.md
+++ b/docs/mechs/kickbacks.md
@@ -44,7 +44,7 @@ ball_saves:
 
 For
 [dynamic values](../config/instructions/dynamic_values.md) and
-[conditional events](../events/overview/conditional.md), the prefix for kickbacks is `device.kickbacks.<name>`.
+[conditional events](../events/overview/conditional.md), the prefix for kickbacks is `device.kickbacks.(name)`.
 
 *enabled*
 

--- a/docs/mechs/lights/flashers.md
+++ b/docs/mechs/lights/flashers.md
@@ -78,7 +78,7 @@ flasher_player:
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for lights is `device.lights.<name>`.
+[conditional events](../../events/overview/conditional.md), the prefix for lights is `device.lights.(name)`.
 
 *color*
 

--- a/docs/mechs/lights/gis.md
+++ b/docs/mechs/lights/gis.md
@@ -102,7 +102,7 @@ shows.
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for lights is `device.lights.<name>`.
+[conditional events](../../events/overview/conditional.md), the prefix for lights is `device.lights.(name)`.
 
 *color*
 

--- a/docs/mechs/lights/index.md
+++ b/docs/mechs/lights/index.md
@@ -241,7 +241,7 @@ Pay attention to the event `single_led_green` to understand how to address a sin
 
 
 ## Monitorable Properties
-For dynamic values and conditional events, the prefix for lights is `device.lights.<name>`.
+For dynamic values and conditional events, the prefix for lights is `device.lights.(name)`.
 
 * brightness: The numeric value of the brightness of this light, from 0-255.
 * color: The current color.

--- a/docs/mechs/lights/leds.md
+++ b/docs/mechs/lights/leds.md
@@ -283,7 +283,7 @@ can compensate for it by configuring
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for LEDs is `device.lights.<name>`.
+[conditional events](../../events/overview/conditional.md), the prefix for LEDs is `device.lights.(name)`.
 
 * *color*
 * *corrected_color*

--- a/docs/mechs/lights/matrix_lights.md
+++ b/docs/mechs/lights/matrix_lights.md
@@ -46,7 +46,7 @@ lights:
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for LEDs is `device.lights.<name>`.
+[conditional events](../../events/overview/conditional.md), the prefix for LEDs is `device.lights.(name)`.
 
 * *color*
 * *corrected_color*

--- a/docs/mechs/magnets/index.md
+++ b/docs/mechs/magnets/index.md
@@ -93,7 +93,7 @@ magnets:
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for magnets is `device.magnets.<name>`.
+[conditional events](../../events/overview/conditional.md), the prefix for magnets is `device.magnets.(name)`.
 
 *active*
 

--- a/docs/mechs/servos/index.md
+++ b/docs/mechs/servos/index.md
@@ -47,7 +47,7 @@ servos:
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for servos is `device.servos.<name>`.
+[conditional events](../../events/overview/conditional.md), the prefix for servos is `device.servos.(name)`.
 
 *position*
 

--- a/docs/mechs/targets/drop_targets/drop_target_bank.md
+++ b/docs/mechs/targets/drop_targets/drop_target_bank.md
@@ -49,7 +49,7 @@ drop_target_banks:
 For
 [dynamic values](../../../config/instructions/dynamic_values.md) and
 [conditional events](../../../events/overview/conditional.md), the prefix for drop target banks is
-`device.drop_target_banks.<name>`.
+`device.drop_target_banks.(name)`.
 
 *complete*
 

--- a/docs/tutorial/15_scoring.md
+++ b/docs/tutorial/15_scoring.md
@@ -45,8 +45,8 @@ variable_player:
 Then inside the `variable_player:` section, you create sub-entries for
 MPF events that you map back to a list of player variables whose value
 you want to change. By default, whenever a switch is hit in MPF, it
-posts an event *<switch_name>_active* . (A second event called
-*<switch_name>_inactive* is also posted when the switch opens back
+posts an event *\(switch_name\)_active* . (A second event called
+*\(switch_name\)_inactive* is also posted when the switch opens back
 up.) To give the player points when a switch is hit, add sub-entries to
 the `variable_player:` section of your config file, with some switch
 name followed by "_active", like this:

--- a/docs/tutorial/18_shots.md
+++ b/docs/tutorial/18_shots.md
@@ -311,11 +311,11 @@ gets 100 points.
 
 That scoring entry is based on the `my_first_shot_hit`, which is
 generated every time that shot is hit since shots make events in the
-form `<shot_name>_hit`.
+form `\(shot_name\)_hit`.
 
 However, each time a shot is hit, there's two ADDITIONAL events posted
-which are `<shot_name>_<profile>_hit` and
-`<shot_name>_<profile>_<state>_hit`.
+which are `\(shot_name\)_\(profile\)_hit` and
+`\(shot_name\)_\(profile\)_\(state\)_hit`.
 
 For example, when you start a new game with the shot and shot profile
 we've been working with, when you hit the switch for that shot, three

--- a/docs/tutorial/5_add_a_display.md
+++ b/docs/tutorial/5_add_a_display.md
@@ -405,7 +405,7 @@ happens.
 So next, go to the `slide_player:` section of your config and add an
 entry for the event `mode_attract_started`. (This is the event that is
 posted whenever a mode starts, in the form of
-*mode_<mode_name>_started*.)
+*mode_\(mode_name\)_started*.)
 
 By the way, if you're wondering how we know what events to use,
 there's an [event reference](../events/index.md) in the documentation which has a list of all the events in


### PR DESCRIPTION
This PR changes name placeholders in the documentation from angle brackets (e.g. `multiball_<name>_started`) to parenthesis (e.g. `multiball_(name)_started`), and escapes the parenthesis with backslashes in all plaintext instances. This supercedes and extends the work started by @thepinballroom in https://github.com/missionpinball/mpf-docs/pull/512

### Get Rid of Angle Brackets
The new MPF Docs site supports a wider range of HTML Markdown than the previous one, which includes arbitrary semantic tags. As a result, text strings within angle brackets were interpreted as semantic tags and hidden from view. This is very confusing for users, for where the documentation says *multiball_\<name\>_started* the rendered page displays *multiball__started* instead... which is very wrong and bad and will lead users astray.

Throughout the documentation, parenthesis and angle brackets are both used as placeholders (typically, parenthesis for event names and brackets for config options, but not always). For this PR, I've opted to go with parenthesis because they are more likely to be understood by less-experienced users.

### Escape Characters
While parentheticals are not used in semantic tags, they can be used for other markdown syntax that might prevent them from being seen in the rendered page. For safety, this PR also adds backslash escape characters to inline text parentheticals. Note that it does not escape parentheticals that appear in code blocks and code lines, because these markdown elements render all text as-is.

![code!](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYmQyamV5ZDB1bTl4cTNzand2NGQyOHUzdnpjNTZvZTlkM2hwMHZ3ZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/scZPhLqaVOM1qG4lT9/giphy.gif)