### PR TITLE
Improve Error reference titles, headers, and nav, and improve Game index

### DIFF
--- a/docs/config/instructions/debug.md
+++ b/docs/config/instructions/debug.md
@@ -1,5 +1,5 @@
 ---
-title: Understanding the debug: setting
+title: "Understanding the debug: setting"
 ---
 
 # Understanding the debug: setting

--- a/docs/cookbook/AFM_super_jets.md
+++ b/docs/cookbook/AFM_super_jets.md
@@ -1,5 +1,5 @@
 ---
-title: Recipe: Attack From Mars Super Jets
+title: "Recipe: Attack From Mars Super Jets"
 ---
 
 # Recipe: Attack From Mars Super Jets

--- a/docs/cookbook/B66_gadget.md
+++ b/docs/cookbook/B66_gadget.md
@@ -1,5 +1,5 @@
 ---
-title: Recipe: GADGET Targets from Stern Batman '66
+title: "Recipe: GADGET Targets from Stern Batman '66"
 ---
 
 # Recipe: GADGET Targets from Stern Batman '66

--- a/docs/cookbook/TAF_mansion_awards.md
+++ b/docs/cookbook/TAF_mansion_awards.md
@@ -1,5 +1,5 @@
 ---
-title: Recipe: The Addams Family Mansion Awards
+title: "Recipe: The Addams Family Mansion Awards"
 ---
 
 # Recipe: The Addams Family Mansion Awards

--- a/docs/cookbook/dual_launch.md
+++ b/docs/cookbook/dual_launch.md
@@ -1,5 +1,5 @@
 ---
-title: Recipe: Modifying the game mode - Dual launch devices
+title: "Recipe: Modifying the game mode - Dual launch devices"
 ---
 
 # Recipe: Modifying the game mode - Dual launch devices

--- a/docs/cookbook/rollover_lanes_with_lane_change.md
+++ b/docs/cookbook/rollover_lanes_with_lane_change.md
@@ -1,5 +1,5 @@
 ---
-title: Recipe: Rollover Lanes (with Lane Change)
+title: "Recipe: Rollover Lanes (with Lane Change)"
 ---
 
 # Recipe: Rollover Lanes (with Lane Change)

--- a/docs/cookbook/sequential_drop_banks.md
+++ b/docs/cookbook/sequential_drop_banks.md
@@ -1,5 +1,5 @@
 ---
-title: Recipe: Sequential Drop Target Banks
+title: "Recipe: Sequential Drop Target Banks"
 ---
 
 # Recipe: Sequential Drop Target Banks

--- a/docs/cookbook/skillshot_with_auto_rotate.md
+++ b/docs/cookbook/skillshot_with_auto_rotate.md
@@ -1,5 +1,5 @@
 ---
-title: Recipe: Skillshot (with Auto-Rotate)
+title: "Recipe: Skillshot (with Auto-Rotate)"
 ---
 
 # Recipe: Skillshot (with Auto-Rotate)

--- a/docs/cookbook/skillshot_with_lane_change.md
+++ b/docs/cookbook/skillshot_with_lane_change.md
@@ -1,5 +1,5 @@
 ---
-title: Recipe: Skillshot (with Lane Change)
+title: "Recipe: Skillshot (with Lane Change)"
 ---
 
 # Recipe: Skillshot (with Lane Change)

--- a/docs/game/index.md
+++ b/docs/game/index.md
@@ -4,11 +4,12 @@ title: Writing your Game Software
 
 # Programming your Game
 
-* Tutorial
-* Pinball Mechs
-* Game Logic
-* Modes
-* Machine Management
-* Testing your game
-* Finalization
-* Cookbook
+* [Tutorial](../tutorial/index.md)
+* [Pinball Mechs](../mechs/index.md)
+* [Game Logic](../game_logic/index.md)
+* [Modes](../game_design/index.md)
+* [Machine Management](../machine_management/index.md)
+* [Testing your game](../testing/index.md)
+* [Finalization](../finalization/index.md)
+* [Cookbook](../cookbook/index.md)
+* [Flowcharts](../flowcharts/index.md)

--- a/docs/logs/CFE-ConfigValidator-1.md
+++ b/docs/logs/CFE-ConfigValidator-1.md
@@ -1,9 +1,8 @@
 ---
-title: CFE-ConfigValidator-1: Section not valid outside of game modes
+title: "CFE-ConfigValidator-1: Section not valid outside of game modes"
 ---
 
 # CFE-ConfigValidator-1: Section not valid outside of game modes
-
 
 This error occurs when MPF needs to reference player variables in a
 device but you defined the device in a non-game

--- a/docs/logs/CFE-ConfigValidator-12.md
+++ b/docs/logs/CFE-ConfigValidator-12.md
@@ -1,9 +1,8 @@
 ---
-title: CFE-ConfigValidator-12: Item is not a dict
+title: "CFE-ConfigValidator-12: Item is not a dict"
 ---
 
 # CFE-ConfigValidator-12: Item is not a dict
-
 
 This error occurs when MPF expects a dictionary in a config setting but
 found something else.

--- a/docs/logs/CFE-ConfigValidator-13.md
+++ b/docs/logs/CFE-ConfigValidator-13.md
@@ -1,9 +1,8 @@
 ---
-title: CFE-ConfigValidator-13: Cannot convert value to boolean
+title: "CFE-ConfigValidator-13: Cannot convert value to boolean"
 ---
 
 # CFE-ConfigValidator-13: Cannot convert value to boolean
-
 
 This error occurs when MPF expects a boolean value (i.e. `true` or
 `false`) for a config setting but got a value of a different type.

--- a/docs/logs/CFE-ConfigValidator-2.md
+++ b/docs/logs/CFE-ConfigValidator-2.md
@@ -1,7 +1,8 @@
 ---
-title: CFE-ConfigValidator-2: Your config contains a value for the
-  setting, but this is not a valid setting name
+title: "CFE-ConfigValidator-2: Your config contains a value for the setting, but this is not a valid setting name"
 ---
+
+# CFE-ConfigValidator-2: Your config contains a value for the setting, but this is not a valid setting name
 
 This error occurs when MPF does not know a setting you specified in a
 device.

--- a/docs/logs/CFE-ConfigValidator-4.md
+++ b/docs/logs/CFE-ConfigValidator-4.md
@@ -1,9 +1,8 @@
 ---
-title: CFE-ConfigValidator-4: Invalid Validator in config spec
+title: "CFE-ConfigValidator-4: Invalid Validator in config spec"
 ---
 
 # CFE-ConfigValidator-4: Invalid Validator in config spec
-
 
 This error occurs when MPF does not understand the config specification
 for a device. Unless you created custom config specs in a mode,

--- a/docs/logs/CFE-ConfigValidator-6.md
+++ b/docs/logs/CFE-ConfigValidator-6.md
@@ -1,7 +1,8 @@
 ---
-title: CFE-ConfigValidator-6: Device not found in section in your
-  config
+title: "CFE-ConfigValidator-6: Device not found in section in your config"
 ---
+
+# CFE-ConfigValidator-6: Device not found in section in your config
 
 This error occurs when MPF does not find a device which is referenced by
 one of your settings in your config.

--- a/docs/logs/CFE-ConfigValidator-9.md
+++ b/docs/logs/CFE-ConfigValidator-9.md
@@ -1,7 +1,8 @@
 ---
-title: CFE-ConfigValidator-9: Required setting is missing from section
-  in your config
+title: "CFE-ConfigValidator-9: Required setting is missing from section in your config"
 ---
+
+# CFE-ConfigValidator-9: Required setting is missing from section in your config
 
 This error occurs when MPF does not find a required setting in one of
 your config sections.

--- a/docs/logs/CFE-DeviceManager-3.md
+++ b/docs/logs/CFE-DeviceManager-3.md
@@ -1,7 +1,8 @@
 ---
-title: CFE-DeviceManager-3: Device does not have a valid config.
-  Expected a dictionary.
+title: "CFE-DeviceManager-3: Device does not have a valid config. Expected a dictionary."
 ---
+
+# CFE-DeviceManager-3: Device does not have a valid config. Expected a dictionary.
 
 This error occurs when MPF expects a dictionary in a config of a device
 but found something else.

--- a/docs/logs/CFE-Smart_Virtual_Platform-1.md
+++ b/docs/logs/CFE-Smart_Virtual_Platform-1.md
@@ -1,8 +1,8 @@
 ---
-title: CFE-Smart_Virtual_Platform-1: Switch used in
-  virtual_platform_start_active_switches was not found in switches
-  section
+title: "CFE-Smart_Virtual_Platform-1: Switch used in virtual_platform_start_active_switches was not found in switches section"
 ---
+
+# CFE-Smart_Virtual_Platform-1: Switch used in virtual_platform_start_active_switches was not found in switches section
 
 Related Config File Sections:
 

--- a/docs/logs/CFE-Virtual_Platform-1.md
+++ b/docs/logs/CFE-Virtual_Platform-1.md
@@ -1,8 +1,8 @@
 ---
-title: CFE-Virtual_Platform-1: Switch used in
-  virtual_platform_start_active_switches was not found in switches
-  section
+title: "CFE-Virtual_Platform-1: Switch used in virtual_platform_start_active_switches was not found in switches section"
 ---
+
+# CFE-Virtual_Platform-1: Switch used in virtual_platform_start_active_switches was not found in switches section
 
 See [/troubleshooting/index](CFE-Smart_Virtual_Platform-1.md) which
 is exactly the same error.

--- a/docs/logs/CFE-coils-1.md
+++ b/docs/logs/CFE-coils-1.md
@@ -1,9 +1,8 @@
 ---
-title: CFE-coils-1: Driver must have a number
+title: "CFE-coils-1: Driver must have a number"
 ---
 
 # CFE-coils-1: Driver must have a number
-
 
 Related Config File Sections:
 

--- a/docs/logs/CFE-show-1.md
+++ b/docs/logs/CFE-show-1.md
@@ -1,9 +1,8 @@
 ---
-title: CFE-show-1: Show does not appear to be a valid show config
+title: "CFE-show-1: Show does not appear to be a valid show config"
 ---
 
 # CFE-show-1: Show does not appear to be a valid show config
-
 
 Related Config File Sections:
 

--- a/docs/logs/Log-SwitchController-1.md
+++ b/docs/logs/Log-SwitchController-1.md
@@ -1,7 +1,8 @@
 ---
-title: Log-SwitchController-1: Received duplicate switch state for
-  switch
+title: "Log-SwitchController-1: Received duplicate switch state for switch"
 ---
+
+# Log-SwitchController-1: Received duplicate switch state for switch
 
 Related Config File Sections:
 

--- a/docs/logs/RE-MPF-MC_BCP_Server-1.md
+++ b/docs/logs/RE-MPF-MC_BCP_Server-1.md
@@ -1,7 +1,8 @@
 ---
-title: RE-MPF-MC_BCP_Server-1: Failed to bind BCP Socket to localhost
-  on port 5050
+title: "RE-MPF-MC_BCP_Server-1: Failed to bind BCP Socket to localhost on port 5050"
 ---
+
+# RE-MPF-MC_BCP_Server-1: Failed to bind BCP Socket to localhost on port 5050
 
 See [/troubleshooting/index](RE-MPF_BCP_Server-1.md) which is exactly
 the same error.

--- a/docs/logs/RE-MPF_BCP_Server-1.md
+++ b/docs/logs/RE-MPF_BCP_Server-1.md
@@ -1,7 +1,8 @@
 ---
-title: RE-MPF_BCP_Server-1: Failed to bind BCP Socket to 127.0.0.1 on
-  port 5051
+title: "RE-MPF_BCP_Server-1: Failed to bind BCP Socket to 127.0.0.1 on port 5051"
 ---
+
+# RE-MPF_BCP_Server-1: Failed to bind BCP Socket to 127.0.0.1 on port 5051
 
 Related Config File Sections:
 

--- a/docs/logs/RE-P-Roc-1.md
+++ b/docs/logs/RE-P-Roc-1.md
@@ -1,9 +1,8 @@
 ---
-title: RE-P-Roc-1 - Known Firmware Bug in P/P3-Roc
+title: "RE-P-Roc-1 - Known Firmware Bug in P/P3-Roc"
 ---
 
 # RE-P-Roc-1 - Known Firmware Bug in P/P3-Roc
-
 
 Related Config File Sections:
 

--- a/docs/logs/RE-P-Roc-2.md
+++ b/docs/logs/RE-P-Roc-2.md
@@ -1,9 +1,8 @@
 ---
-title: RE-P-Roc-2 - Communication with P/P3-Roc broke down
+title: "RE-P-Roc-2 - Communication with P/P3-Roc broke down"
 ---
 
 # RE-P-Roc-2 - Communication with P/P3-Roc broke down
-
 
 Related Config File Sections:
 

--- a/docs/logs/RE-P-Roc-3.md
+++ b/docs/logs/RE-P-Roc-3.md
@@ -1,9 +1,8 @@
 ---
-title: RE-P-Roc-3 - Failed to Import Pinproc
+title: "RE-P-Roc-3 - Failed to Import Pinproc"
 ---
 
 # RE-P-Roc-3 - Failed to Import Pinproc
-
 
 Related Config File Sections:
 

--- a/docs/logs/index.md
+++ b/docs/logs/index.md
@@ -4,8 +4,9 @@ title: Log and Error Descriptions
 
 # Log and Error Descriptions
 
-MPF tries to give IDs to errors that happen a lot so you can look them up here. Here are the ones
-that have been created so far:
+MPF tries to give IDs to errors that happen a lot so you can look them up here, especially if they are common problems with known fixes. There are almost 200 different errors with unique codes, and most are not documented here (yet!). The errors with documentation available are:
+
+### Config File Errors:
 
 * [CFE-coils-1](CFE-coils-1.md)
 * [CFE-ConfigValidator-1](CFE-ConfigValidator-1.md)
@@ -19,9 +20,16 @@ that have been created so far:
 * [CFE-show-1](CFE-show-1.md)
 * [CFE-Smart_Virtual_Platform-1](CFE-Smart_Virtual_Platform-1.md)
 * [CFE-Virtual_Platform-1](CFE-Virtual_Platform-1.md)
-* [Log-SwitchController-1](Log-SwitchController-1.md)
+
+### Runtime Errors:
+
 * [RE-MPF-MC_BCP_Server-1](RE-MPF-MC_BCP_Server-1.md)
 * [RE-MPF_BCP_Server-1](RE-MPF_BCP_Server-1.md)
 * [RE-P-Roc-1](RE-P-Roc-1.md)
 * [RE-P-Roc-2](RE-P-Roc-2.md)
 * [RE-P-Roc-3](RE-P-Roc-3.md)
+
+### Warning Logs:
+
+* [Log-SwitchController-1](Log-SwitchController-1.md)
+


### PR DESCRIPTION
Touchups! I've also logged the 180ish errors currently in MPF so that I can build out a more complete error reference. There are maybe a dozen CFE errors with duplicated codes, so I'll also be making a PR with deduping soon. I'd really like to introduce an errors module with everything listed as enums in there, especially as 3/4 of the errors are generated via raise_config_error, and 1/4 are via constructing the class directly (so it's hard to be certain that you've checked all existing codes).