### PR TITLE
Change includes files to use absolute URIs to fix broken relative links

### DIFF
--- a/includes/common_ground_warning.md
+++ b/includes/common_ground_warning.md
@@ -1,15 +1,15 @@
 !!! warning
 
     Please ensure that you have established
-    [common ground between logic and coil power](/hardware/voltages_and_power/voltages_and_power) before turning on high voltage on your coils (especially on
+    [common ground between logic and coil power](https://missionpinball.org/latest/hardware/voltages_and_power/voltages_and_power) before turning on high voltage on your coils (especially on
     homebrew machines). Ignoring this might lock on your coils, overheat
     them, burn down your house or kill you. We are serious, floating grounds
     are dangerous. If you are not an electrical engineer read the
-    [guide about voltages and power](/hardware/voltages_and_power).
+    [guide about voltages and power](https://missionpinball.org/latest/hardware/voltages_and_power).
     
     In a nutshell: You need to connect your logic ground (5V/12V) and your
     high voltage ground (48V or 80V). A
-    [power entry or power filter board](/hardware/voltages_and_power) is a convenient solution to solve this (and more) issues.
+    [power entry or power filter board](https://missionpinball.org/latest/hardware/voltages_and_power) is a convenient solution to solve this (and more) issues.
     
     Always turn all PSUs off when connecting power or you might fry all
     boards at once. This is generally a good idea but even more important

--- a/includes/config_section.md
+++ b/includes/config_section.md
@@ -1,5 +1,5 @@
 ??? note "This is a config file reference. Click for instructions."
 
     This page is reference material which explains every setting and option for this section of an MPF yaml config file.
-    See the [instructions for config files](/config/instructions) for formatting and other details. See our guide
-    to [config file examples](/examples) for more examples of real configs in action.
+    See the [instructions for config files](instructions/index.md) for formatting and other details. See our guide
+    to [config file examples](../examples/index.md) for more examples of real configs in action.

--- a/includes/content_footer.md
+++ b/includes/content_footer.md
@@ -7,7 +7,7 @@
 
     Please help us! You can fix it yourself and be an official "open source" contributor!
 
-    It's easy! See our _[Beginner's guide to editing the docs](/latest/about/help)_.
+    It's easy! See our _[Beginner's guide to editing the docs](https://missionpinball.org/latest/about/help)_.
 
 ??? tip "Page navigation via the keyboard: ++less++ ++greater++"
 

--- a/includes/event.md
+++ b/includes/event.md
@@ -1,3 +1,3 @@
 !!! note "This is an MPF Event"
 
-    The content on this page is technical documentation for an [MPF Event](/events/overview).
+    The content on this page is technical documentation for an [MPF Event](overview/index.md).

--- a/includes/light_channels_numbers.md
+++ b/includes/light_channels_numbers.md
@@ -1,16 +1,16 @@
-In MPF [lights](/config/lights) abstract
+In MPF [lights](https://missionpinball.org/latest/config/lights) abstract
 a light source which emits arbitrary colors. However, this is not true
 for all real lights. Some support only white (GIs), others only a
 single-color (i.e. red inserts) and others support full RGB. For that
-reason MPF knows
-[light numbers and channel numbers](/config/lights). Internally, a light consists of one or multiple channels.
+reason MPF knows [light numbers and channel numbers](https://missionpinball.org/latest/config/lights).
+Internally, a light consists of one or multiple channels.
 For instance, a single-color GI will contain a single white channel.
 While a RGB light will control a red, green and a blue channel. A white
 light behind a red insert should be a single red channel (because it
 cannot emit other colors through the red insert). You can configure
 those channels using the `channels` setting or use `start_channel` and
 `type` to define the channels. See
-[/mechs/lights/index](/mechs/lights) for details.
+[Lights](https://missionpinball.org/latest/mechs/lights) for details.
 
 However, in most cases a platform supports one type of lights (per
 `subtype`) this would be overly verbose and we added the `number`

--- a/includes/troubleshooting_coils.md
+++ b/includes/troubleshooting_coils.md
@@ -1,9 +1,4 @@
----
-title: Coils Are Not Firing
----
-
 # Coils Are Not Firing
-
 
 What to do if your coils are not working?
 

--- a/includes/troubleshooting_lights.md
+++ b/includes/troubleshooting_lights.md
@@ -1,6 +1,5 @@
 # Reducing light update rate
 
-
 If you got a lot of lights you might run into bus contention issues. You
 can reduce the light update rate in MPF:
 


### PR DESCRIPTION
When an include file generates a link, it is referenced relative to the generating file's path. This means that reusing the include in different nesting levels and context across the docs will result in inconsistent links that will always be broken (many are missing the latest/ version namespace, for instance.)

The easiest/laziest solution is to always generate pointing to the live website, latest version, with an absolute URI. If each version from Mike can instead have a template-available variable that is the hostname and version number (or latest), then we could improve this by generating self-contained links instead of always-prod ones.