### PR TITLE
Document mode_list BCP command

### DIFF
--- a/docs/code/BCP_Protocol/index.md
+++ b/docs/code/BCP_Protocol/index.md
@@ -82,6 +82,7 @@ The following BCP commands have been defined (and implemented) in MPF:
 * [machine_variable](machine_variable.md)
 * [mode_start](mode_start.md)
 * [mode_stop](mode_stop.md)
+* [mode_list](mode_list.md)
 * [monitor_start](monitor_start.md)
 * [monitor_stop](monitor_stop.md)
 * [player_added](player_added.md)

--- a/docs/code/BCP_Protocol/mode_list.md
+++ b/docs/code/BCP_Protocol/mode_list.md
@@ -1,0 +1,32 @@
+
+# mode_list (BCP command)
+This message informs the media controller about which modes are currently running. It is sent whenever a mode starts or stops, but only to clients currently [monitoring](monitor_start.md) the `mode` category.
+
+## Origin
+Pin controller
+
+
+## Parameters
+### running_modes
+Type: JSON Array
+
+Example (Formatted for legibility; the parameter does not contain line-breaks):
+```
+{
+    "running_modes": [
+        [
+            "base",
+            100
+        ],
+        [
+            "game",
+            20
+        ]
+    ]
+}
+```
+
+Each element of the array is another JSON Array with the following elements:
+
+1. The name of the mode (`string`)
+2. The priority of the mode (`int`)


### PR DESCRIPTION
This PR adds documentation for the currently undocumented `mode_list` BCP command.