### PR TITLE
Update overrides meta tags (favicon etc) for production link structure

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -4,15 +4,15 @@ icons & this code generated via https://realfavicongenerator.net
 -->
 {% extends "base.html" %}
 {% block extrahead %}
-<link rel="apple-touch-icon" sizes="180x180" href="/images/icons/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/images/icons/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/images/icons/favicon-16x16.png">
-<link rel="manifest" href="/images/icons/site.webmanifest">
-<link rel="mask-icon" href="/images/icons/safari-pinned-tab.svg" color="#d63e29">
-<link rel="shortcut icon" href="/images/icons/favicon.ico">
+<link rel="apple-touch-icon" sizes="180x180" href="/latest/images/icons/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/latest/images/icons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/latest/images/icons/favicon-16x16.png">
+<link rel="manifest" href="/latest/images/icons/site.webmanifest">
+<link rel="mask-icon" href="/latest/images/icons/safari-pinned-tab.svg" color="#d63e29">
+<link rel="shortcut icon" href="/latest/images/icons/favicon.ico">
 <meta name="apple-mobile-web-app-title" content="MPF">
 <meta name="application-name" content="MPF">
 <meta name="msapplication-TileColor" content="#ffc40d">
-<meta name="msapplication-config" content="/images/icons/browserconfig.xml">
+<meta name="msapplication-config" content="/latest/images/icons/browserconfig.xml">
 <meta name="theme-color" content="#ffffff">
 {% endblock %}


### PR DESCRIPTION
Favicon and other meta embed assets arent loading properly due to the mike version URL namespacing. This fix will break the assets when running with mkdocs serve, but work with mike locally and on prod.

The fixes are in an HTML override file. This file doesn't seem to go through markdown processing in the same way as the other templates, but I haven't yet played with it to try some things. I've started investigating mkdocs env var solutions to see if we could make the hostname configurable, see: https://www.mkdocs.org/user-guide/configuration/#environment-variables and also https://www.mkdocs.org/user-guide/customizing-your-theme/ re: main.html overrides.