### PR TITLE
Fix blank anchor links

### DIFF
--- a/docs/config/bcp.md
+++ b/docs/config/bcp.md
@@ -47,7 +47,7 @@ List of one (or more) values, each is a type:
 [bcp_connection:](bcp_connection.md).
 Defaults to empty.
 
-The [connections:](#) section is where you can specify the
+The `connections:` section is where you can specify the
 connections the MPF core engine will make to standalone media
 controllers. MPF supports connecting to multiple media controllers
 simultaneously which is why you can add multiple entries here.
@@ -64,7 +64,7 @@ List of one (or more) values, each is a type:
 [bcp_server:](bcp_server.md). Defaults to
 empty.
 
-The [servers:](#) section is where you can specify bcp server
+The `servers:` section is where you can specify bcp server
 instances which can be connected from other processes. For instance,
 this is used for the
 [service cli](../running/commands/service.md).

--- a/docs/config/color_correction_profile.md
+++ b/docs/config/color_correction_profile.md
@@ -64,7 +64,7 @@ converted to floating point). Default: `1.0, 1.0, 1.0`
 Specifies the white point (or white balance) of your lights. Enter it as
 a list of three floating point values that correspond to the red, blue,
 and green light segments. These values are treated as multipliers to all
-incoming color commands. The default of [1.0, 1.0, 1.0](#)
+incoming color commands. The default of `1.0, 1.0, 1.0`
 means that no white point adjustment is used. [1.0, 1.0,
 0.8](#) would set the blue segment to be at 80% brightness
 while red and green are 100%, etc.

--- a/docs/config/fadecandy.md
+++ b/docs/config/fadecandy.md
@@ -127,7 +127,7 @@ converted to floating point). Default: `1.0, 1.0, 1.0`
 Specifies the white point (or white balance) of your lights. Enter it as
 a list of three floating point values that correspond to the red, blue,
 and green light segments. These values are treated as multipliers to all
-incoming color commands. The default of [1.0, 1.0, 1.0](#)
+incoming color commands. The default of `1.0, 1.0, 1.0`
 means that no white point adjustment is used. [1.0, 1.0,
 0.8](#) would set the blue segment to be at 80% brightness
 while red and green are 100%, etc.

--- a/docs/config/images.md
+++ b/docs/config/images.md
@@ -100,9 +100,9 @@ Specifies when this asset should be loaded. (See the
 [Assets](../assets/index.md) documentation for an
 explanation on loading.)
 
-* [preload](#) (The asset is loaded when MPF boots and stays
+* `preload` (The asset is loaded when MPF boots and stays
     in memory as long as MPF is running.)
-* [mode_start](#) (The asset is loaded when the mode starts
+* `mode_start` (The asset is loaded when the mode starts
     and is unloaded when the mode ends. This option is only valid for
     asset files that are in mode folders, not machine-wide assets.)
 * Anything else (or nothing at all) means that the asset it loaded

--- a/docs/config/led_player.md
+++ b/docs/config/led_player.md
@@ -5,5 +5,5 @@ title: "led_player:"
 # led_player:
 
 
-[led_player](#) and [matrix_light_player](#) were
+`led_player` and `matrix_light_player` were
 replaced with [light_player](light_player.md) in MPF 0.50. See [lights:](lights.md) for details.

--- a/docs/config/lights.md
+++ b/docs/config/lights.md
@@ -156,9 +156,9 @@ For multi-color LEDs, the color defined here will be used when the light
 is enabled via "on" (as opposed to being enabled with a specific
 color). Not intended for single-color lights.
 
-Color values may be a hex string (e.g. [22FFCC](#)), a list of
-RGB values (e.g. [\[50, 128, 206\]](#)), or a color name (e.g.
-[turquoise](#)). MPF knows 140+ standard web color names, and
+Color values may be a hex string (e.g. `22FFCC`), a list of
+RGB values (e.g. `\[50, 128, 206\]`), or a color name (e.g.
+`turquoise`). MPF knows 140+ standard web color names, and
 you can define your own custom colors in the
 [named_colors:](named_colors.md) section of your
 config.
@@ -295,7 +295,7 @@ This describes the channel order of an LED. Can be 1 to many channels
 (always off).
 
 When using serial LEDs (e.g. with FAST or Fadecandy), use
-[rgb](#) for WS2812 and [grb](#) for WS2811 LEDs.
+`rgb` for WS2812 and `grb` for WS2811 LEDs.
 
 ### x:
 
@@ -353,7 +353,7 @@ List of one (or more) values, each is a type: `string`. Defaults to
 empty.
 
 Lights can be referenced by their tags in light_players. Typical tags
-are [gi](#) for all GIs or [playfield_inserts](#) for
+are `gi` for all GIs or `playfield_inserts` for
 all inserts on the playfield.
 
 ## Related How To guides

--- a/docs/config/mode.md
+++ b/docs/config/mode.md
@@ -147,7 +147,7 @@ that's ok. (i.e. It won't start over or break.)
 
 For modes that you want to start when the player's ball starts (like
 for your base mode, ball save, or skillshot, you'd enter
-[ball_starting](#) here. For modes that should start when some
+`ball_starting` here. For modes that should start when some
 progress has been made in the game, enter the name of the event that
 represents when you want to start the mode. This could be the event from
 a shot being made, the resultant event from a logic block being

--- a/docs/config/mode.md
+++ b/docs/config/mode.md
@@ -251,7 +251,7 @@ mode, and if other modes don't have a stop_priority set then they'll
 stop after it. (A higher number means that mode stops first.)
 
 If you have a mode you want to stop last, then don't enter a
-*stop_priority* for it but enter [stop_priority: 1](#) for all
+*stop_priority* for it but enter `stop_priority: 1` for all
 the other modes you want to stop first. You can add different
 *stop_priority* values for different modes, and they will all stop in
 order, highest numeric value to lowest. Note that the *stop_priority*

--- a/docs/config/playfields.md
+++ b/docs/config/playfields.md
@@ -16,7 +16,7 @@ The `playfields:` section of your config is where you configure your
 [playfields](../mechs/playfields/index.md) in
 your machine. You can have multiple playfields and MPF will track balls
 per playfield. One playfield should contain the tag
-[default](#) so that the game knows which playfield to use.
+`default` so that the game knows which playfield to use.
 
 ## Required settings
 

--- a/docs/config/playfields.md
+++ b/docs/config/playfields.md
@@ -107,7 +107,7 @@ gives up.
 Single value, type: `time string (ms)`
 ([Instructions for entering time strings](instructions/time_strings.md)). Default: `15s`
 
-[ball_search_timeout](#) configures the time of inactivity
+`ball_search_timeout` configures the time of inactivity
 which has to pass until ball search starts.
 
 ### ball_search_unblock_events:

--- a/docs/config/sequence_shots.md
+++ b/docs/config/sequence_shots.md
@@ -169,7 +169,7 @@ Timeout starting when the sequence starts (e.g. after the first switch
 was hit). This is the time limit the switches in the `switch_sequence:`
 section have to be activated in, from start to finish, in order for the
 sequence to be hit/completed. You can enter values with "s" or "ms"
-after the number, like [200ms](#) or [3s](#). If you
+after the number, like `200ms` or `3s`. If you
 just enter a number then the system assumes you mean seconds. If you do
 not enter a time, or you enter a value of 0, then there is no timeout
 (i.e. the player could literally take multiple minutes between switch

--- a/docs/config/shot_groups.md
+++ b/docs/config/shot_groups.md
@@ -137,7 +137,7 @@ the shot group rotates.
 
 The presence or absence of this value will not affect whether individual
 shots in the group can be enabled via their own
-[enable_events](#) settings. An individual shot can always be
+`enable_events` settings. An individual shot can always be
 enabled/disabled regardless of the group state, although a subsequent
 group enable/disable events will also affect that individual shot.
 
@@ -198,7 +198,7 @@ List of one (or more) device control events
 This list of events that, when posted, will rotate the current lit and
 unlit shot states to the right. This can be a simple list of events or a
 time-delayed list. The state of right-most (i.e. last entry) in your
-[shots:](#) list will rotate over to the left-most shot.
+`shots:` list will rotate over to the left-most shot.
 
 ### shots:
 

--- a/docs/config/smartmatrix.md
+++ b/docs/config/smartmatrix.md
@@ -50,7 +50,7 @@ Baud rate of your serial port. Depends on the smartmatrix firmware.
 Single value, type: `string`. Defaults to empty.
 
 Name of the serial port of your smartmatrix device. This will be
-[comX](#) on Windows. On Linux and Mac it depends on the
+`comX` on Windows. On Linux and Mac it depends on the
 usb-serial chip (usually /dev/ttyUSBX on linux or /dev/tty.usbmodemYYY
 on Mac).
 

--- a/docs/config/sound_pools.md
+++ b/docs/config/sound_pools.md
@@ -57,8 +57,8 @@ sound_pools:
 To create a sound pool, add a sub entry to the `sound_pools:` section of
 your config which will be the name of that sound pool. The name must be
 unique among all sound pools *and* sound assets. In the above example
-[drain_callout:](#), [slingshot:](#) and
-[target_completion:](#) are each a sound pool name. Then create
+`drain_callout:`, `slingshot:` and
+`target_completion:` are each a sound pool name. Then create
 one or more of the following settings for each sound pool:
 
 ## Required settings
@@ -77,11 +77,11 @@ number controls the relative weighting for random item selection, or the
 number of times to play the sound before moving to the next sound in the
 pool with a sequence pool. If no weight value is provided, a default
 value of `1` will be applied. In the example above, the
-[slingshot:](#) random sound pool contains relative weighting
+`slingshot:` random sound pool contains relative weighting
 values. The weights sum to 10 for the three sounds so the
-[slingshot_01](#) sound has a probability of being randomly
-selected of 5 out of 10 (50%), [slingshot_02](#) 3/10 (30%),
-and [slingshot_03](#) 2/10 (20%).
+`slingshot_01` sound has a probability of being randomly
+selected of 5 out of 10 (50%), `slingshot_02` 3/10 (30%),
+and `slingshot_03` 2/10 (20%).
 
 !!! note
 

--- a/docs/config/sound_system.md
+++ b/docs/config/sound_system.md
@@ -67,9 +67,9 @@ machine. The example above shows three tracks, called *music*, *voice*,
 and *sfx*. The idea (in case it isn't obvious) is that you play all
 your music clips on the music track, voice callouts on the voice track,
 and the sound effects on the sfx track. To create a track, add a sub
-entry to the [tracks:](#) section which will be the name of
-that track. (So again, [music:](#), [voice:](#) and
-[sfx:](#) in the example.)
+entry to the `tracks:` section which will be the name of
+that track. (So again, `music:`, `voice:` and
+`sfx:` in the example.)
 
 ## Optional settings
 

--- a/docs/config/sounds.md
+++ b/docs/config/sounds.md
@@ -167,10 +167,10 @@ Single value, type: `string`. Defaults to empty.
 Sometimes you might want to name a file one thing on disk but refer to
 it as another thing in your game and config files. In this case, you can
 create an `file:` setting in an asset entry. (Note the file:
-[extra_ball_12753.wav](#) setting in the example above, and
+`extra_ball_12753.wav` setting in the example above, and
 note that it includes the file extension.) In this example, you would
-refer to that image asset as [extra_ball](#) even though the
-file is [extra_ball_12753](#). You might be wondering why this
+refer to that image asset as `extra_ball` even though the
+file is `extra_ball_12753`. You might be wondering why this
 exists? Why not just change the file name to be whatever you want and/or
 who cares what the name is? The reason this function exists is because
 it allows for the separation of the actual file on disk from the way

--- a/docs/config_players/led_player.md
+++ b/docs/config_players/led_player.md
@@ -5,6 +5,6 @@ title: LED player
 # LED player
 
 
-[led_player](#) and [matrix_light_player](#) were
+`led_player` and `matrix_light_player` were
 replaced with
 [light_player](light_player.md) in MPF 0.50. See [lights:](../config/lights.md) for details.

--- a/docs/config_players/random_event_player.md
+++ b/docs/config_players/random_event_player.md
@@ -36,9 +36,9 @@ random_event_player:
       likely_event2: 50
 ```
 
-When [play_random_event](#) is posted a random event is posted
-out of the list [event1](#), [event2](#) or
-[event3](#).
+When `play_random_event` is posted a random event is posted
+out of the list `event1`, `event2` or
+`event3`.
 
 ## Usage in config files
 

--- a/docs/cookbook/AFM_super_jets.md
+++ b/docs/cookbook/AFM_super_jets.md
@@ -256,7 +256,7 @@ s_left_bumper_active:
 ```
 
 Everytime "s_left_bumper_active" is seen, the score has 3,000,000
-points added onto it. The [\|block](#) is used to prevent any
+points added onto it. The `\|block` is used to prevent any
 other instances that awards points for hitting "s_left_bumper_active"
 from adding points as well.
 
@@ -523,7 +523,7 @@ bumper hit is worth 1,000,000 at the start. But, we also have to add
 50,000 points for each time the rollovers are completed. To do that, we
 take the value of the counter, "lb_rollover_complete_count" and
 multiply it by 50000. Then we add that value to the standard 1,000,000.
-Remember in "super_jets" that we added [\|block](#) to the
+Remember in "super_jets" that we added `\|block` to the
 end of the scoring? That was in part to keep these lines from continuing
 to add to the score, and to just have the scoring from
 "super_jets.yaml" to appear.

--- a/docs/cookbook/lanes_mode.md
+++ b/docs/cookbook/lanes_mode.md
@@ -281,10 +281,10 @@ not in progress.)
 If you played with this, you most likely noticed that the shots didn't
 actually reset once they were all complete. So that's what we'll do in
 this step. The way we'll do that is to add an entry for
-[reset_events:](#) which specifies what events will cause the
-shots to reset. To do that, go back into your [base.yaml](#)
+`reset_events:` which specifies what events will cause the
+shots to reset. To do that, go back into your `base.yaml`
 file and add another setting to your *indy_lanes* shot group for
-[reset_events:](#), like this:
+`reset_events:`, like this:
 
 ``` mpf-config
 #! switches:
@@ -475,7 +475,7 @@ As it is now, when you complete the lanes, you get the points which is
 cool, but after 1 second the lights just sort of unceremoniously reset.
 Boring! So let's create a light show that flashes the lane lights when
 you complete the lanes. To do this, let's first create a light show
-(details in Steps A and B [here](#)) called
+(details in Steps A and B `here`) called
 \`indy_lanes_complete.yaml\`:
 
 ``` mpf-config
@@ -496,8 +496,8 @@ you complete the lanes. To do this, let's first create a light show
 
 Obviously you can make this show do whatever you want; I opted for a
 simple one that sort of alternates the lights. Then to run the light
-show, go back to your [base.yaml](#) mode config and add a
-[light_player:](#) entry which plays this show when the lanes
+show, go back to your `base.yaml` mode config and add a
+`light_player:` entry which plays this show when the lanes
 are complete, like this:
 
 ``` mpf-config

--- a/docs/game_design/mode_selection.md
+++ b/docs/game_design/mode_selection.md
@@ -195,7 +195,7 @@ of your modes.
 This might be useful for cases where you want to select characters or
 general awards which then might influence how fast your modes start. For
 instance this might be combined with the example above by influencing
-the [starting_count:](#) or [count_complete_value](#)
+the `starting_count:` or `count_complete_value:`
 using conditional events:
 
 ``` mpf-config

--- a/docs/game_design/wizard_modes.md
+++ b/docs/game_design/wizard_modes.md
@@ -78,7 +78,7 @@ progress, your own game design may have other approaches.
 ## Starting and Stopping Wizard Modes
 
 Most wizard modes will be started and stopped like any other game mode,
-using the mode [start_events](#) and [stop_events](#).
+using the mode `start_events` and `stop_events`.
 There will usually be a close relationship between the start/stop events
 and the achievement state events, as in these typical examples:
 

--- a/docs/game_logic/ball_search/configuring_ball_search.md
+++ b/docs/game_logic/ball_search/configuring_ball_search.md
@@ -5,7 +5,7 @@ title: How to configure Ball Search
 # How to configure Ball Search
 
 
-To enable ball search set [enable_ball_search](#) to True for
+To enable ball search set `enable_ball_search` to True for
 your playfield(s). In most cases, this is as simple as this:
 
 ``` mpf-config
@@ -30,14 +30,14 @@ playfields:
 Ball search will run in multiple phases with increasing intensity (phase
 1 to 3) and give up afterwards. To change the timeout before ball search
 starts when no ball was seen by MPF, change
-[ball-search-timeout](#). Similarly,
-[ball-search-interval](#) determines the delay between coil
+`ball-search-timeout`. Similarly,
+`ball-search-interval` determines the delay between coil
 fires during search. You can further configure ball search per
 [playfield](../../config/playfields.md).
 
 Coils are included indirectly using their devices. Most devices allow
 you to configure their order in ball search using the
-[ball_search_order](#) attribute (see the
+`ball_search_order` attribute (see the
 [example ball_search](../../examples/index.md)). By default flippers are not included in ball search.
 However, you might want to enable it for upper playfield flippers:
 

--- a/docs/game_logic/ball_search/configuring_ball_search.md
+++ b/docs/game_logic/ball_search/configuring_ball_search.md
@@ -57,7 +57,7 @@ flippers:
     activation_switch: s_flipper_left
 ```
 
-Make sure to include the tag [playfield_active](#) in all
+Make sure to include the tag `playfield_active` in all
 playfield switches which are not bound to devices. For instance do not
 put that tag into your plunger switch but put it to target, inlane and
 outlane switches.

--- a/docs/game_logic/ball_start_end.md
+++ b/docs/game_logic/ball_start_end.md
@@ -12,7 +12,7 @@ ending.
 
 During game start (see [Flowcharts](../flowcharts/index.md)
 for details) you can trigger shows/lights or any other player on the
-[ball_started](#) event (see
+`ball_started` event (see
 [Ball Start Sequence](../flowcharts/ball_start.md)). This will not
 delay the ball start and the ball will eject instantly.
 

--- a/docs/game_logic/credits.md
+++ b/docs/game_logic/credits.md
@@ -357,11 +357,11 @@ they're displayed in your particular machine. (We'll use an example of
     including the fraction (if there are any partial credits). For
     example, `2 1/4`.
 * `credits_whole_num` -- This is just the whole number of credits.
-    Example: [2](#).
+    Example: `2`.
 * `credits_numerator` -- This is just the numerator of the fraction of
-    partial credits. Example: [1](#).
+    partial credits. Example: `1`.
 * `credits_denominator` -- This is just the denominator of the
-    fraction of partial credits. Example: [4](#).
+    fraction of partial credits. Example: `4`.
 
 The denominator of the fraction in the `credit_string` is automatically
 calculated based on the smallest value coin switch and the price of your

--- a/docs/game_logic/logic_blocks/persisting_state_in_a_player_variable.md
+++ b/docs/game_logic/logic_blocks/persisting_state_in_a_player_variable.md
@@ -23,7 +23,7 @@ You can easily use this numerical value in a text widget to show the
 number of combos complete, or the number of pop bumper hits required for
 super jets, etc. This player variable "state" is different than the
 state of the logic block itself, which is an object with
-[enabled](#), [completed](#), and [value](#)
+`enabled`, `completed`, and `value`
 attributes. Note the difference in accessing the logic block state as a
 dynamic value vs. placeholder text:
 

--- a/docs/game_logic/multiballs/multiball_with_multiple_lock_devices.md
+++ b/docs/game_logic/multiballs/multiball_with_multiple_lock_devices.md
@@ -27,8 +27,7 @@ multiball starts reset counters of your locks.
 
 In the following example, you have to lock balls sequentially in your
 three locks. Every lock will enable the next lock using the
-[multiball_lock_(name)_full](../../events/multiball_lock_multiball_lock_full.md) event. The last lock will start the [multiball](#)
-mode. If you hit [s_target1](#) the multiball will start which
+[multiball_lock_(name)_full](../../events/multiball_lock_multiball_lock_full.md) event. The last lock will start the `multiball` mode. If you hit `s_target1` the multiball will start which
 will reset and disable all locks using the
 [multiball_(name)_started](../../events/multiball_multiball_started.md)
 event. After all the balls from the multiball drained all lock modes and

--- a/docs/game_logic/scoring/index.md
+++ b/docs/game_logic/scoring/index.md
@@ -11,8 +11,8 @@ Related Config File Sections:
 
 The variable_player is commonly used to score points for the current
 player when a certain event is posted. This event could be a switch hit
-(i.e. for [s_your_switch](#) use the event
-[s_your_switch_active](#)).
+(i.e. for `s_your_switch` use the event
+`s_your_switch_active`).
 
 ``` mpf-config
 ##! mode: mode1

--- a/docs/hardware/fadecandy/index.md
+++ b/docs/hardware/fadecandy/index.md
@@ -193,9 +193,9 @@ Start your fadecandy server with the following config:
 }
 ```
 
-Replace [YOUR_FADECANDY_SERIAL](#) with the serial of your
+Replace `YOUR_FADECANDY_SERIAL` with the serial of your
 fadecandy. The serial will be shown on the console of
-[fcserver](#) when connecting your fadecandy.
+`fcserver` when connecting your fadecandy.
 
 Then configure your lights as follows:
 
@@ -271,11 +271,11 @@ config:
 }
 ```
 
-Replace [YOUR_FADECANDY_SERIAL1](#),
-[YOUR_FADECANDY_SERIAL2](#) and
-[YOUR_FADECANDY_SERIAL3](#) with the serials of your fadecandy
+Replace `YOUR_FADECANDY_SERIAL1`,
+`YOUR_FADECANDY_SERIAL2` and
+`YOUR_FADECANDY_SERIAL3` with the serials of your fadecandy
 boards (you can use more or less than three). The serial will be shown
-on the console of [fcserver](#) when connecting your fadecandy.
+on the console of `fcserver` when connecting your fadecandy.
 
 Afterwards, configure your lights as follows:
 

--- a/docs/hardware/fast/config.md
+++ b/docs/hardware/fast/config.md
@@ -33,7 +33,7 @@ fast:
   driverboards: fast
 ```
 
-You also need to configure the [driverboards:](#) entry for
+You also need to configure the `driverboards:` entry for
 what kind of driver boards you're controlling.
 
 Use `driverboards: fast` if you're using FAST I/O boards (like the

--- a/docs/hardware/multimorphic/leds.md
+++ b/docs/hardware/multimorphic/leds.md
@@ -68,7 +68,7 @@ Channels use the format: `board_number-led_index`
 
 This is almost the same as above but it addresses only one output
 (instead of three). You can use the channel syntax as for
-[l_led0](#) above:
+`l_led0` above:
 
 ``` mpf-config
 lights:

--- a/docs/hardware/multimorphic/troubleshooting.md
+++ b/docs/hardware/multimorphic/troubleshooting.md
@@ -139,7 +139,7 @@ the following points:
 
 ### On the P3-Roc
 
-* Do your SW-16 show in [mpf hardware scan](#)? (see above)
+* Do your SW-16 show in `mpf hardware scan`? (see above)
 * If not: Is the SW-16 bus connected properly (and not twisted)?
 * Is ground connected properly to your switches? Should be connected
     to pin 10 on J2 or J6 of SW-16.

--- a/docs/hardware/mypinballs/index.md
+++ b/docs/hardware/mypinballs/index.md
@@ -54,7 +54,7 @@ segment_displays:
     number: 6
 ```
 
-You can configure your serial port in [port](#). See
+You can configure your serial port in `port`. See
 [segment_display](../../mc/displays/alpha_numeric.md) for more informations about how to drive segment display in
 your game.
 
@@ -86,7 +86,7 @@ segment_displays:
     number: 4
 ```
 
-You can configure your serial port in [port](#). See
+You can configure your serial port in `port`. See
 [segment_display](../../mc/displays/alpha_numeric.md) for more informations about how to drive segment display in
 your game.
 

--- a/docs/hardware/opp/leds.md
+++ b/docs/hardware/opp/leds.md
@@ -48,11 +48,10 @@ USB. See [/mechs/lights/ws2812](connecting.md) for details about
 chains. If you only got one chain you can omit this part and your format
 becomes `card_num`-`index`.
 
-`card_num`[ is the index of the board on the chain. As the first board
-is always at addr ](#)[0x20](#)[ you can calculate the
-addr using ](#)[0x20 + card_num](#)[. If you only got
-one board you can omit the board and your format becomes just
-](#)[index](#)\`.
+`card_num` is the index of the board on the chain. As the first board
+is always at addr `0x20` you can calculate the
+addr using `0x20` + card_num. If you only got
+one board you can omit the board and your format becomes just `index`.
 
 For instance, `0-0-0` for the first RGB LED on chain `0` on card `0x20`.
 In this case you can also use `0-0` or `0` (channel `0-2`). `0-0-1` or

--- a/docs/hardware/pin2dmd/index.md
+++ b/docs/hardware/pin2dmd/index.md
@@ -60,7 +60,7 @@ Once you have your hardware all set, you need to add a `smartmatrix:`
 section to your machine-wide config and which tells MPF how to talk to
 RGB DMDs that use the SmartMatrix platform.
 
-1.  Add [pin2dmd](#) to your hardware section:
+1.  Add `pin2dmd` to your hardware section:
 
 ``` mpf-config
 hardware:

--- a/docs/hardware/rpi.md
+++ b/docs/hardware/rpi.md
@@ -40,7 +40,7 @@ systemctl enable pigpiod.service
 systemctl start pigpiod.service
 ```
 
-The [enable](#) step gets the service running at startup, thus
+The `enable` step gets the service running at startup, thus
 it is optional.
 
 ## Using pigpio via network

--- a/docs/hardware/smartmatrix.md
+++ b/docs/hardware/smartmatrix.md
@@ -255,7 +255,7 @@ smartmatrix:
 Just enter the `baud:` and `old_cookie:` settings like they are in the
 example above. These are the settings that are needed for the
 SmartMatrix. If you are using the FAST DMD board set baud to
-[3000000](#).
+`3000000`.
 
 ## 3. Add a physical RGB DMD device entry
 

--- a/docs/hardware/spike/mpf-spike-bridge.md
+++ b/docs/hardware/spike/mpf-spike-bridge.md
@@ -91,7 +91,7 @@ original game again.)
 
 Add mpf-spike-bridge to /bin/bridge and mark it as executable.
 
-On Linux this can be done with [chmod +x bridge](#) from within
+On Linux this can be done with `chmod +x bridge` from within
 the folder.
 
 Get the bridge from <https://github.com/missionpinball/mpf-spike>

--- a/docs/hardware/virtual/keyboard.md
+++ b/docs/hardware/virtual/keyboard.md
@@ -18,7 +18,7 @@ map single key presses or combinations of keys, and you can use the
 keyboard module with or without a physical pinball machine connected to
 your computer.
 
-To use the keyboard interface, you add a [keyboard:](#) section
+To use the keyboard interface, you add a `keyboard:` section
 to your machine configuration file and then create a list which maps
 keyboard keys to pinball machine switch names or MPF events. Then when
 you press a key on the keyboard, the switch controller receives that

--- a/docs/install/linux/index.md
+++ b/docs/install/linux/index.md
@@ -162,7 +162,7 @@ File “/usr/local/lib/python3.8/dist-packages/mpf/platforms/p_roc_common.py”,
 ImportError: No module named ‘pinproc’
 ```
 
-Try Changing [Edit install-proc:](#)
+Try Changing `Edit install-proc:`
 
 From:
 

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -115,7 +115,7 @@ You can test it by typing this command:
 mpf --version
 ```
 
-This should print out something like [MPF 0.57.0](#). If you
+This should print out something like `MPF 0.57.0`. If you
 get an error, something went wrong. If you get a different version, then
 you might have an older version of MPF which you need to uninstall
 first. (See the "Remove prior versions of MPF" section above.)

--- a/docs/mc/displays/architecture.md
+++ b/docs/mc/displays/architecture.md
@@ -34,7 +34,7 @@ on the host operating system. If you do not provide a "window:"
 section in your config, a default window will be created for you (800 x
 600 pixels). The size settings (width, height) control the dimensions
 (in pixels) of the host operating system window that will be created.
-Various settings in the [window:](#) section control the
+Various settings in the `window:` section control the
 appearance and behavior of the main on-screen window which is created by
 MPF-MC. These settings include things such as whether or not the window
 has a border, is full screen, or whether special image processing is

--- a/docs/mc/sound/basic_setup.md
+++ b/docs/mc/sound/basic_setup.md
@@ -15,7 +15,7 @@ you're using MPF-MC for your media controller. Please ensure your
 system is properly setup to play sound (drivers are installed and
 configured) before proceeding with this guide.
 
-## 1. Configuring the [sound_system](#)
+## 1. Configuring the `sound_system`
 
 The first step in the process of setting up sound for your machine is to
 setup the `sound_system:` section of your machine configuration file

--- a/docs/mc/sound/ducking.md
+++ b/docs/mc/sound/ducking.md
@@ -28,7 +28,7 @@ music. The following parameters control the ducking behavior of the
 voice clip:
 
 * `target` - The track name to apply the ducking to when the sound is
-    played. In the example above the [music](#) track is the
+    played. In the example above the `music` track is the
     target.
 * `delay` - The duration to delay after the sound starts playing
     before ducking starts. This value may be specified as a time string

--- a/docs/mc/widgets/dmd_fonts.md
+++ b/docs/mc/widgets/dmd_fonts.md
@@ -38,7 +38,7 @@ low-res DMD.)
 
 ## style: big
 
-[big](#) is 10 pixels tall.
+`big` is 10 pixels tall.
 
 ``` mpf-mc-config
 slides:
@@ -59,7 +59,7 @@ slides:
 
 ## style: med
 
-[medium](#) is 7 pixels tall.
+`medium` is 7 pixels tall.
 
 ``` mpf-mc-config
 slides:
@@ -80,7 +80,7 @@ slides:
 
 ## style: small
 
-[small](#) is 5 pixels tall.
+`small` is 5 pixels tall.
 
 Notice that this font has a color set and we're using it with a Color
 DMD. All three of these fonts (like any font) can be used on a mono or

--- a/docs/mc/widgets/reusable_widgets.md
+++ b/docs/mc/widgets/reusable_widgets.md
@@ -392,8 +392,8 @@ variable_player:
 
 You can also use the parameters of an event to determine the widget to
 include. In the following example from a game with different multiballs,
-the event [mball_lock_lit](#) might post with either "angel"
-or "demon" as the [mball_name](#) parameter.
+the event `mball_lock_lit` might post with either "angel"
+or "demon" as the `mball_name` parameter.
 
 ``` mpf-mc-config
 slide_player:

--- a/docs/mc/widgets/segment_display_emulator/index.md
+++ b/docs/mc/widgets/segment_display_emulator/index.md
@@ -249,10 +249,8 @@ The `character_map` parameter allows custom character segment mappings
 This advanced feature is useful for creating your own special characters
 or simply overriding the default mappings for any individual character.
 For more information on segment display character mappings, see [David
-Madison's Segmented LED Display - ASCII Library page
-<https://github.com/dmadison/LED-Segment-ASCII>](#). This
-parameter is a dictionary with integer keys and values (key is the ascii
-character ordinal number, value is the segment bit mapping as an
-integer).
+Madison's Segmented LED Display - ASCII Library page](https://github.com/dmadison/LED-Segment-ASCII).
+This parameter is a dictionary with integer keys and values (key is the ascii
+character ordinal number, value is the segment bit mapping as an integer).
 
 * [How to setup and use the virtual segment display emulator](how_to.md)

--- a/docs/mc/widgets/text/index.md
+++ b/docs/mc/widgets/text/index.md
@@ -79,7 +79,7 @@ This value is required. If you don't want text, use ""
 Your text can contain placeholders as described in
 [dynamic text](text_dynamic.md).
 
-Newline characters ([n](#)) are supported in text values to
+Newline characters (`\n`) are supported in text values to
 create multiple lines with line breaks, however you must surround the
 text with quotes or the backslash will be treated as a printing
 character and will appear in the output. For example:

--- a/docs/mc/widgets/text/index.md
+++ b/docs/mc/widgets/text/index.md
@@ -123,13 +123,13 @@ pixel-style display), we have some
 
 ### bitmap_font:
 
-A true/false value indicating whether the [font_name:](#)
+A true/false value indicating whether the `font_name:`
 setting contains the name of a
 [bitmap_font](../../../config/bitmap_fonts.md)
-asset. When set to [True](#), [font_name:](#) must
-refer to an existing bitmap_font asset name and [font_size:](#)
-will be ignored. When set to [False](#),
-[font_name:](#) should refer to a font name.
+asset. When set to `True`, `font_name:` must
+refer to an existing bitmap_font asset name and `font_size:`
+will be ignored. When set to `False`,
+`font_name:` should refer to a font name.
 
 ### font_size:
 

--- a/docs/mechs/lights/lights_versus_leds.md
+++ b/docs/mechs/lights/lights_versus_leds.md
@@ -7,7 +7,7 @@ title: Lights versus LEDs
 
 In MPF 0.33 and earlier not all LEDs had to be configured as LEDs. This
 changed in 0.50+ where all lights, GIs and matrix_lights were unified as
-lights. The distinction is now only the [subtype](#) in the
+lights. The distinction is now only the `subtype` in the
 [lights config](../../config/matrix_lights.md).
 
 Taking a step back. There are two types of lighting systems in pinball
@@ -26,7 +26,7 @@ LED bulbs in your lamp matrix.
 
 Alternately, if you have directly-controlled LEDs (i.e. no lamp matrix),
 whether single color or RGB, then you'll configure them as
-[subtype](#) led in the [lights:](../../config/lights.md) section of your config.
+`subtype` led in the [lights:](../../config/lights.md) section of your config.
 
 The following diagram shows the different types. An easy way to tell is
 if your lights or LEDs have mini bayonet or mini wedge bases, they're

--- a/docs/mechs/lights/matrix_lights.md
+++ b/docs/mechs/lights/matrix_lights.md
@@ -33,7 +33,7 @@ machines used #555 bulbs (or the vibration resistant variant #444 or the
 ## Config
 
 Details differ by platform but the syntax for the number of such a light
-is usually [column:row](#) or [column:row](#) (see
+is usually `column:row` or `column:row` (see
 your platform for details). The config looks like this:
 
 ``` mpf-config

--- a/docs/mechs/motors.md
+++ b/docs/mechs/motors.md
@@ -48,11 +48,11 @@ motors:
 
 The motor can run continuously and drives a camshaft which moves the
 bank up and down. MPF will figure the position using two position
-switches [s_position_up](#) and [s_position_down](#).
-To enable the motor we use a digitial_output [c_motor_run](#)
+switches `s_position_up` and `s_position_down`.
+To enable the motor we use a digitial_output `c_motor_run`
 which maps to a driver. On reset the bank moves down and can afterwards
-be commanded using the events [go_up](#) and
-[go_down](#).
+be commanded using the events `go_up` and
+`go_down`.
 
 The following is an example to drive the slimer in Stern Ghostbusters:
 
@@ -85,12 +85,12 @@ motors:
 ```
 
 The slimer motor can move in two directions using two digital_outputs
-[c_slimer_motor_forward](#) and
-[c_slimer_motor_backward](#) which map to lights in Spike. The
-switches [s_slimer_home](#) and [s_slimer_away](#) are
+`c_slimer_motor_forward` and
+`c_slimer_motor_backward` which map to lights in Spike. The
+switches `s_slimer_home` and `s_slimer_away` are
 used by to determine the current position. To command the slimer use the
-events [slimer_home](#) or [slimer_away](#).
+events `slimer_home` or `slimer_away`.
 
 ## Related Events
 
-* [motor_(name)_[reached_(position)](../events/motor_motor_reached_position.md)
+* [motor_(name)\_[reached_(position)](../events/motor_motor_reached_position.md)

--- a/docs/mechs/troughs/classic_single_ball.md
+++ b/docs/mechs/troughs/classic_single_ball.md
@@ -98,7 +98,7 @@ ball device.
     this device mean that a ball has drained from the playfield, that
     it's ok to start a game with a ball here, and that this device is
     used to store unused balls.
-* Set [eject_timeouts](#) to the maximum time the ball can
+* Set `eject_timeouts` to the maximum time the ball can
     take to return if the eject fails.
 
 Your drain device configuration should look now look like this:

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow: /welcome_wall/
+Disallow: */welcome_wall/

--- a/docs/running/commands/game.md
+++ b/docs/running/commands/game.md
@@ -77,7 +77,7 @@ Specify the name of the MPF default config file which is loaded before
 your machine config. (MPF includes a file `mpfconfig.yaml`
 which is inside the MPF package which sets up default things like which
 modules are loaded, paths used, etc. If for some reason you want to
-override this file, you can do so with the [-C](#) option.
+override this file, you can do so with the `-C` option.
 
 ### -h
 
@@ -128,7 +128,7 @@ Note that due to the way the command prompt console works on Windows,
 enabling verbose logging on Windows will significantly affect MPF (in a
 bad way). Windows computers can run MPF no problem, but because of their
 weird console slowness we recommend that you do not use the
-[-V](#) command line option from a Windows computer.
+`-V` command line option from a Windows computer.
 
 ### -x (lowercase)
 
@@ -139,10 +139,10 @@ your physical hardware attached.
 
 ### -X (uppercase)
 
-Like [-x](#), except it forces the
+Like `-x`, except it forces the
 [smart virtual platform](../../hardware/virtual/smart_virtual.md).
 
 ### --vpx
 
-Like [-x](#), except it forces the
+Like `-x`, except it forces the
 [Virtual Pinball (VPX) platform](../../hardware/virtual/virtual_pinball_vpx.md).

--- a/docs/running/commands/mc.md
+++ b/docs/running/commands/mc.md
@@ -60,7 +60,7 @@ before your before your machine config. (MPF MC includes a file
 `mcconfig.yaml` which is inside the MPF MC package which sets up default
 things like which modules are loaded, paths used, etc. If for some
 reason you want to override this file, you can do so with the
-[-C](#) option.
+`-C` option.
 
 Note that the `-C` option is used by both `mpf game` and `mpf mc`, but
 these two packages use different default files. So if you want to
@@ -115,7 +115,7 @@ Note that on due to the way the command prompt console works on Windows,
 enabling verbose logging on Windows will significantly affect MPF (in a
 bad way). Windows computers can run MPF no problem, but because of their
 weird console slowness we recommend that you do not use the
-[-V](#) command line option from a Windows computer.
+`-V` command line option from a Windows computer.
 
 ### -x (lowercase)
 
@@ -125,7 +125,7 @@ when you don't have your physical hardware attached.
 
 ### -X (uppercase)
 
-Like [-x](#), except it forces the *smart virtual* platform.
+Like `-x`, except it forces the *smart virtual* platform.
 
 ## Unused Options
 

--- a/docs/tools/hardware.md
+++ b/docs/tools/hardware.md
@@ -10,7 +10,7 @@ hardware:
 
 ## mpf hardware scan
 
-You can run [mpf hardware scan](#) to get an overview over the
+You can run `mpf hardware scan` to get an overview over the
 connected hardware. MPF will try to enumerate all connected boards and
 tell you what it know about your hardware. The output varies per
 hardware platform from almost nothing to a lot.

--- a/docs/tools/hardware.md
+++ b/docs/tools/hardware.md
@@ -60,14 +60,14 @@ hardware_benchmark:
   flipper: f_flipper
 ```
 
-Disconnect or disable high voltage. Then connect [s_test1](#)
-to [c_coil1](#) and [s_test2](#) to
-[c_coil2](#). MPF will enable the flipper
-[f_flipper](#) which will create a hardware rule on
-[s_test1](#) to pulse [c_coil2](#). Afterwards, MPF
-will pulse [c_coil1](#) which should then activate
-[s_test1](#). In turn the hardware rule should pulse
-[c_coil2](#) which then activates [s_test2](#).
+Disconnect or disable high voltage. Then connect `s_test1`
+to `c_coil1` and `s_test2` to
+`c_coil2`. MPF will enable the flipper
+`f_flipper` which will create a hardware rule on
+`s_test1` to pulse `c_coil2`. Afterwards, MPF
+will pulse `c_coil1` which should then activate
+`s_test1`. In turn the hardware rule should pulse
+`c_coil2` which then activates `s_test2`.
 Hardware benchmark will measure the timings of the two switches. It will
 repeat this procedure a few times and run some statistics on the
 results.

--- a/docs/tutorial/14_add_a_mode.md
+++ b/docs/tutorial/14_add_a_mode.md
@@ -316,9 +316,9 @@ slide_player:
 * If you get some kind of crash or error, specifically any errors that
     mention anything about "config" or "path," double-check that you
     put all the files in the proper locations back in Step 2. (A common
-    mistake is to put [base.yaml](#) in the
-    [/modes/base](#) folder rather than the
-    [/modes/base/config](#) folder.)
+    mistake is to put `base.yaml` in the
+    `/modes/base` folder rather than the
+    `/modes/base/config` folder.)
 
 ## Check out the complete config.yaml file so far
 

--- a/docs/tutorial/2_creating_a_new_machine.md
+++ b/docs/tutorial/2_creating_a_new_machine.md
@@ -258,8 +258,8 @@ This means you don't have `#config_version=6` in the top line of your
 config file. (Make sure you include the hash mark as part of that.)
 
 If the following line at the end of your log and nothing more happens
-you probably started mpf with mc (i.e. by omitting the [-b](#)
-switch). This can be fixed by either running [mpf -b](#) or by
+you probably started mpf with mc (i.e. by omitting the `-b`
+switch). This can be fixed by either running `mpf -b` or by
 making sure that the media controller is running.
 
 ``` console

--- a/docs/tutorial/3_get_flipping.md
+++ b/docs/tutorial/3_get_flipping.md
@@ -675,8 +675,8 @@ any flipping, check the following:
 If MPF crashes or gives an error:
 
 * If you're using a P-ROC and you get a bunch of really fast messages
-    about [Error opening P-ROC device](#) and [Failed, trying
-    again...](#), this is because (1) your pinball machine is
+    about `Error opening P-ROC device` and `Failed, trying
+    again...`, this is because (1) your pinball machine is
     not turned on, (2) your P-ROC is not connected to your computer (via
     USB), or (3) you have a problem with the P-ROC drivers. If you're
     running MPF in a virtual machine, make sure the USB connection is

--- a/docs/tutorial/3_get_flipping.md
+++ b/docs/tutorial/3_get_flipping.md
@@ -453,8 +453,7 @@ you need to add a `hardware:` section to your config file, and then you
 add settings for `platform:` and `driverboards:`.
 
 Don't worry if you do not have any hardware yet. You can run through
-the tutorial without hardware by using the [virtual](#)
-hardware platform.
+the tutorial without hardware by using the `virtual` hardware platform.
 
 Remember earlier in this step, we provided links to the documentation
 for each platform. Here is

--- a/docs/versions/docs.md
+++ b/docs/versions/docs.md
@@ -10,19 +10,11 @@ you can find it here. Each link below contains the docs in several
 formats, including PDF, text, and HTML zip bundles of the documentation
 for that version.
 
-* [MPF v0.33
-    Docs](https://archive.org/details/mission-pinball-framework-html-docs-v-0.33)
-* [MPF v0.50
-    Docs](https://archive.org/details/mission-pinball-framework-html-docs-v-0.50)
-* [MPF v0.51
-    Docs](https://archive.org/details/mission-pinball-framework-html-docs-v-0.51)
-* [MPF v0.52
-    Docs](https://archive.org/details/mission-pinball-framework-html-docs-v-0.52)
-* [MPF v0.53
-    Docs](https://archive.org/details/mission-pinball-framework-html-docs-v-0.53)
-* [MPF v0.54
-    Docs](https://archive.org/details/mission-pinball-framework-html-docs-v-0.54)
-* [MPF v0.55
-    Docs](https://archive.org/details/mission-pinball-framework-docs-v-0.55)
-* [MPF v0.56
-    Docs](https://archive.org/details/mission-pinball-framework-docs-v-0.56)
+* [MPF v0.33 Docs](https://archive.org/details/mission-pinball-framework-html-docs-v-0.33)
+* [MPF v0.50 Docs](https://archive.org/details/mission-pinball-framework-html-docs-v-0.50)
+* [MPF v0.51 Docs](https://archive.org/details/mission-pinball-framework-html-docs-v-0.51)
+* [MPF v0.52 Docs](https://archive.org/details/mission-pinball-framework-html-docs-v-0.52)
+* [MPF v0.53 Docs](https://archive.org/details/mission-pinball-framework-html-docs-v-0.53)
+* [MPF v0.54 Docs](https://archive.org/details/mission-pinball-framework-html-docs-v-0.54)
+* [MPF v0.55 Docs](https://archive.org/details/mission-pinball-framework-docs-v-0.55)
+* [MPF v0.56 Docs](https://archive.org/details/mission-pinball-framework-docs-v-0.56)

--- a/docs/versions/index.md
+++ b/docs/versions/index.md
@@ -6,7 +6,7 @@ title: MPF Versions
 
 
 MPF is a work-in-progress. New versions are released every so often. You
-can find your MPF version by running [mpf --version](#) from
+can find your MPF version by running `mpf --version` from
 the command line.
 
 **The current long-term-support (LTS) version of MPF is 0.57**

--- a/docs/versions/release_notes.md
+++ b/docs/versions/release_notes.md
@@ -671,10 +671,9 @@ This is a 0.52 maintenance release with cleanups and some refactorings.
 We identified a few potential upgrade issues:
 
 * We fixed validation of animations. You might get a validation error
-    with [repeat: -1](#). Change it to [repeat:
-    false](#). See the [change in the
+    with `repeat: -1`. Change it to `repeat: false`. See the [change in the
     docs](https://github.com/missionpinball/mpf-docs/commit/6a141ec4434a0904d92f05bcbce1fe345513c018).
-* We changed [active_time](#) of ball_save from ms to secs.
+* We changed `active_time` of ball_save from ms to secs.
     In case you did not use a unit here this might change the time.
     [Details](https://github.com/missionpinball/mpf/pull/1463).
 * [Machine variables
@@ -1773,7 +1772,7 @@ Sept 14, 2015
         config processing was done manually in each module before.
     * The config processing is more efficient and less-error prone
         since it's not written from scratch for each module.
-    * There's now a master list (in [mpfconfig.yaml](#)) of
+    * There's now a master list (in `mpfconfig.yaml`) of
         all config settings for all device types.
     * The config processor and validator can run as a service to
         support the back-end business logic behind future GUI tools
@@ -1898,9 +1897,9 @@ Released: May 4, 2015
 * Added version control to config files.
 * Added volume control.
 * Switches that you want to start active when using virtual hardware
-    are now added to the [virtual platform start active
-    switches:](#) section instead of being a property of the
-    [keyboard:](#) entry.
+    are now added to the `virtual platform start active
+    switches:` section instead of being a property of the
+    `keyboard:` entry.
 * Converted several former plugins to system modules, including shots,
     scoring, bcp, and logic blocks.
 * General performance improvements. (Running MPF on my machine used to
@@ -1981,10 +1980,10 @@ Released: February 9, 2015
     playfield device module.
 * Different types of events were broken out into their own methods.
     For example, to post a boolean event, instead of calling
-    [event.post(type='boolean')](#), you now use
-    [event.post_boolean()](#). There are similar new methods
-    for other event types, like [post_relay()](#) and
-    [post_queue()](#).
+    `event.post(type='boolean')`, you now use
+    `event.post_boolean()`. There are similar new methods
+    for other event types, like `post_relay()` and
+    `post_queue()`.
 * Added a debug option for ball devices which enables extra debug
     logging for problem devices.
 * Tilt status was removed from the machine controller. (It was


### PR DESCRIPTION
There are ~160 links to the anchor "#", which just results in a scroll to top. About half of these should be just `inline code blocks` and the other half could probably link to config docs, event references, or other pages.

This PR makes those links all just inline blocks as well, but the commit 52c8eb798cc5fcf8aa3e118bddd0f9825162f9d7 contains all of those which I thought had potential.