### PR TITLE
Resolve outstanding not-in-nav pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,10 +81,18 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/missionpinball
 
+# index is not included because it has no other section members
+# code samples are not included because they are all embedded in other pages
+# showcase cannot be included trivially because the files are generated in a separate step
+# icons readme is a note for embedding the meta tags in overrides/main.md
+# welcome wall is for editors to try things out!
 not_in_nav: |
+  index.md
   code/BCP_Protocol/
   code/api_reference/
   showcase/
+  images/icons/README.md
+  welcome_wall.md
 
 nav:
 - Getting Started:


### PR DESCRIPTION
I put all the remaining files that mkdocs thinks are pages to serve in the not-in-nav config section. Icons/readme could probably be deleted entirely and welcome_wall could be included somewhere in the future. The code samples aren't really pages, and including the root page (index.md) adds it as a top bar item on all pages in an undesired way.

I may look into generating a nav for the showcase pages as well, but it's p low priority. It's tempting to do something like alpha-sort on project names, since there are so many now and it's kind of hard to scan the list in the current order. (Also, the order generates differently on different OSes -- on windows it is alpha sorted)