### PR TITLE
Update counters.md

### DIFF
--- a/docs/game_logic/logic_blocks/counters.md
+++ b/docs/game_logic/logic_blocks/counters.md
@@ -68,7 +68,7 @@ counters:
 
 For
 [dynamic values](../../config/instructions/dynamic_values.md) and
-[conditional events](../../events/overview/conditional.md), the prefix for ball holds is `device.counters.(name)`.
+[conditional events](../../events/overview/conditional.md), the prefix for counters is `device.counters.(name)`.
 
 *value*
 


### PR DESCRIPTION
fixed a typo where it said 'the prefix for ball holds is' but it should say 'the prefix for counters is'