### PR TITLE
Reformat events

### DIFF
--- a/docs/events/achievement_achievement_changed_state.md
+++ b/docs/events/achievement_achievement_changed_state.md
@@ -7,6 +7,8 @@ title: achievement_(name)_changed_state
 
 --8<-- "event.md"
 
+Event is posted by [achievements:](../config/achievements.md)
+
 The achievement called (name) changed state.
 
 Valid states are: disabled, enabled, started, completed, stopped
@@ -31,5 +33,3 @@ Whatever this achievement is selected currently
 #### `state`:
 
 Current state
-
-Event is posted by [achievements:](../config/achievements.md)

--- a/docs/events/achievement_achievement_changed_state.md
+++ b/docs/events/achievement_achievement_changed_state.md
@@ -2,7 +2,7 @@
 title: achievement_(name)_changed_state
 ---
 
-# achievement_(name)_changed_state
+# achievement_(name)\_changed_state
 
 
 --8<-- "event.md"
@@ -20,16 +20,16 @@ next ball to restore state.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`restore`
+#### `restore`:
 
-:   true if this is reposted to restore state
+true if this is reposted to restore state
 
-`selected`
+#### `selected`:
 
-:   Whatever this achievement is selected currently
+Whatever this achievement is selected currently
 
-`state`
+#### `state`:
 
-:   Current state
+Current state
 
 Event is posted by [achievements:](../config/achievements.md)

--- a/docs/events/achievement_achievement_changed_state.md
+++ b/docs/events/achievement_achievement_changed_state.md
@@ -11,7 +11,7 @@ Event is posted by [achievements:](../config/achievements.md)
 
 The achievement called (name) changed state.
 
-Valid states are: disabled, enabled, started, completed, stopped
+Valid states are: `disabled`, `enabled`, `started`, `completed`, `stopped`
 
 This is only posted once per state. Its also posted on restart on the
 next ball to restore state.

--- a/docs/events/achievement_achievement_state_state.md
+++ b/docs/events/achievement_achievement_state_state.md
@@ -20,16 +20,16 @@ next ball to restore state and when selection changes.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`restore`
+#### `restore`:
 
-:   true if this is reposted to restore state
+true if this is reposted to restore state
 
-`selected`
+#### `selected`:
 
-:   Whatever this achievement is selected currently
+Whatever this achievement is selected currently
 
-`state`
+#### `state`:
 
-:   Current state
+Current state
 
 Event is posted by [achievements:](../config/achievements.md)

--- a/docs/events/achievement_achievement_state_state.md
+++ b/docs/events/achievement_achievement_state_state.md
@@ -7,6 +7,8 @@ title: achievement_(name)_state_(state)
 
 --8<-- "event.md"
 
+Event is posted by [achievements:](../config/achievements.md)
+
 The achievement called (name) changed to state (state).
 
 Valid states are: disabled, enabled, started, completed, stopped
@@ -31,5 +33,3 @@ Whatever this achievement is selected currently
 #### `state`:
 
 Current state
-
-Event is posted by [achievements:](../config/achievements.md)

--- a/docs/events/achievement_achievement_state_state.md
+++ b/docs/events/achievement_achievement_state_state.md
@@ -11,7 +11,7 @@ Event is posted by [achievements:](../config/achievements.md)
 
 The achievement called (name) changed to state (state).
 
-Valid states are: disabled, enabled, started, completed, stopped
+Valid states are: `disabled`, `enabled`, `started`, `completed`, `stopped`
 
 This is only posted once per state. Its also posted on restart on the
 next ball to restore state and when selection changes.

--- a/docs/events/asset_loading_complete.md
+++ b/docs/events/asset_loading_complete.md
@@ -21,4 +21,4 @@ and connects, MPF will need to load its own assets, which means the MPF
 MC will post more *loading_assets* and then a final
 *asset_loading_complete* event a second time for the MPF-based assets.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_drain.md
+++ b/docs/events/ball_drain.md
@@ -18,11 +18,11 @@ This is a relay event.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of balls that have just drained. Any balls remaining
-    after the relay will be processed as newly-drained balls.
+The number of balls that have just drained. Any balls remaining
+after the relay will be processed as newly-drained balls.
 
-`device`
+#### `device`:
 
-:   The ball device object that received the ball(s)
+The ball device object that received the ball(s)

--- a/docs/events/ball_ended.md
+++ b/docs/events/ball_ended.md
@@ -13,4 +13,4 @@ Note that this does not necessarily mean that the next player's turn
 will start, as this player may have an extra ball which means they'll
 shoot again.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_ending.md
+++ b/docs/events/ball_ending.md
@@ -12,4 +12,4 @@ end until the queue is cleared.
 
 This event is posted just after [ball_will_end](ball_will_end.md)
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_hold_ball_hold_balls_released.md
+++ b/docs/events/ball_hold_ball_hold_balls_released.md
@@ -2,7 +2,7 @@
 title: ball_hold_(name)_balls_released
 ---
 
-# ball_hold_(name)_balls_released
+# ball_hold_(name)\_balls_released
 
 
 --8<-- "event.md"
@@ -15,8 +15,8 @@ The ball hold device called (name) has just released a ball(s).
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls_released`
+#### `balls_released`:
 
-:   The number of balls that were just released.
+The number of balls that were just released.
 
 Event is posted by [ball_holds:](../config/ball_holds.md)

--- a/docs/events/ball_hold_ball_hold_balls_released.md
+++ b/docs/events/ball_hold_ball_hold_balls_released.md
@@ -7,6 +7,8 @@ title: ball_hold_(name)_balls_released
 
 --8<-- "event.md"
 
+Event is posted by [ball_holds:](../config/ball_holds.md)
+
 The ball hold device called (name) has just released a ball(s).
 
 ## Keyword arguments
@@ -18,5 +20,3 @@ only respond to certain combinations of the arguments below.)
 #### `balls_released`:
 
 The number of balls that were just released.
-
-Event is posted by [ball_holds:](../config/ball_holds.md)

--- a/docs/events/ball_hold_ball_hold_full.md
+++ b/docs/events/ball_hold_ball_hold_full.md
@@ -2,7 +2,7 @@
 title: ball_hold_(name)_full
 ---
 
-# ball_hold_(name)_full
+# ball_hold_(name)\_full
 
 
 --8<-- "event.md"
@@ -15,8 +15,8 @@ The ball hold device called (name) is now full.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of balls currently held in this device.
+The number of balls currently held in this device.
 
 Event is posted by [ball_holds:](../config/ball_holds.md)

--- a/docs/events/ball_hold_ball_hold_full.md
+++ b/docs/events/ball_hold_ball_hold_full.md
@@ -7,6 +7,8 @@ title: ball_hold_(name)_full
 
 --8<-- "event.md"
 
+Event is posted by [ball_holds:](../config/ball_holds.md)
+
 The ball hold device called (name) is now full.
 
 ## Keyword arguments
@@ -18,5 +20,3 @@ only respond to certain combinations of the arguments below.)
 #### `balls`:
 
 The number of balls currently held in this device.
-
-Event is posted by [ball_holds:](../config/ball_holds.md)

--- a/docs/events/ball_hold_ball_hold_held_ball.md
+++ b/docs/events/ball_hold_ball_hold_held_ball.md
@@ -2,7 +2,7 @@
 title: ball_hold_(name)_held_ball
 ---
 
-# ball_hold_(name)_held_ball
+# ball_hold_(name)\_held_ball
 
 
 --8<-- "event.md"
@@ -15,12 +15,12 @@ The ball hold device called (name) has just held additional ball(s).
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls_held`
+#### `balls_held`:
 
-:   The number of new balls just held.
+The number of new balls just held.
 
-`total_balls_held`
+#### `total_balls_held`:
 
-:   The current total number of balls this device has held.
+The current total number of balls this device has held.
 
 Event is posted by [ball_holds:](../config/ball_holds.md)

--- a/docs/events/ball_hold_ball_hold_held_ball.md
+++ b/docs/events/ball_hold_ball_hold_held_ball.md
@@ -7,6 +7,8 @@ title: ball_hold_(name)_held_ball
 
 --8<-- "event.md"
 
+Event is posted by [ball_holds:](../config/ball_holds.md)
+
 The ball hold device called (name) has just held additional ball(s).
 
 ## Keyword arguments
@@ -22,5 +24,3 @@ The number of new balls just held.
 #### `total_balls_held`:
 
 The current total number of balls this device has held.
-
-Event is posted by [ball_holds:](../config/ball_holds.md)

--- a/docs/events/ball_save_ball_save_disabled.md
+++ b/docs/events/ball_save_ball_save_disabled.md
@@ -2,7 +2,7 @@
 title: ball_save_(name)_disabled
 ---
 
-# ball_save_(name)_disabled
+# ball_save_(name)\_disabled
 
 
 --8<-- "event.md"

--- a/docs/events/ball_save_ball_save_disabled.md
+++ b/docs/events/ball_save_ball_save_disabled.md
@@ -11,4 +11,4 @@ Event is posted by [ball_saves:](../config/ball_saves.md)
 
 The ball save called (name) has just been disabled.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_save_ball_save_disabled.md
+++ b/docs/events/ball_save_ball_save_disabled.md
@@ -7,8 +7,8 @@ title: ball_save_(name)_disabled
 
 --8<-- "event.md"
 
+Event is posted by [ball_saves:](../config/ball_saves.md)
+
 The ball save called (name) has just been disabled.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [ball_saves:](../config/ball_saves.md)

--- a/docs/events/ball_save_ball_save_enabled.md
+++ b/docs/events/ball_save_ball_save_enabled.md
@@ -7,8 +7,8 @@ title: ball_save_(name)_enabled
 
 --8<-- "event.md"
 
+Event is posted by [ball_saves:](../config/ball_saves.md)
+
 The ball save called (name) has just been enabled.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [ball_saves:](../config/ball_saves.md)

--- a/docs/events/ball_save_ball_save_enabled.md
+++ b/docs/events/ball_save_ball_save_enabled.md
@@ -2,7 +2,7 @@
 title: ball_save_(name)_enabled
 ---
 
-# ball_save_(name)_enabled
+# ball_save_(name)\_enabled
 
 
 --8<-- "event.md"

--- a/docs/events/ball_save_ball_save_enabled.md
+++ b/docs/events/ball_save_ball_save_enabled.md
@@ -11,4 +11,4 @@ Event is posted by [ball_saves:](../config/ball_saves.md)
 
 The ball save called (name) has just been enabled.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_save_ball_save_grace_period.md
+++ b/docs/events/ball_save_ball_save_grace_period.md
@@ -7,8 +7,8 @@ title: ball_save_(name)_grace_period
 
 --8<-- "event.md"
 
+Event is posted by [ball_saves:](../config/ball_saves.md)
+
 The ball save called (name) has just entered its grace period time.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [ball_saves:](../config/ball_saves.md)

--- a/docs/events/ball_save_ball_save_grace_period.md
+++ b/docs/events/ball_save_ball_save_grace_period.md
@@ -11,4 +11,4 @@ Event is posted by [ball_saves:](../config/ball_saves.md)
 
 The ball save called (name) has just entered its grace period time.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_save_ball_save_grace_period.md
+++ b/docs/events/ball_save_ball_save_grace_period.md
@@ -2,7 +2,7 @@
 title: ball_save_(name)_grace_period
 ---
 
-# ball_save_(name)_grace_period
+# ball_save_(name)\_grace_period
 
 
 --8<-- "event.md"

--- a/docs/events/ball_save_ball_save_hurry_up.md
+++ b/docs/events/ball_save_ball_save_hurry_up.md
@@ -2,7 +2,7 @@
 title: ball_save_(name)_hurry_up
 ---
 
-# ball_save_(name)_hurry_up
+# ball_save_(name)\_hurry_up
 
 
 --8<-- "event.md"

--- a/docs/events/ball_save_ball_save_hurry_up.md
+++ b/docs/events/ball_save_ball_save_hurry_up.md
@@ -11,4 +11,4 @@ Event is posted by [ball_saves:](../config/ball_saves.md)
 
 The ball save called (name) has just entered its hurry up mode.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_save_ball_save_hurry_up.md
+++ b/docs/events/ball_save_ball_save_hurry_up.md
@@ -7,8 +7,8 @@ title: ball_save_(name)_hurry_up
 
 --8<-- "event.md"
 
+Event is posted by [ball_saves:](../config/ball_saves.md)
+
 The ball save called (name) has just entered its hurry up mode.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [ball_saves:](../config/ball_saves.md)

--- a/docs/events/ball_save_ball_save_saving_ball.md
+++ b/docs/events/ball_save_ball_save_saving_ball.md
@@ -7,6 +7,8 @@ title: ball_save_(name)_saving_ball
 
 --8<-- "event.md"
 
+Event is posted by [ball_saves:](../config/ball_saves.md)
+
 The ball save called (name) has just saved one (or more) balls.
 
 ## Keyword arguments
@@ -22,5 +24,3 @@ The number of balls this ball saver is saving.
 #### `early_save`:
 
 True if this is an early ball save.
-
-Event is posted by [ball_saves:](../config/ball_saves.md)

--- a/docs/events/ball_save_ball_save_saving_ball.md
+++ b/docs/events/ball_save_ball_save_saving_ball.md
@@ -2,7 +2,7 @@
 title: ball_save_(name)_saving_ball
 ---
 
-# ball_save_(name)_saving_ball
+# ball_save_(name)\_saving_ball
 
 
 --8<-- "event.md"
@@ -15,12 +15,12 @@ The ball save called (name) has just saved one (or more) balls.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of balls this ball saver is saving.
+The number of balls this ball saver is saving.
 
-`early_save`
+#### `early_save`:
 
-:   True if this is an early ball save.
+True if this is an early ball save.
 
 Event is posted by [ball_saves:](../config/ball_saves.md)

--- a/docs/events/ball_save_ball_save_timer_start.md
+++ b/docs/events/ball_save_ball_save_timer_start.md
@@ -11,4 +11,4 @@ Event is posted by [ball_saves:](../config/ball_saves.md)
 
 The ball save called (name) has just start its countdown timer.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_save_ball_save_timer_start.md
+++ b/docs/events/ball_save_ball_save_timer_start.md
@@ -7,8 +7,8 @@ title: ball_save_(name)_timer_start
 
 --8<-- "event.md"
 
+Event is posted by [ball_saves:](../config/ball_saves.md)
+
 The ball save called (name) has just start its countdown timer.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [ball_saves:](../config/ball_saves.md)

--- a/docs/events/ball_save_ball_save_timer_start.md
+++ b/docs/events/ball_save_ball_save_timer_start.md
@@ -2,7 +2,7 @@
 title: ball_save_(name)_timer_start
 ---
 
-# ball_save_(name)_timer_start
+# ball_save_(name)\_timer_start
 
 
 --8<-- "event.md"

--- a/docs/events/ball_save_multiball_add_a_ball_timer_start.md
+++ b/docs/events/ball_save_multiball_add_a_ball_timer_start.md
@@ -7,9 +7,9 @@ title: ball_save_(name)_add_a_ball_timer_start
 
 --8<-- "event.md"
 
+Event is posted by [multiballs:](../config/multiballs.md)
+
 The multiball add a ball ball save called (name) has just start its
 countdown timer.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [multiballs:](../config/multiballs.md)

--- a/docs/events/ball_save_multiball_add_a_ball_timer_start.md
+++ b/docs/events/ball_save_multiball_add_a_ball_timer_start.md
@@ -12,4 +12,4 @@ Event is posted by [multiballs:](../config/multiballs.md)
 The multiball add a ball ball save called (name) has just start its
 countdown timer.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_save_multiball_add_a_ball_timer_start.md
+++ b/docs/events/ball_save_multiball_add_a_ball_timer_start.md
@@ -2,7 +2,7 @@
 title: ball_save_(name)_add_a_ball_timer_start
 ---
 
-# ball_save_(name)_add_a_ball_timer_start
+# ball_save_(name)\_add_a_ball_timer_start
 
 
 --8<-- "event.md"

--- a/docs/events/ball_save_multiball_timer_start.md
+++ b/docs/events/ball_save_multiball_timer_start.md
@@ -7,9 +7,9 @@ title: ball_save_(name)_timer_start
 
 --8<-- "event.md"
 
+Event is posted by [multiballs:](../config/multiballs.md)
+
 The multiball ball save called (name) has just start its countdown
 timer.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [multiballs:](../config/multiballs.md)

--- a/docs/events/ball_save_multiball_timer_start.md
+++ b/docs/events/ball_save_multiball_timer_start.md
@@ -12,4 +12,4 @@ Event is posted by [multiballs:](../config/multiballs.md)
 The multiball ball save called (name) has just start its countdown
 timer.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_save_multiball_timer_start.md
+++ b/docs/events/ball_save_multiball_timer_start.md
@@ -2,7 +2,7 @@
 title: ball_save_(name)_timer_start
 ---
 
-# ball_save_(name)_timer_start
+# ball_save_(name)\_timer_start
 
 
 --8<-- "event.md"

--- a/docs/events/ball_search_failed.md
+++ b/docs/events/ball_search_failed.md
@@ -11,4 +11,4 @@ The ball search process has failed to locate a missing or stuck ball and
 has given up. This event will be posted immediately after the
 *ball_search_stopped* event.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_search_phase_num.md
+++ b/docs/events/ball_search_phase_num.md
@@ -15,6 +15,6 @@ The ball search phase (num) has started.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`iteration`
+#### `iteration`:
 
-:   Current iteration of phase (num)
+Current iteration of phase (num)

--- a/docs/events/ball_search_prevents_game_start.md
+++ b/docs/events/ball_search_prevents_game_start.md
@@ -12,4 +12,4 @@ and thus the game start has been blocked. This is a good event to use
 for a slide player to inform the player that the machine is looking for
 a missing ball.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_search_started.md
+++ b/docs/events/ball_search_started.md
@@ -9,4 +9,4 @@ title: ball_search_started
 
 The ball search process has been begun.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_search_stopped.md
+++ b/docs/events/ball_search_stopped.md
@@ -12,4 +12,4 @@ ball search stops, regardless of whether it found a ball or gave up. (If
 the ball search failed to find the ball, it will also post the
 *ball_search_failed* event.)
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_start_target.md
+++ b/docs/events/ball_start_target.md
@@ -18,8 +18,8 @@ This is a relay event.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`target`
+#### `target`:
 
-:   The name of the ball_device target where the ball will be ejected
-    to. Can be modified by a relay event handler to change the target
-    before the ball is ejected.
+The name of the ball_device target where the ball will be ejected
+to. Can be modified by a relay event handler to change the target
+before the ball is ejected.

--- a/docs/events/ball_started.md
+++ b/docs/events/ball_started.md
@@ -15,18 +15,18 @@ A new ball has started.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`ball`
+#### `ball`:
 
-:   The ball number
+The ball number
 
-`balls_remaining`
+#### `balls_remaining`:
 
-:   The number of balls left in the game (not including this one)
+The number of balls left in the game (not including this one)
 
-`is_extra_ball`
+#### `is_extra_ball`:
 
-:   True if this ball is an extra ball (default False)
+True if this ball is an extra ball (default False)
 
-`player`
+#### `player`:
 
-:   The player number
+The player number

--- a/docs/events/ball_starting.md
+++ b/docs/events/ball_starting.md
@@ -16,18 +16,18 @@ start until the queue is cleared.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`ball`
+#### `ball`:
 
-:   The ball number
+The ball number
 
-`balls_remaining`
+#### `balls_remaining`:
 
-:   The number of balls left in the game (not including this one)
+The number of balls left in the game (not including this one)
 
-`is_extra_ball`
+#### `is_extra_ball`:
 
-:   True if this ball is an extra ball (default False)
+True if this ball is an extra ball (default False)
 
-`player`
+#### `player`:
 
-:   The player number
+The player number

--- a/docs/events/ball_will_end.md
+++ b/docs/events/ball_will_end.md
@@ -10,4 +10,4 @@ title: ball_will_end
 The ball is about to end. This event is posted just before
 [ball_ending](ball_ending.md).
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/ball_will_start.md
+++ b/docs/events/ball_will_start.md
@@ -16,18 +16,18 @@ The ball is about to start. This event is posted just before
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`ball`
+#### `ball`:
 
-:   The ball number
+The ball number
 
-`balls_remaining`
+#### `balls_remaining`:
 
-:   The number of balls left in the game (not including this one)
+The number of balls left in the game (not including this one)
 
-`is_extra_ball`
+#### `is_extra_ball`:
 
-:   True if this ball is an extra ball (default False)
+True if this ball is an extra ball (default False)
 
-`player`
+#### `player`:
 
-:   The player number
+The player number

--- a/docs/events/balldevice_ball_device_ball_count_changed.md
+++ b/docs/events/balldevice_ball_device_ball_count_changed.md
@@ -7,6 +7,8 @@ title: balldevice_(name)_ball_count_changed
 
 --8<-- "event.md"
 
+Event is posted by [ball_devices:](../config/ball_devices.md)
+
 The ball count for device (name) just changed.
 
 This event may also be called without a change in some circumstances.
@@ -20,5 +22,3 @@ only respond to certain combinations of the arguments below.)
 #### `balls`:
 
 The number of new balls in this device.
-
-Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ball_count_changed.md
+++ b/docs/events/balldevice_ball_device_ball_count_changed.md
@@ -2,7 +2,7 @@
 title: balldevice_(name)_ball_count_changed
 ---
 
-# balldevice_(name)_ball_count_changed
+# balldevice_(name)\_ball_count_changed
 
 
 --8<-- "event.md"
@@ -17,8 +17,8 @@ This event may also be called without a change in some circumstances.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of new balls in this device.
+The number of new balls in this device.
 
 Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ball_eject_attempt.md
+++ b/docs/events/balldevice_ball_device_ball_eject_attempt.md
@@ -2,7 +2,7 @@
 title: balldevice_(name)_ball_eject_attempt
 ---
 
-# balldevice_(name)_ball_eject_attempt
+# balldevice_(name)\_ball_eject_attempt
 
 
 --8<-- "event.md"
@@ -17,24 +17,24 @@ until the queue is cleared.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of balls that are to be ejected.
+The number of balls that are to be ejected.
 
-`mechanical_eject`
+#### `mechanical_eject`:
 
-:   Boolean as to whether this is a mechanical eject.
+Boolean as to whether this is a mechanical eject.
 
-`num_attempts`
+#### `num_attempts`:
 
-:   How many eject attempts have been tried so far.
+How many eject attempts have been tried so far.
 
-`source`
+#### `source`:
 
-:   The source device that will be ejecting the balls.
+The source device that will be ejecting the balls.
 
-`target`
+#### `target`:
 
-:   The target ball device that will receive these balls.
+The target ball device that will receive these balls.
 
 Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ball_eject_attempt.md
+++ b/docs/events/balldevice_ball_device_ball_eject_attempt.md
@@ -7,6 +7,8 @@ title: balldevice_(name)_ball_eject_attempt
 
 --8<-- "event.md"
 
+Event is posted by [ball_devices:](../config/ball_devices.md)
+
 The ball device called (name) is attempting to eject a ball (or
 balls). This is a queue event. The eject will not actually be attempted
 until the queue is cleared.
@@ -36,5 +38,3 @@ The source device that will be ejecting the balls.
 #### `target`:
 
 The target ball device that will receive these balls.
-
-Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ball_eject_failed.md
+++ b/docs/events/balldevice_ball_device_ball_eject_failed.md
@@ -7,6 +7,8 @@ title: balldevice_(name)_ball_eject_failed
 
 --8<-- "event.md"
 
+Event is posted by [ball_devices:](../config/ball_devices.md)
+
 A ball (or balls) has failed to eject from the device (name).
 
 ## Keyword arguments
@@ -30,5 +32,3 @@ Boolean as to whether this eject will be retried.
 #### `target`:
 
 The target device that was supposed to receive the ejected balls.
-
-Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ball_eject_failed.md
+++ b/docs/events/balldevice_ball_device_ball_eject_failed.md
@@ -2,7 +2,7 @@
 title: balldevice_(name)_ball_eject_failed
 ---
 
-# balldevice_(name)_ball_eject_failed
+# balldevice_(name)\_ball_eject_failed
 
 
 --8<-- "event.md"
@@ -15,20 +15,20 @@ A ball (or balls) has failed to eject from the device (name).
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of balls that failed to eject.
+The number of balls that failed to eject.
 
-`num_attempts`
+#### `num_attempts`:
 
-:   How many attemps have been made to eject this ball (or balls).
+How many attemps have been made to eject this ball (or balls).
 
-`retry`
+#### `retry`:
 
-:   Boolean as to whether this eject will be retried.
+Boolean as to whether this eject will be retried.
 
-`target`
+#### `target`:
 
-:   The target device that was supposed to receive the ejected balls.
+The target device that was supposed to receive the ejected balls.
 
 Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ball_eject_success.md
+++ b/docs/events/balldevice_ball_device_ball_eject_success.md
@@ -2,7 +2,7 @@
 title: balldevice_(name)_ball_eject_success
 ---
 
-# balldevice_(name)_ball_eject_success
+# balldevice_(name)\_ball_eject_success
 
 
 --8<-- "event.md"
@@ -15,13 +15,13 @@ One or more balls has successfully ejected from the device called (name).
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of balls that have successfully ejected.
+The number of balls that have successfully ejected.
 
-`target`
+#### `target`:
 
-:   The target device that has received (or will be receiving) the
-    ejected ball(s).
+The target device that has received (or will be receiving) the
+ejected ball(s).
 
 Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ball_eject_success.md
+++ b/docs/events/balldevice_ball_device_ball_eject_success.md
@@ -7,6 +7,8 @@ title: balldevice_(name)_ball_eject_success
 
 --8<-- "event.md"
 
+Event is posted by [ball_devices:](../config/ball_devices.md)
+
 One or more balls has successfully ejected from the device called (name).
 
 ## Keyword arguments
@@ -23,5 +25,3 @@ The number of balls that have successfully ejected.
 
 The target device that has received (or will be receiving) the
 ejected ball(s).
-
-Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ball_enter.md
+++ b/docs/events/balldevice_ball_device_ball_enter.md
@@ -2,7 +2,7 @@
 title: balldevice_(name)_ball_enter
 ---
 
-# balldevice_(name)_ball_enter
+# balldevice_(name)\_ball_enter
 
 
 --8<-- "event.md"
@@ -22,12 +22,12 @@ available_balls of the device during this event.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`device`
+#### `device`:
 
-:   A reference to the ball device object that is posting this event.
+A reference to the ball device object that is posting this event.
 
-`unclaimed_balls`
+#### `unclaimed_balls`:
 
-:   The number of balls that have not yet been claimed.
+The number of balls that have not yet been claimed.
 
 Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ball_enter.md
+++ b/docs/events/balldevice_ball_device_ball_enter.md
@@ -7,6 +7,8 @@ title: balldevice_(name)_ball_enter
 
 --8<-- "event.md"
 
+Event is posted by [ball_devices:](../config/ball_devices.md)
+
 A ball (or balls) have just entered the ball device called (name).
 
 Note that this is a relay event based on the "unclaimed_balls" arg.
@@ -29,5 +31,3 @@ A reference to the ball device object that is posting this event.
 #### `unclaimed_balls`:
 
 The number of balls that have not yet been claimed.
-
-Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ball_entered.md
+++ b/docs/events/balldevice_ball_device_ball_entered.md
@@ -7,6 +7,8 @@ title: balldevice_(name)_ball_entered
 
 --8<-- "event.md"
 
+Event is posted by [ball_devices:](../config/ball_devices.md)
+
 A ball (or balls) have just entered the ball device called (name).
 
 The ball was also added to balls and available_balls of the device.
@@ -25,5 +27,3 @@ A reference to the ball device object that is posting this event.
 
 The number of new balls that have not been claimed (by locks or
 similar).
-
-Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ball_entered.md
+++ b/docs/events/balldevice_ball_device_ball_entered.md
@@ -2,7 +2,7 @@
 title: balldevice_(name)_ball_entered
 ---
 
-# balldevice_(name)_ball_entered
+# balldevice_(name)\_ball_entered
 
 
 --8<-- "event.md"
@@ -17,13 +17,13 @@ The ball was also added to balls and available_balls of the device.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`device`
+#### `device`:
 
-:   A reference to the ball device object that is posting this event.
+A reference to the ball device object that is posting this event.
 
-`new_balls`
+#### `new_balls`:
 
-:   The number of new balls that have not been claimed (by locks or
-    similar).
+The number of new balls that have not been claimed (by locks or
+similar).
 
 Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ball_entered.md
+++ b/docs/events/balldevice_ball_device_ball_entered.md
@@ -11,7 +11,7 @@ Event is posted by [ball_devices:](../config/ball_devices.md)
 
 A ball (or balls) have just entered the ball device called (name).
 
-The ball was also added to balls and available_balls of the device.
+The ball was also added to `balls` and `available_balls` of the device.
 
 ## Keyword arguments
 

--- a/docs/events/balldevice_ball_device_ball_missing.md
+++ b/docs/events/balldevice_ball_device_ball_missing.md
@@ -10,7 +10,7 @@ title: balldevice_(name)_ball_missing
 Event is posted by [ball_devices:](../config/ball_devices.md)
 
 The device (name) is missing a ball. Note this event is posted in
-addition to the generic *balldevice_ball_missing* event.
+addition to the generic *[balldevice_ball_missing](balldevice_ball_missing.md)* event.
 
 ## Keyword arguments
 

--- a/docs/events/balldevice_ball_device_ball_missing.md
+++ b/docs/events/balldevice_ball_device_ball_missing.md
@@ -7,6 +7,8 @@ title: balldevice_(name)_ball_missing
 
 --8<-- "event.md"
 
+Event is posted by [ball_devices:](../config/ball_devices.md)
+
 The device (name) is missing a ball. Note this event is posted in
 addition to the generic *balldevice_ball_missing* event.
 
@@ -19,5 +21,3 @@ only respond to certain combinations of the arguments below.)
 #### `balls`:
 
 The number of balls that are missing
-
-Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ball_missing.md
+++ b/docs/events/balldevice_ball_device_ball_missing.md
@@ -2,7 +2,7 @@
 title: balldevice_(name)_ball_missing
 ---
 
-# balldevice_(name)_ball_missing
+# balldevice_(name)\_ball_missing
 
 
 --8<-- "event.md"
@@ -16,8 +16,8 @@ addition to the generic *balldevice_ball_missing* event.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of balls that are missing
+The number of balls that are missing
 
 Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_broken.md
+++ b/docs/events/balldevice_ball_device_broken.md
@@ -11,4 +11,4 @@ Event is posted by [ball_devices:](../config/ball_devices.md)
 
 The ball device called (name) is broken and will no longer operate.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/balldevice_ball_device_broken.md
+++ b/docs/events/balldevice_ball_device_broken.md
@@ -2,7 +2,7 @@
 title: balldevice_(name)_broken
 ---
 
-# balldevice_(name)_broken
+# balldevice_(name)\_broken
 
 
 --8<-- "event.md"

--- a/docs/events/balldevice_ball_device_broken.md
+++ b/docs/events/balldevice_ball_device_broken.md
@@ -7,8 +7,8 @@ title: balldevice_(name)_broken
 
 --8<-- "event.md"
 
+Event is posted by [ball_devices:](../config/ball_devices.md)
+
 The ball device called (name) is broken and will no longer operate.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ejecting_ball.md
+++ b/docs/events/balldevice_ball_device_ejecting_ball.md
@@ -2,7 +2,7 @@
 title: balldevice_(name)_ejecting_ball
 ---
 
-# balldevice_(name)_ejecting_ball
+# balldevice_(name)\_ejecting_ball
 
 
 --8<-- "event.md"
@@ -15,24 +15,24 @@ The ball device called (name) is ejecting a ball right now.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of balls that are to be ejected.
+The number of balls that are to be ejected.
 
-`mechanical_eject`
+#### `mechanical_eject`:
 
-:   Boolean as to whether this is a mechanical eject.
+Boolean as to whether this is a mechanical eject.
 
-`num_attempts`
+#### `num_attempts`:
 
-:   How many eject attempts have been tried so far.
+How many eject attempts have been tried so far.
 
-`source`
+#### `source`:
 
-:   The source device that will be ejecting the balls.
+The source device that will be ejecting the balls.
 
-`target`
+#### `target`:
 
-:   The target ball device that will receive these balls.
+The target ball device that will receive these balls.
 
 Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_device_ejecting_ball.md
+++ b/docs/events/balldevice_ball_device_ejecting_ball.md
@@ -7,6 +7,8 @@ title: balldevice_(name)_ejecting_ball
 
 --8<-- "event.md"
 
+Event is posted by [ball_devices:](../config/ball_devices.md)
+
 The ball device called (name) is ejecting a ball right now.
 
 ## Keyword arguments
@@ -34,5 +36,3 @@ The source device that will be ejecting the balls.
 #### `target`:
 
 The target ball device that will receive these balls.
-
-Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_missing.md
+++ b/docs/events/balldevice_ball_missing.md
@@ -15,12 +15,12 @@ A ball is missing from a device.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of balls that are missing
+The number of balls that are missing
 
-`name`
+#### `name`:
 
-:   Name of device which lost the ball
+Name of device which lost the ball
 
 Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_ball_missing.md
+++ b/docs/events/balldevice_ball_missing.md
@@ -7,6 +7,8 @@ title: balldevice_ball_missing
 
 --8<-- "event.md"
 
+Event is posted by [ball_devices:](../config/ball_devices.md)
+
 A ball is missing from a device.
 
 ## Keyword arguments
@@ -22,5 +24,3 @@ The number of balls that are missing
 #### `name`:
 
 Name of device which lost the ball
-
-Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_balls_available.md
+++ b/docs/events/balldevice_balls_available.md
@@ -7,8 +7,8 @@ title: balldevice_balls_available
 
 --8<-- "event.md"
 
+Event is posted by [ball_devices:](../config/ball_devices.md)
+
 A device has balls available to be ejected.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_balls_available.md
+++ b/docs/events/balldevice_balls_available.md
@@ -11,4 +11,4 @@ Event is posted by [ball_devices:](../config/ball_devices.md)
 
 A device has balls available to be ejected.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/balldevice_captured_from_captures_from.md
+++ b/docs/events/balldevice_captured_from_captures_from.md
@@ -7,6 +7,8 @@ title: balldevice_captured_from_(captures_from)
 
 --8<-- "event.md"
 
+Event is posted by [ball_devices:](../config/ball_devices.md)
+
 A ball device has just captured a ball from the device called
 (captures_from)
 
@@ -19,5 +21,3 @@ only respond to certain combinations of the arguments below.)
 #### `balls`:
 
 The number of balls that were captured.
-
-Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balldevice_captured_from_captures_from.md
+++ b/docs/events/balldevice_captured_from_captures_from.md
@@ -16,8 +16,8 @@ A ball device has just captured a ball from the device called
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of balls that were captured.
+The number of balls that were captured.
 
 Event is posted by [ball_devices:](../config/ball_devices.md)

--- a/docs/events/balls_in_play.md
+++ b/docs/events/balls_in_play.md
@@ -21,6 +21,6 @@ play even though there are no balls on the playfield.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of ball(s) in play.
+The number of ball(s) in play.

--- a/docs/events/bcp_clients_connected.md
+++ b/docs/events/bcp_clients_connected.md
@@ -9,4 +9,4 @@ title: bcp_clients_connected
 
 All BCP outgoing BCP connections have been made.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/bcp_connection_attempt.md
+++ b/docs/events/bcp_connection_attempt.md
@@ -15,14 +15,14 @@ MPF is attempting to make a BCP connection.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`host`
+#### `host`:
 
-:   The host name MPF is attempting to connect to.
+The host name MPF is attempting to connect to.
 
-`name`
+#### `name`:
 
-:   The name of the connection.
+The name of the connection.
 
-`port`
+#### `port`:
 
-:   The TCP port MPF is attempting to connect to
+The TCP port MPF is attempting to connect to

--- a/docs/events/bonus_multiplier.md
+++ b/docs/events/bonus_multiplier.md
@@ -16,6 +16,6 @@ screen. If the bonus multiplier is 1, then this event is skipped.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`multiplier`
+#### `multiplier`:
 
-:   The numeric value of the bonus multiplier.
+The numeric value of the bonus multiplier.

--- a/docs/events/bonus_start.md
+++ b/docs/events/bonus_start.md
@@ -11,4 +11,4 @@ The end-of-ball bonus is starting. You can use this event in your slide
 player to trigger the bonus intro slide. If the game has tilted, this
 event will not be posted.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/bonus_subtotal.md
+++ b/docs/events/bonus_subtotal.md
@@ -19,6 +19,6 @@ so if the bonus multiplier is 1, then this event will be skipped.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`score`
+#### `score`:
 
-:   The score of the bonus (so far)
+The score of the bonus (so far)

--- a/docs/events/cancel_ball_search.md
+++ b/docs/events/cancel_ball_search.md
@@ -10,4 +10,4 @@ title: cancel_ball_search
 This event will cancel all running ball searches and mark the balls as
 lost. This is only a handler so all you have to do is to post the event.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/clear.md
+++ b/docs/events/clear.md
@@ -16,6 +16,6 @@ on the key passed. Typically posted when a show or mode ends.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`key`
+#### `key`:
 
-:   string name of the configs to clear
+String name of the configs to clear

--- a/docs/events/client_connected.md
+++ b/docs/events/client_connected.md
@@ -15,10 +15,10 @@ Posted on the MPF-MC only when a BCP client has connected.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`address`
+#### `address`:
 
-:   The IP address of the client that connected.
+The IP address of the client that connected.
 
-`port`
+#### `port`:
 
-:   The port the client connected on.
+The port the client connected on.

--- a/docs/events/client_disconnected.md
+++ b/docs/events/client_disconnected.md
@@ -19,10 +19,10 @@ This is useful for triggering a slide notifying of the disconnect.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`host`
+#### `host`:
 
-:   The hostname or IP address that the socket is listening on.
+The hostname or IP address that the socket is listening on.
 
-`port`
+#### `port`:
 
-:   The port that the socket is listening on.
+The port that the socket is listening on.

--- a/docs/events/collecting_balls.md
+++ b/docs/events/collecting_balls.md
@@ -10,4 +10,4 @@ title: collecting_balls
 Posted by the ball controller when it starts the collecting balls
 process.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/collecting_balls_complete.md
+++ b/docs/events/collecting_balls_complete.md
@@ -10,4 +10,4 @@ title: collecting_balls_complete
 Posted by the ball controller when it has finished the collecting balls
 process.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/combo_switch_both.md
+++ b/docs/events/combo_switch_both.md
@@ -7,15 +7,16 @@ title: (combo_switch_name)_both
 
 --8<-- "event.md"
 
+Event is posted by [combo_switches:](../config/combo_switches.md)
+
 Combo switch named (combo_switch_name) changed to state both.
 
 A switch from group 1 and group 2 are both active at the same time,
 having been pressed within the `max_offset_time:` and being active for
 at least the `hold_time:`.
 
-*This event does not have any keyword arguments*
-
-Event is posted by [combo_switches:](../config/combo_switches.md)
-
 The event name can be changed by using the "events_when_both:"
 attribute.
+
+*This event does not have any keyword arguments*
+

--- a/docs/events/combo_switch_both.md
+++ b/docs/events/combo_switch_both.md
@@ -2,7 +2,7 @@
 title: (combo_switch_name)_both
 ---
 
-# (combo_switch_name)_both
+# (combo_switch_name)\_both
 
 
 --8<-- "event.md"

--- a/docs/events/combo_switch_both.md
+++ b/docs/events/combo_switch_both.md
@@ -18,5 +18,5 @@ at least the `hold_time:`.
 The event name can be changed by using the "events_when_both:"
 attribute.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"
 

--- a/docs/events/combo_switch_both.md
+++ b/docs/events/combo_switch_both.md
@@ -15,7 +15,7 @@ A switch from group 1 and group 2 are both active at the same time,
 having been pressed within the `max_offset_time:` and being active for
 at least the `hold_time:`.
 
-The event name can be changed by using the "events_when_both:"
+The event name can be changed by using the `events_when_both:`
 attribute.
 
 --8<-- "event_no_keywords_notice.md"

--- a/docs/events/combo_switch_inactive.md
+++ b/docs/events/combo_switch_inactive.md
@@ -7,13 +7,13 @@ title: (combo_switch_name)_inactive
 
 --8<-- "event.md"
 
+Event is posted by [combo_switches:](../config/combo_switches.md)
+
 Combo switch named (combo_switch_name) changed to state inactive.
 
 Both switches are inactive.
 
-*This event does not have any keyword arguments*
-
-Event is posted by [combo_switches:](../config/combo_switches.md)
-
 The event name can be changed by using the "events_when_inactive:"
 attribute.
+
+*This event does not have any keyword arguments*

--- a/docs/events/combo_switch_inactive.md
+++ b/docs/events/combo_switch_inactive.md
@@ -16,4 +16,4 @@ Both switches are inactive.
 The event name can be changed by using the "events_when_inactive:"
 attribute.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/combo_switch_inactive.md
+++ b/docs/events/combo_switch_inactive.md
@@ -2,7 +2,7 @@
 title: (combo_switch_name)_inactive
 ---
 
-# (combo_switch_name)_inactive
+# (combo_switch_name)\_inactive
 
 
 --8<-- "event.md"

--- a/docs/events/combo_switch_inactive.md
+++ b/docs/events/combo_switch_inactive.md
@@ -13,7 +13,7 @@ Combo switch named (combo_switch_name) changed to state inactive.
 
 Both switches are inactive.
 
-The event name can be changed by using the "events_when_inactive:"
+The event name can be changed by using the `events_when_inactive:`
 attribute.
 
 --8<-- "event_no_keywords_notice.md"

--- a/docs/events/combo_switch_one.md
+++ b/docs/events/combo_switch_one.md
@@ -7,14 +7,14 @@ title: (combo_switch_name)_one
 
 --8<-- "event.md"
 
+Event is posted by [combo_switches:](../config/combo_switches.md)
+
 Combo switch named (combo_switch_name) changed to state one.
 
 Either switch 1 or switch 2 has been released for at least the
 `release_time:` but the other switch is still active.
 
-*This event does not have any keyword arguments*
-
-Event is posted by [combo_switches:](../config/combo_switches.md)
-
 The event name can be changed by using the "events_when_one:"
 attribute.
+
+*This event does not have any keyword arguments*

--- a/docs/events/combo_switch_one.md
+++ b/docs/events/combo_switch_one.md
@@ -2,7 +2,7 @@
 title: (combo_switch_name)_one
 ---
 
-# (combo_switch_name)_one
+# (combo_switch_name)\_one
 
 
 --8<-- "event.md"

--- a/docs/events/combo_switch_one.md
+++ b/docs/events/combo_switch_one.md
@@ -14,7 +14,7 @@ Combo switch named (combo_switch_name) changed to state one.
 Either switch 1 or switch 2 has been released for at least the
 `release_time:` but the other switch is still active.
 
-The event name can be changed by using the "events_when_one:"
+The event name can be changed by using the `events_when_one:`
 attribute.
 
 --8<-- "event_no_keywords_notice.md"

--- a/docs/events/combo_switch_one.md
+++ b/docs/events/combo_switch_one.md
@@ -17,4 +17,4 @@ Either switch 1 or switch 2 has been released for at least the
 The event name can be changed by using the "events_when_one:"
 attribute.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/combo_switch_switches_1.md
+++ b/docs/events/combo_switch_switches_1.md
@@ -7,15 +7,15 @@ title: (combo_switch_name)_switches_1
 
 --8<-- "event.md"
 
+Event is posted by [combo_switches:](../config/combo_switches.md)
+
 Combo switch named (combo_switch_name) changed to state switches_1.
 
 Only switches_1 is active. max_offset_time has passed and this hit
 cannot become both later on. Only emited when `max_offset_time:` is
 defined.
 
-*This event does not have any keyword arguments*
-
-Event is posted by [combo_switches:](../config/combo_switches.md)
-
 The event name can be changed by using the "events_when_switches_1:"
 attribute.
+
+*This event does not have any keyword arguments*

--- a/docs/events/combo_switch_switches_1.md
+++ b/docs/events/combo_switch_switches_1.md
@@ -2,7 +2,7 @@
 title: (combo_switch_name)_switches_1
 ---
 
-# (combo_switch_name)_switches_1
+# (combo_switch_name)\_switches_1
 
 
 --8<-- "event.md"

--- a/docs/events/combo_switch_switches_1.md
+++ b/docs/events/combo_switch_switches_1.md
@@ -18,4 +18,4 @@ defined.
 The event name can be changed by using the "events_when_switches_1:"
 attribute.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/combo_switch_switches_1.md
+++ b/docs/events/combo_switch_switches_1.md
@@ -15,7 +15,7 @@ Only switches_1 is active. max_offset_time has passed and this hit
 cannot become both later on. Only emited when `max_offset_time:` is
 defined.
 
-The event name can be changed by using the "events_when_switches_1:"
+The event name can be changed by using the `events_when_switches_1:`
 attribute.
 
 --8<-- "event_no_keywords_notice.md"

--- a/docs/events/combo_switch_switches_2.md
+++ b/docs/events/combo_switch_switches_2.md
@@ -2,7 +2,7 @@
 title: (combo_switch_name)_switches_2
 ---
 
-# (combo_switch_name)_switches_2
+# (combo_switch_name)\_switches_2
 
 
 --8<-- "event.md"

--- a/docs/events/combo_switch_switches_2.md
+++ b/docs/events/combo_switch_switches_2.md
@@ -15,7 +15,7 @@ Only switches_2 is active. max_offset_time has passed and this hit
 cannot become both later on. Only emited when `max_offset_time:` is
 defined.
 
-The event name can be changed by using the "events_when_switches_2:"
+The event name can be changed by using the `events_when_switches_2:`
 attribute.
 
 --8<-- "event_no_keywords_notice.md"

--- a/docs/events/combo_switch_switches_2.md
+++ b/docs/events/combo_switch_switches_2.md
@@ -7,15 +7,16 @@ title: (combo_switch_name)_switches_2
 
 --8<-- "event.md"
 
+Event is posted by [combo_switches:](../config/combo_switches.md)
+
 Combo switch named (combo_switch_name) changed to state switches_2.
 
 Only switches_2 is active. max_offset_time has passed and this hit
 cannot become both later on. Only emited when `max_offset_time:` is
 defined.
 
-*This event does not have any keyword arguments*
-
-Event is posted by [combo_switches:](../config/combo_switches.md)
-
 The event name can be changed by using the "events_when_switches_2:"
 attribute.
+
+*This event does not have any keyword arguments*
+

--- a/docs/events/combo_switch_switches_2.md
+++ b/docs/events/combo_switch_switches_2.md
@@ -18,5 +18,5 @@ defined.
 The event name can be changed by using the "events_when_switches_2:"
 attribute.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"
 

--- a/docs/events/credits_added.md
+++ b/docs/events/credits_added.md
@@ -9,4 +9,4 @@ title: credits_added
 
 Credits (or partial credits) have just been added to the machine.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/display_display_initialized.md
+++ b/docs/events/display_display_initialized.md
@@ -17,4 +17,4 @@ This event is part of the MPF-MC boot process and is not particularly
 useful for game developers. If you want to show a "boot" slide as
 early as possible, use the *mc_ready* event.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/display_display_initialized.md
+++ b/docs/events/display_display_initialized.md
@@ -2,7 +2,7 @@
 title: display_(name)_initialized
 ---
 
-# display_(name)_initialized
+# display_(name)\_initialized
 
 
 *MPF-MC Event*

--- a/docs/events/display_display_initialized.md
+++ b/docs/events/display_display_initialized.md
@@ -7,6 +7,8 @@ title: display_(name)_initialized
 
 *MPF-MC Event*
 
+Event is posted by [displays:](../config/displays.md)
+
 The display called (name) has been initialized. This event is generated
 in the MC, so it won't be sent to MPF if the MC is started up and ready
 first.
@@ -16,5 +18,3 @@ useful for game developers. If you want to show a "boot" slide as
 early as possible, use the *mc_ready* event.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [displays:](../config/displays.md)

--- a/docs/events/display_display_ready.md
+++ b/docs/events/display_display_ready.md
@@ -21,4 +21,4 @@ MPF-MC and will not exist on the MPF side. So you can use this event for
 slide_player, widget_player, etc., but not to start shows or other
 things controlled by MPF.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/display_display_ready.md
+++ b/docs/events/display_display_ready.md
@@ -2,7 +2,7 @@
 title: display_(name)_ready
 ---
 
-# display_(name)_ready
+# display_(name)\_ready
 
 
 *MPF-MC Event*

--- a/docs/events/display_display_ready.md
+++ b/docs/events/display_display_ready.md
@@ -7,6 +7,8 @@ title: display_(name)_ready
 
 *MPF-MC Event*
 
+Event is posted by [displays:](../config/displays.md)
+
 The display target called (name) is now ready and available to show
 slides. This event is useful with display widgets where you want to add
 a display to an existing slide which shows some content, but you need to
@@ -20,5 +22,3 @@ slide_player, widget_player, etc., but not to start shows or other
 things controlled by MPF.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [displays:](../config/displays.md)

--- a/docs/events/displays_initialized.md
+++ b/docs/events/displays_initialized.md
@@ -23,4 +23,4 @@ exist on the MPF side of things.
 Also note that if you're using a media controller other than the MPF-MC
 (such as the Unity 3D backbox controller), then this event won't exist.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/diverter_diverter_activating.md
+++ b/docs/events/diverter_diverter_activating.md
@@ -12,4 +12,4 @@ Event is posted by [diverters:](../config/diverters.md)
 The diverter called (name) is activating itself, which means it's
 physically pulsing or holding the coil to move.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/diverter_diverter_activating.md
+++ b/docs/events/diverter_diverter_activating.md
@@ -7,9 +7,9 @@ title: diverter_(name)_activating
 
 --8<-- "event.md"
 
+Event is posted by [diverters:](../config/diverters.md)
+
 The diverter called (name) is activating itself, which means it's
 physically pulsing or holding the coil to move.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [diverters:](../config/diverters.md)

--- a/docs/events/diverter_diverter_activating.md
+++ b/docs/events/diverter_diverter_activating.md
@@ -2,7 +2,7 @@
 title: diverter_(name)_activating
 ---
 
-# diverter_(name)_activating
+# diverter_(name)\_activating
 
 
 --8<-- "event.md"

--- a/docs/events/diverter_diverter_deactivating.md
+++ b/docs/events/diverter_diverter_deactivating.md
@@ -11,4 +11,4 @@ Event is posted by [diverters:](../config/diverters.md)
 
 The diverter called (name) is deativating itself.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/diverter_diverter_deactivating.md
+++ b/docs/events/diverter_diverter_deactivating.md
@@ -2,7 +2,7 @@
 title: diverter_(name)_deactivating
 ---
 
-# diverter_(name)_deactivating
+# diverter_(name)\_deactivating
 
 
 --8<-- "event.md"

--- a/docs/events/diverter_diverter_deactivating.md
+++ b/docs/events/diverter_diverter_deactivating.md
@@ -7,8 +7,8 @@ title: diverter_(name)_deactivating
 
 --8<-- "event.md"
 
+Event is posted by [diverters:](../config/diverters.md)
+
 The diverter called (name) is deativating itself.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [diverters:](../config/diverters.md)

--- a/docs/events/diverter_diverter_disabling.md
+++ b/docs/events/diverter_diverter_disabling.md
@@ -7,6 +7,8 @@ title: diverter_(name)_disabling
 
 --8<-- "event.md"
 
+Event is posted by [diverters:](../config/diverters.md)
+
 The diverter called (name) is disabling itself. Note that if this
 diverter has `activation_switches:` configured, it will not physically
 deactivate now, instead deactivating based on switch hits and timing.
@@ -23,5 +25,3 @@ only respond to certain combinations of the arguments below.)
 Boolean which indicates whether this diverter disabled itself
 automatically for the purpose of routing balls to their proper
 location(s).
-
-Event is posted by [diverters:](../config/diverters.md)

--- a/docs/events/diverter_diverter_disabling.md
+++ b/docs/events/diverter_diverter_disabling.md
@@ -2,7 +2,7 @@
 title: diverter_(name)_disabling
 ---
 
-# diverter_(name)_disabling
+# diverter_(name)\_disabling
 
 
 --8<-- "event.md"
@@ -18,10 +18,10 @@ Otherwise this diverter will deactivate immediately.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`auto`
+#### `auto`:
 
-:   Boolean which indicates whether this diverter disabled itself
-    automatically for the purpose of routing balls to their proper
-    location(s).
+Boolean which indicates whether this diverter disabled itself
+automatically for the purpose of routing balls to their proper
+location(s).
 
 Event is posted by [diverters:](../config/diverters.md)

--- a/docs/events/diverter_diverter_enabling.md
+++ b/docs/events/diverter_diverter_enabling.md
@@ -7,6 +7,8 @@ title: diverter_(name)_enabling
 
 --8<-- "event.md"
 
+Event is posted by [diverters:](../config/diverters.md)
+
 The diverter called (name) is enabling itself. Note that if this
 diverter has `activation_switches:` configured, it will not physically
 activate until one of those switches is hit. Otherwise this diverter
@@ -23,5 +25,3 @@ only respond to certain combinations of the arguments below.)
 Boolean which indicates whether this diverter enabled itself
 automatically for the purpose of routing balls to their proper
 location(s).
-
-Event is posted by [diverters:](../config/diverters.md)

--- a/docs/events/diverter_diverter_enabling.md
+++ b/docs/events/diverter_diverter_enabling.md
@@ -2,7 +2,7 @@
 title: diverter_(name)_enabling
 ---
 
-# diverter_(name)_enabling
+# diverter_(name)\_enabling
 
 
 --8<-- "event.md"
@@ -18,10 +18,10 @@ will activate immediately.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`auto`
+#### `auto`:
 
-:   Boolean which indicates whether this diverter enabled itself
-    automatically for the purpose of routing balls to their proper
-    location(s).
+Boolean which indicates whether this diverter enabled itself
+automatically for the purpose of routing balls to their proper
+location(s).
 
 Event is posted by [diverters:](../config/diverters.md)

--- a/docs/events/drop_target_bank_drop_target_bank_down.md
+++ b/docs/events/drop_target_bank_drop_target_bank_down.md
@@ -2,7 +2,7 @@
 title: drop_target_bank_(name)_down
 ---
 
-# drop_target_bank_(name)_down
+# drop_target_bank_(name)\_down
 
 
 --8<-- "event.md"

--- a/docs/events/drop_target_bank_drop_target_bank_down.md
+++ b/docs/events/drop_target_bank_drop_target_bank_down.md
@@ -7,10 +7,10 @@ title: drop_target_bank_(name)_down
 
 --8<-- "event.md"
 
+Event is posted by [drop_target_banks:](../config/drop_target_banks.md)
+
 Every drop target in the drop target bank called (name) is now in the
 "down" state. This event is only posted once, when all the drop
 targets are down.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [drop_target_banks:](../config/drop_target_banks.md)

--- a/docs/events/drop_target_bank_drop_target_bank_down.md
+++ b/docs/events/drop_target_bank_drop_target_bank_down.md
@@ -13,4 +13,4 @@ Every drop target in the drop target bank called (name) is now in the
 "down" state. This event is only posted once, when all the drop
 targets are down.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/drop_target_bank_drop_target_bank_mixed.md
+++ b/docs/events/drop_target_bank_drop_target_bank_mixed.md
@@ -7,11 +7,11 @@ title: drop_target_bank_(name)_mixed
 
 --8<-- "event.md"
 
+Event is posted by [drop_target_banks:](../config/drop_target_banks.md)
+
 The drop targets in the drop target bank (name) are in a "mixed"
 state, meaning that they're not all down or not all up. This event is
 posted every time a member drop target changes but the overall bank is
 not not complete.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [drop_target_banks:](../config/drop_target_banks.md)

--- a/docs/events/drop_target_bank_drop_target_bank_mixed.md
+++ b/docs/events/drop_target_bank_drop_target_bank_mixed.md
@@ -2,7 +2,7 @@
 title: drop_target_bank_(name)_mixed
 ---
 
-# drop_target_bank_(name)_mixed
+# drop_target_bank_(name)\_mixed
 
 
 --8<-- "event.md"

--- a/docs/events/drop_target_bank_drop_target_bank_mixed.md
+++ b/docs/events/drop_target_bank_drop_target_bank_mixed.md
@@ -14,4 +14,4 @@ state, meaning that they're not all down or not all up. This event is
 posted every time a member drop target changes but the overall bank is
 not not complete.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/drop_target_bank_drop_target_bank_up.md
+++ b/docs/events/drop_target_bank_drop_target_bank_up.md
@@ -7,10 +7,10 @@ title: drop_target_bank_(name)_up
 
 --8<-- "event.md"
 
+Event is posted by [drop_target_banks:](../config/drop_target_banks.md)
+
 Every drop target in the drop target bank called (name) is now in the
 "up" state. This event is only posted once, when all the drop targets
 are up.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [drop_target_banks:](../config/drop_target_banks.md)

--- a/docs/events/drop_target_bank_drop_target_bank_up.md
+++ b/docs/events/drop_target_bank_drop_target_bank_up.md
@@ -2,7 +2,7 @@
 title: drop_target_bank_(name)_up
 ---
 
-# drop_target_bank_(name)_up
+# drop_target_bank_(name)\_up
 
 
 --8<-- "event.md"

--- a/docs/events/drop_target_bank_drop_target_bank_up.md
+++ b/docs/events/drop_target_bank_drop_target_bank_up.md
@@ -13,4 +13,4 @@ Every drop target in the drop target bank called (name) is now in the
 "up" state. This event is only posted once, when all the drop targets
 are up.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/drop_target_drop_target_down.md
+++ b/docs/events/drop_target_drop_target_down.md
@@ -2,7 +2,7 @@
 title: drop_target_(name)_down
 ---
 
-# drop_target_(name)_down
+# drop_target_(name)\_down
 
 
 --8<-- "event.md"

--- a/docs/events/drop_target_drop_target_down.md
+++ b/docs/events/drop_target_drop_target_down.md
@@ -7,8 +7,8 @@ title: drop_target_(name)_down
 
 --8<-- "event.md"
 
+Event is posted by [drop_targets:](../config/drop_targets.md)
+
 The drop target with the (name) has just changed to the "down" state.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [drop_targets:](../config/drop_targets.md)

--- a/docs/events/drop_target_drop_target_down.md
+++ b/docs/events/drop_target_drop_target_down.md
@@ -11,4 +11,4 @@ Event is posted by [drop_targets:](../config/drop_targets.md)
 
 The drop target with the (name) has just changed to the "down" state.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/drop_target_drop_target_up.md
+++ b/docs/events/drop_target_drop_target_up.md
@@ -11,4 +11,4 @@ Event is posted by [drop_targets:](../config/drop_targets.md)
 
 The drop target (name) has just changed to the "up" state.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/drop_target_drop_target_up.md
+++ b/docs/events/drop_target_drop_target_up.md
@@ -2,7 +2,7 @@
 title: drop_target_(name)_up
 ---
 
-# drop_target_(name)_up
+# drop_target_(name)\_up
 
 
 --8<-- "event.md"

--- a/docs/events/drop_target_drop_target_up.md
+++ b/docs/events/drop_target_drop_target_up.md
@@ -7,8 +7,8 @@ title: drop_target_(name)_up
 
 --8<-- "event.md"
 
+Event is posted by [drop_targets:](../config/drop_targets.md)
+
 The drop target (name) has just changed to the "up" state.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [drop_targets:](../config/drop_targets.md)

--- a/docs/events/enabling_credit_play.md
+++ b/docs/events/enabling_credit_play.md
@@ -11,4 +11,4 @@ The game is no longer on free play. Credits are required to start a
 game. This event is also posted on MPF boot if the credits mode is
 enabled and the game is not set to free play.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/enabling_free_play.md
+++ b/docs/events/enabling_free_play.md
@@ -11,4 +11,4 @@ Credits are no longer required to start a game. This event is also
 posted on MPF boot if the credits mode is enabled and the game is set to
 free play.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/extra_ball_award_disabled.md
+++ b/docs/events/extra_ball_award_disabled.md
@@ -11,4 +11,4 @@ Event is posted by [extra_balls:](../config/extra_balls.md)
 
 The award for an extra ball has just been disabled.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/extra_ball_award_disabled.md
+++ b/docs/events/extra_ball_award_disabled.md
@@ -7,8 +7,8 @@ title: extra_ball_award_disabled
 
 --8<-- "event.md"
 
+Event is posted by [extra_balls:](../config/extra_balls.md)
+
 The award for an extra ball has just been disabled.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [extra_balls:](../config/extra_balls.md)

--- a/docs/events/extra_ball_awarded.md
+++ b/docs/events/extra_ball_awarded.md
@@ -7,8 +7,8 @@ title: extra_ball_awarded
 
 --8<-- "event.md"
 
+Event is posted by [extra_balls:](../config/extra_balls.md)
+
 An extra ball has just been awarded.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [extra_balls:](../config/extra_balls.md)

--- a/docs/events/extra_ball_awarded.md
+++ b/docs/events/extra_ball_awarded.md
@@ -11,4 +11,4 @@ Event is posted by [extra_balls:](../config/extra_balls.md)
 
 An extra ball has just been awarded.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/extra_ball_extra_ball_award_disabled.md
+++ b/docs/events/extra_ball_extra_ball_award_disabled.md
@@ -2,7 +2,7 @@
 title: extra_ball_(name)_award_disabled
 ---
 
-# extra_ball_(name)_award_disabled
+# extra_ball_(name)\_award_disabled
 
 
 --8<-- "event.md"

--- a/docs/events/extra_ball_extra_ball_award_disabled.md
+++ b/docs/events/extra_ball_extra_ball_award_disabled.md
@@ -7,8 +7,8 @@ title: extra_ball_(name)_award_disabled
 
 --8<-- "event.md"
 
+Event is posted by [extra_balls:](../config/extra_balls.md)
+
 The award for the extra ball called (name) has just been disabled.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [extra_balls:](../config/extra_balls.md)

--- a/docs/events/extra_ball_extra_ball_award_disabled.md
+++ b/docs/events/extra_ball_extra_ball_award_disabled.md
@@ -11,4 +11,4 @@ Event is posted by [extra_balls:](../config/extra_balls.md)
 
 The award for the extra ball called (name) has just been disabled.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/extra_ball_extra_ball_awarded.md
+++ b/docs/events/extra_ball_extra_ball_awarded.md
@@ -2,7 +2,7 @@
 title: extra_ball_(name)_awarded
 ---
 
-# extra_ball_(name)_awarded
+# extra_ball_(name)\_awarded
 
 
 --8<-- "event.md"

--- a/docs/events/extra_ball_extra_ball_awarded.md
+++ b/docs/events/extra_ball_extra_ball_awarded.md
@@ -11,4 +11,4 @@ Event is posted by [extra_balls:](../config/extra_balls.md)
 
 The extra ball called (name) has just been awarded.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/extra_ball_extra_ball_awarded.md
+++ b/docs/events/extra_ball_extra_ball_awarded.md
@@ -7,8 +7,8 @@ title: extra_ball_(name)_awarded
 
 --8<-- "event.md"
 
+Event is posted by [extra_balls:](../config/extra_balls.md)
+
 The extra ball called (name) has just been awarded.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [extra_balls:](../config/extra_balls.md)

--- a/docs/events/extra_ball_extra_ball_lit.md
+++ b/docs/events/extra_ball_extra_ball_lit.md
@@ -7,8 +7,8 @@ title: extra_ball_(name)_lit
 
 --8<-- "event.md"
 
+Event is posted by [extra_balls:](../config/extra_balls.md)
+
 The extra ball called (name) has just been lit.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [extra_balls:](../config/extra_balls.md)

--- a/docs/events/extra_ball_extra_ball_lit.md
+++ b/docs/events/extra_ball_extra_ball_lit.md
@@ -2,7 +2,7 @@
 title: extra_ball_(name)_lit
 ---
 
-# extra_ball_(name)_lit
+# extra_ball_(name)\_lit
 
 
 --8<-- "event.md"

--- a/docs/events/extra_ball_extra_ball_lit.md
+++ b/docs/events/extra_ball_extra_ball_lit.md
@@ -11,4 +11,4 @@ Event is posted by [extra_balls:](../config/extra_balls.md)
 
 The extra ball called (name) has just been lit.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/extra_ball_group_extra_ball_group_award_disabled.md
+++ b/docs/events/extra_ball_group_extra_ball_group_award_disabled.md
@@ -7,11 +7,11 @@ title: extra_ball_group_(name)_award_disabled
 
 --8<-- "event.md"
 
+Event is posted by [extra_ball_groups:](../config/extra_ball_groups.md)
+
 Posted when you have the global extra ball settings set to not enable
 extra balls but where an extra ball would have been awarded. This is a
 good alternative event to use to score points or whatever else you want
 to give the player when extra balls are disabled.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [extra_ball_groups:](../config/extra_ball_groups.md)

--- a/docs/events/extra_ball_group_extra_ball_group_award_disabled.md
+++ b/docs/events/extra_ball_group_extra_ball_group_award_disabled.md
@@ -2,7 +2,7 @@
 title: extra_ball_group_(name)_award_disabled
 ---
 
-# extra_ball_group_(name)_award_disabled
+# extra_ball_group_(name)\_award_disabled
 
 
 --8<-- "event.md"

--- a/docs/events/extra_ball_group_extra_ball_group_award_disabled.md
+++ b/docs/events/extra_ball_group_extra_ball_group_award_disabled.md
@@ -14,4 +14,4 @@ extra balls but where an extra ball would have been awarded. This is a
 good alternative event to use to score points or whatever else you want
 to give the player when extra balls are disabled.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/extra_ball_group_extra_ball_group_awarded.md
+++ b/docs/events/extra_ball_group_extra_ball_group_awarded.md
@@ -7,9 +7,9 @@ title: extra_ball_group_(name)_awarded
 
 --8<-- "event.md"
 
+Event is posted by [extra_ball_groups:](../config/extra_ball_groups.md)
+
 An extra ball from this group was just awarded. This is a good event to
 use to trigger award shows, sounds, etc.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [extra_ball_groups:](../config/extra_ball_groups.md)

--- a/docs/events/extra_ball_group_extra_ball_group_awarded.md
+++ b/docs/events/extra_ball_group_extra_ball_group_awarded.md
@@ -2,7 +2,7 @@
 title: extra_ball_group_(name)_awarded
 ---
 
-# extra_ball_group_(name)_awarded
+# extra_ball_group_(name)\_awarded
 
 
 --8<-- "event.md"

--- a/docs/events/extra_ball_group_extra_ball_group_awarded.md
+++ b/docs/events/extra_ball_group_extra_ball_group_awarded.md
@@ -12,4 +12,4 @@ Event is posted by [extra_ball_groups:](../config/extra_ball_groups.md)
 An extra ball from this group was just awarded. This is a good event to
 use to trigger award shows, sounds, etc.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/extra_ball_group_extra_ball_group_lit.md
+++ b/docs/events/extra_ball_group_extra_ball_group_lit.md
@@ -7,6 +7,8 @@ title: extra_ball_group_(name)_lit
 
 --8<-- "event.md"
 
+Event is posted by [extra_ball_groups:](../config/extra_ball_groups.md)
+
 An extra ball was just lit. This is a good event to use to start your
 extra ball lit mode, to turn on an extra ball light, to play the "get
 that extra ball" sound, etc.
@@ -19,5 +21,3 @@ for a similar event that is only posted when an extra ball is lit during
 play, and not if the player starts their turn with the extra ball lit.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [extra_ball_groups:](../config/extra_ball_groups.md)

--- a/docs/events/extra_ball_group_extra_ball_group_lit.md
+++ b/docs/events/extra_ball_group_extra_ball_group_lit.md
@@ -16,7 +16,7 @@ that extra ball" sound, etc.
 Note that this event is posted if an extra ball is lit during play and
 also when a player's turn starts if they have a lit extra ball.
 
-See also the [/config/extra_ball_groups](extra_ball_extra_ball_lit.md)
+See also the [*extra_ball_extra_ball_lit*](extra_ball_extra_ball_lit.md) event
 for a similar event that is only posted when an extra ball is lit during
 play, and not if the player starts their turn with the extra ball lit.
 

--- a/docs/events/extra_ball_group_extra_ball_group_lit.md
+++ b/docs/events/extra_ball_group_extra_ball_group_lit.md
@@ -20,4 +20,4 @@ See also the [/config/extra_ball_groups](extra_ball_extra_ball_lit.md)
 for a similar event that is only posted when an extra ball is lit during
 play, and not if the player starts their turn with the extra ball lit.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/extra_ball_group_extra_ball_group_lit.md
+++ b/docs/events/extra_ball_group_extra_ball_group_lit.md
@@ -2,7 +2,7 @@
 title: extra_ball_group_(name)_lit
 ---
 
-# extra_ball_group_(name)_lit
+# extra_ball_group_(name)\_lit
 
 
 --8<-- "event.md"

--- a/docs/events/extra_ball_group_extra_ball_group_lit_awarded.md
+++ b/docs/events/extra_ball_group_extra_ball_group_lit_awarded.md
@@ -2,7 +2,7 @@
 title: extra_ball_group_(name)_lit_awarded
 ---
 
-# extra_ball_group_(name)_lit_awarded
+# extra_ball_group_(name)\_lit_awarded
 
 
 --8<-- "event.md"

--- a/docs/events/extra_ball_group_extra_ball_group_lit_awarded.md
+++ b/docs/events/extra_ball_group_extra_ball_group_lit_awarded.md
@@ -19,4 +19,4 @@ because that is also posted when the player's turn starts and you
 don't want the award show to play again when they're starting their
 turn.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/extra_ball_group_extra_ball_group_lit_awarded.md
+++ b/docs/events/extra_ball_group_extra_ball_group_lit_awarded.md
@@ -7,6 +7,8 @@ title: extra_ball_group_(name)_lit_awarded
 
 --8<-- "event.md"
 
+Event is posted by [extra_ball_groups:](../config/extra_ball_groups.md)
+
 This even is posted when an extra ball is lit during play. It is NOT
 posted when a player's turn starts if they have a lit extra ball from
 their previous turn. Therefore this event is a good event to use for
@@ -18,5 +20,3 @@ don't want the award show to play again when they're starting their
 turn.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [extra_ball_groups:](../config/extra_ball_groups.md)

--- a/docs/events/extra_ball_group_extra_ball_group_unlit.md
+++ b/docs/events/extra_ball_group_extra_ball_group_unlit.md
@@ -2,7 +2,7 @@
 title: extra_ball_group_(name)_unlit
 ---
 
-# extra_ball_group_(name)_unlit
+# extra_ball_group_(name)\_unlit
 
 
 --8<-- "event.md"

--- a/docs/events/extra_ball_group_extra_ball_group_unlit.md
+++ b/docs/events/extra_ball_group_extra_ball_group_unlit.md
@@ -7,11 +7,11 @@ title: extra_ball_group_(name)_unlit
 
 --8<-- "event.md"
 
+Event is posted by [extra_ball_groups:](../config/extra_ball_groups.md)
+
 No more lit extra balls are available for this extra ball group. This is
 a good event to use as a stop event for your extra ball lit mode or
 whatever you're using to indicate to the player that an extra ball is
 available.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [extra_ball_groups:](../config/extra_ball_groups.md)

--- a/docs/events/extra_ball_group_extra_ball_group_unlit.md
+++ b/docs/events/extra_ball_group_extra_ball_group_unlit.md
@@ -14,4 +14,4 @@ a good event to use as a stop event for your extra ball lit mode or
 whatever you're using to indicate to the player that an extra ball is
 available.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/flipper_cancel.md
+++ b/docs/events/flipper_cancel.md
@@ -16,4 +16,4 @@ Note that in order for this event to work, you have to add
 
 See [combo_switches:](../config/combo_switches.md) for details.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/flipper_cradle.md
+++ b/docs/events/flipper_cradle.md
@@ -15,4 +15,4 @@ Note that in order for this event to work, you have to add
 
 See [timed_switches:](../config/timed_switches.md) for details.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/flipper_cradle_release.md
+++ b/docs/events/flipper_cradle_release.md
@@ -20,4 +20,4 @@ Note that in order for this event to work, you have to add
 
 See [timed_switches:](../config/timed_switches.md) for details.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/game_ended.md
+++ b/docs/events/game_ended.md
@@ -9,4 +9,4 @@ title: game_ended
 
 The game has ended.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/game_ending.md
+++ b/docs/events/game_ending.md
@@ -10,4 +10,4 @@ title: game_ending
 The game is in the process of ending. This is a queue event, and the
 game won't actually end until the queue is cleared.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/game_start.md
+++ b/docs/events/game_start.md
@@ -18,15 +18,15 @@ code. Instead, use the *request_to_start_game* event.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`buttons`
+#### `buttons`:
 
-:   A list of switches tagged with *player* that were held in when the
-    start button was released. This is used for "alternate" game
-    starts (e.g. hold the right flipper and press start for tournament
-    mode, etc.)
+A list of switches tagged with *player* that were held in when the
+start button was released. This is used for "alternate" game
+starts (e.g. hold the right flipper and press start for tournament
+mode, etc.)
 
-`hold_time`
+#### `hold_time`:
 
-:   The time, in seconds, that the start button was held in to start the
-    game. This can be used to start alternate games via a "long press"
-    of the start button.
+The time, in seconds, that the start button was held in to start the
+game. This can be used to start alternate games via a "long press"
+of the start button.

--- a/docs/events/game_started.md
+++ b/docs/events/game_started.md
@@ -9,4 +9,4 @@ title: game_started
 
 A new game has started.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/game_starting.md
+++ b/docs/events/game_starting.md
@@ -16,6 +16,6 @@ game won't actually start until the queue is cleared.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`game`
+#### `game`:
 
-:   A reference to the game mode object.
+A reference to the game mode object.

--- a/docs/events/game_will_end.md
+++ b/docs/events/game_will_end.md
@@ -10,4 +10,4 @@ title: game_will_end
 The game is about to end. This event is posted just before
 [game_ending](game_ending.md).
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/game_will_start.md
+++ b/docs/events/game_will_start.md
@@ -10,4 +10,4 @@ title: game_will_start
 The game is about to start. This event is posted just before
 [game_starting](game_starting.md).
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/init_done.md
+++ b/docs/events/init_done.md
@@ -10,4 +10,4 @@ title: init_done
 Posted when the initial (one-time / boot) init phase is done. In other
 words, once this is posted, MPF is booted and ready to go.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/init_phase_1.md
+++ b/docs/events/init_phase_1.md
@@ -9,4 +9,4 @@ title: init_phase_1
 
 Posted during the initial boot up of MPF.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/init_phase_2.md
+++ b/docs/events/init_phase_2.md
@@ -9,4 +9,4 @@ title: init_phase_2
 
 Posted during the initial boot up of MPF.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/init_phase_3.md
+++ b/docs/events/init_phase_3.md
@@ -9,4 +9,4 @@ title: init_phase_3
 
 Posted during the initial boot up of MPF.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/init_phase_4.md
+++ b/docs/events/init_phase_4.md
@@ -9,4 +9,4 @@ title: init_phase_4
 
 Posted during the initial boot up of MPF.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/init_phase_5.md
+++ b/docs/events/init_phase_5.md
@@ -9,4 +9,4 @@ title: init_phase_5
 
 Posted during the initial boot up of MPF.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/kickback_kickback_fired.md
+++ b/docs/events/kickback_kickback_fired.md
@@ -7,8 +7,8 @@ title: kickback_(name)_fired
 
 --8<-- "event.md"
 
+Event is posted by [kickbacks:](../config/kickbacks.md)
+
 Kickback fired a ball.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [kickbacks:](../config/kickbacks.md)

--- a/docs/events/kickback_kickback_fired.md
+++ b/docs/events/kickback_kickback_fired.md
@@ -11,4 +11,4 @@ Event is posted by [kickbacks:](../config/kickbacks.md)
 
 Kickback fired a ball.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/kickback_kickback_fired.md
+++ b/docs/events/kickback_kickback_fired.md
@@ -2,7 +2,7 @@
 title: kickback_(name)_fired
 ---
 
-# kickback_(name)_fired
+# kickback_(name)\_fired
 
 
 --8<-- "event.md"

--- a/docs/events/loading_assets.md
+++ b/docs/events/loading_assets.md
@@ -18,23 +18,23 @@ to zero.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`loaded`
+#### `loaded`:
 
-:   The number of assets that have been loaded so far.
+The number of assets that have been loaded so far.
 
-`percent`
+#### `percent`:
 
-:   The numerical percent completion of the assets loaded, express in
-    the range of 0 to 100.
+The numerical percent completion of the assets loaded, express in
+the range of 0 to 100.
 
-`remaining`
+#### `remaining`:
 
-:   The number of assets that are remaining to be loaded.
+The number of assets that are remaining to be loaded.
 
-`total`
+#### `total`:
 
-:   The total number of assets that need to be loaded. This is equal to
-    the sum of the *loaded* and *remaining* values below. It also
-    includes assets that MPF is loading itself as well as any assets
-    that have been reported from remotely connected BCP hosts (e.g. the
-    media controller).
+The total number of assets that need to be loaded. This is equal to
+the sum of the *loaded* and *remaining* values below. It also
+includes assets that MPF is loading itself as well as any assets
+that have been reported from remotely connected BCP hosts (e.g. the
+media controller).

--- a/docs/events/logicblock_name_complete.md
+++ b/docs/events/logicblock_name_complete.md
@@ -16,4 +16,4 @@ this can be changed in a logic block's "events_when_complete:"
 setting, so this might not be the actual event that's posted for all
 logic blocks in your machine.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/logicblock_name_complete.md
+++ b/docs/events/logicblock_name_complete.md
@@ -2,7 +2,7 @@
 title: logicblock_(name)_complete
 ---
 
-# logicblock_(name)_complete
+# logicblock_(name)\_complete
 
 
 --8<-- "event.md"

--- a/docs/events/logicblock_name_complete.md
+++ b/docs/events/logicblock_name_complete.md
@@ -7,6 +7,8 @@ title: logicblock_(name)_complete
 
 --8<-- "event.md"
 
+Event is posted by [counters:](../config/counters.md), [accruals:](../config/accruals.md), and [sequences:](../config/sequences.md)
+
 The logic block called (name) has just been completed.
 
 Note that this is the default completion event for logic blocks, but
@@ -15,9 +17,3 @@ setting, so this might not be the actual event that's posted for all
 logic blocks in your machine.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [counters:](../config/counters.md)
-
-Event is posted by [accruals:](../config/accruals.md)
-
-Event is posted by [sequences:](../config/sequences.md)

--- a/docs/events/logicblock_name_hit.md
+++ b/docs/events/logicblock_name_hit.md
@@ -2,7 +2,7 @@
 title: logicblock_(name)_hit
 ---
 
-# logicblock_(name)_hit
+# logicblock_(name)\_hit
 
 
 --8<-- "event.md"

--- a/docs/events/logicblock_name_hit.md
+++ b/docs/events/logicblock_name_hit.md
@@ -7,6 +7,8 @@ title: logicblock_(name)_hit
 
 --8<-- "event.md"
 
+Event is posted by [counters:](../config/counters.md), [accruals:](../config/accruals.md), and [sequences:](../config/sequences.md)
+
 The logic block (name) was just hit.
 
 Note that this is the default hit event for logic blocks, but this can
@@ -15,9 +17,3 @@ might not be the actual event that's posted for all logic blocks in
 your machine.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [counters:](../config/counters.md)
-
-Event is posted by [accruals:](../config/accruals.md)
-
-Event is posted by [sequences:](../config/sequences.md)

--- a/docs/events/logicblock_name_hit.md
+++ b/docs/events/logicblock_name_hit.md
@@ -16,4 +16,4 @@ be changed in a logic block's "events_when_hit:" setting, so this
 might not be the actual event that's posted for all logic blocks in
 your machine.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/logicblock_name_updated.md
+++ b/docs/events/logicblock_name_updated.md
@@ -2,7 +2,7 @@
 title: logicblock_(name)_updated
 ---
 
-# logicblock_(name)_updated
+# logicblock_(name)\_updated
 
 
 --8<-- "event.md"
@@ -17,13 +17,13 @@ This might happen when the block advanced, was reset, or was restored.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`enabled`
+#### `enabled`:
 
-:   Whatever this block is enabled or not.
+Whatever this block is enabled or not.
 
-`value`
+#### `value`:
 
-:   The current value of this block.
+The current value of this block.
 
 Event is posted by [counters:](../config/counters.md)
 

--- a/docs/events/logicblock_name_updated.md
+++ b/docs/events/logicblock_name_updated.md
@@ -7,6 +7,8 @@ title: logicblock_(name)_updated
 
 --8<-- "event.md"
 
+Event is posted by [counters:](../config/counters.md), [accruals:](../config/accruals.md), and [sequences:](../config/sequences.md)
+
 The logic block called (name) has changed.
 
 This might happen when the block advanced, was reset, or was restored.
@@ -24,9 +26,3 @@ Whatever this block is enabled or not.
 #### `value`:
 
 The current value of this block.
-
-Event is posted by [counters:](../config/counters.md)
-
-Event is posted by [accruals:](../config/accruals.md)
-
-Event is posted by [sequences:](../config/sequences.md)

--- a/docs/events/machine_reset_phase_1.md
+++ b/docs/events/machine_reset_phase_1.md
@@ -16,4 +16,4 @@ posted), and they're also posted subsequently when the machine is reset
 This is a queue event. The machine reset phase 1 will not be complete
 until the queue is cleared.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/machine_reset_phase_2.md
+++ b/docs/events/machine_reset_phase_2.md
@@ -16,4 +16,4 @@ posted), and they're also posted subsequently when the machine is reset
 This is a queue event. The machine reset phase 2 will not be complete
 until the queue is cleared.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/machine_reset_phase_3.md
+++ b/docs/events/machine_reset_phase_3.md
@@ -16,4 +16,4 @@ posted), and they're also posted subsequently when the machine is reset
 This is a queue event. The machine reset phase 3 will not be complete
 until the queue is cleared.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/machine_var_machine_var.md
+++ b/docs/events/machine_var_machine_var.md
@@ -17,20 +17,20 @@ machine-wide instead of per-player or per-game.)
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`change`
+#### `change`:
 
-:   If the machine variable just changed, this will be the amount of the
-    change. If it's not possible to determine a numeric change (for
-    example, if this machine variable is a list), then this *change*
-    value will be set to the boolean *True*.
+If the machine variable just changed, this will be the amount of the
+change. If it's not possible to determine a numeric change (for
+example, if this machine variable is a list), then this *change*
+value will be set to the boolean *True*.
 
-`prev_value`
+#### `prev_value`:
 
-:   The previous value of this machine variable, e.g. what it was before
-    the current value.
+The previous value of this machine variable, e.g. what it was before
+the current value.
 
-`value`
+#### `value`:
 
-:   The new value of this machine variable.
+The new value of this machine variable.
 
 Event is posted by [machine_vars:](../config/machine_vars.md)

--- a/docs/events/machine_var_machine_var.md
+++ b/docs/events/machine_var_machine_var.md
@@ -7,6 +7,8 @@ title: machine_var_(var_name)
 
 --8<-- "event.md"
 
+Event is posted by [machine_vars:](../config/machine_vars.md)
+
 Posted when a machine variable is added or changes value. (Machine
 variables are like player variables, except they're maintained
 machine-wide instead of per-player or per-game.)
@@ -32,5 +34,3 @@ the current value.
 #### `value`:
 
 The new value of this machine variable.
-
-Event is posted by [machine_vars:](../config/machine_vars.md)

--- a/docs/events/magnet_magnet_flinged_ball.md
+++ b/docs/events/magnet_magnet_flinged_ball.md
@@ -7,8 +7,8 @@ title: magnet_(name)_flinged_ball
 
 --8<-- "event.md"
 
+Event is posted by [magnets:](../config/magnets.md)
+
 The magnet called (name) has just flinged a ball.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [magnets:](../config/magnets.md)

--- a/docs/events/magnet_magnet_flinged_ball.md
+++ b/docs/events/magnet_magnet_flinged_ball.md
@@ -11,4 +11,4 @@ Event is posted by [magnets:](../config/magnets.md)
 
 The magnet called (name) has just flinged a ball.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/magnet_magnet_flinged_ball.md
+++ b/docs/events/magnet_magnet_flinged_ball.md
@@ -2,7 +2,7 @@
 title: magnet_(name)_flinged_ball
 ---
 
-# magnet_(name)_flinged_ball
+# magnet_(name)\_flinged_ball
 
 
 --8<-- "event.md"

--- a/docs/events/magnet_magnet_flinging_ball.md
+++ b/docs/events/magnet_magnet_flinging_ball.md
@@ -2,7 +2,7 @@
 title: magnet_(name)_flinging_ball
 ---
 
-# magnet_(name)_flinging_ball
+# magnet_(name)\_flinging_ball
 
 
 --8<-- "event.md"

--- a/docs/events/magnet_magnet_flinging_ball.md
+++ b/docs/events/magnet_magnet_flinging_ball.md
@@ -12,4 +12,4 @@ Event is posted by [magnets:](../config/magnets.md)
 The magnet called (name) is flinging a ball by disabling and enabling
 the magnet again for a short time.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/magnet_magnet_flinging_ball.md
+++ b/docs/events/magnet_magnet_flinging_ball.md
@@ -7,9 +7,9 @@ title: magnet_(name)_flinging_ball
 
 --8<-- "event.md"
 
+Event is posted by [magnets:](../config/magnets.md)
+
 The magnet called (name) is flinging a ball by disabling and enabling
 the magnet again for a short time.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [magnets:](../config/magnets.md)

--- a/docs/events/magnet_magnet_grabbed_ball.md
+++ b/docs/events/magnet_magnet_grabbed_ball.md
@@ -7,11 +7,11 @@ title: magnet_(name)_grabbed_ball
 
 --8<-- "event.md"
 
+Event is posted by [magnets:](../config/magnets.md)
+
 The magnet called (name) has completed grabbing the ball. Note that the
 magnet doesn't actually "know" whether it successfully grabbed a ball
 or not, so this event is saying that that the process is complete rather
 than confirming that it has a ball.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [magnets:](../config/magnets.md)

--- a/docs/events/magnet_magnet_grabbed_ball.md
+++ b/docs/events/magnet_magnet_grabbed_ball.md
@@ -2,7 +2,7 @@
 title: magnet_(name)_grabbed_ball
 ---
 
-# magnet_(name)_grabbed_ball
+# magnet_(name)\_grabbed_ball
 
 
 --8<-- "event.md"

--- a/docs/events/magnet_magnet_grabbed_ball.md
+++ b/docs/events/magnet_magnet_grabbed_ball.md
@@ -14,4 +14,4 @@ magnet doesn't actually "know" whether it successfully grabbed a ball
 or not, so this event is saying that that the process is complete rather
 than confirming that it has a ball.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/magnet_magnet_grabbing_ball.md
+++ b/docs/events/magnet_magnet_grabbing_ball.md
@@ -11,4 +11,4 @@ Event is posted by [magnets:](../config/magnets.md)
 
 The magnet called (name) is attempting to grab a ball.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/magnet_magnet_grabbing_ball.md
+++ b/docs/events/magnet_magnet_grabbing_ball.md
@@ -7,8 +7,8 @@ title: magnet_(name)_grabbing_ball
 
 --8<-- "event.md"
 
+Event is posted by [magnets:](../config/magnets.md)
+
 The magnet called (name) is attempting to grab a ball.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [magnets:](../config/magnets.md)

--- a/docs/events/magnet_magnet_grabbing_ball.md
+++ b/docs/events/magnet_magnet_grabbing_ball.md
@@ -2,7 +2,7 @@
 title: magnet_(name)_grabbing_ball
 ---
 
-# magnet_(name)_grabbing_ball
+# magnet_(name)\_grabbing_ball
 
 
 --8<-- "event.md"

--- a/docs/events/magnet_magnet_released_ball.md
+++ b/docs/events/magnet_magnet_released_ball.md
@@ -11,4 +11,4 @@ Event is posted by [magnets:](../config/magnets.md)
 
 The magnet called (name) has just released a ball.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/magnet_magnet_released_ball.md
+++ b/docs/events/magnet_magnet_released_ball.md
@@ -7,8 +7,8 @@ title: magnet_(name)_released_ball
 
 --8<-- "event.md"
 
+Event is posted by [magnets:](../config/magnets.md)
+
 The magnet called (name) has just released a ball.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [magnets:](../config/magnets.md)

--- a/docs/events/magnet_magnet_released_ball.md
+++ b/docs/events/magnet_magnet_released_ball.md
@@ -2,7 +2,7 @@
 title: magnet_(name)_released_ball
 ---
 
-# magnet_(name)_released_ball
+# magnet_(name)\_released_ball
 
 
 --8<-- "event.md"

--- a/docs/events/magnet_magnet_releasing_ball.md
+++ b/docs/events/magnet_magnet_releasing_ball.md
@@ -11,4 +11,4 @@ Event is posted by [magnets:](../config/magnets.md)
 
 The magnet called (name) is in the process of releasing a ball.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/magnet_magnet_releasing_ball.md
+++ b/docs/events/magnet_magnet_releasing_ball.md
@@ -2,7 +2,7 @@
 title: magnet_(name)_releasing_ball
 ---
 
-# magnet_(name)_releasing_ball
+# magnet_(name)\_releasing_ball
 
 
 --8<-- "event.md"

--- a/docs/events/magnet_magnet_releasing_ball.md
+++ b/docs/events/magnet_magnet_releasing_ball.md
@@ -7,8 +7,8 @@ title: magnet_(name)_releasing_ball
 
 --8<-- "event.md"
 
+Event is posted by [magnets:](../config/magnets.md)
+
 The magnet called (name) is in the process of releasing a ball.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [magnets:](../config/magnets.md)

--- a/docs/events/master_volume_decrease.md
+++ b/docs/events/master_volume_decrease.md
@@ -15,6 +15,6 @@ Decrease the master volume of the audio system.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`volume`
+#### `volume`:
 
-:   New volume as float between 0.0 an 1.0
+New volume as float between 0.0 an 1.0

--- a/docs/events/master_volume_increase.md
+++ b/docs/events/master_volume_increase.md
@@ -15,6 +15,6 @@ Increase the master volume of the audio system.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`volume`
+#### `volume`:
 
-:   New volume as float between 0.0 an 1.0
+New volume as float between 0.0 an 1.0

--- a/docs/events/match_has_match.md
+++ b/docs/events/match_has_match.md
@@ -15,22 +15,22 @@ At least one player has a match.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`match_number0`
+#### `match_number0`:
 
-:   Match number for player 0
+Match number for player 0
 
-`match_number1`
+#### `match_number1`:
 
-:   Match number for player 1
+Match number for player 1
 
-`match_numberX`
+#### `match_numberX`:
 
-:   Match number for player X (up to max players)
+Match number for player X (up to max players)
 
-`winner_number`
+#### `winner_number`:
 
-:   Winner number
+Winner number
 
-`winners`
+#### `winners`:
 
-:   Number of winners (always more than 0 here)
+Number of winners (always more than 0 here)

--- a/docs/events/match_no_match.md
+++ b/docs/events/match_no_match.md
@@ -15,22 +15,22 @@ All players missed the match number.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`match_number0`
+#### `match_number0`:
 
-:   Match number for player 0
+Match number for player 0
 
-`match_number1`
+#### `match_number1`:
 
-:   Match number for player 1
+Match number for player 1
 
-`match_numberX`
+#### `match_numberX`:
 
-:   Match number for player X (up to max players)
+Match number for player X (up to max players)
 
-`winner_number`
+#### `winner_number`:
 
-:   Winner number
+Winner number
 
-`winners`
+#### `winners`:
 
-:   Number of winners (always 0 here)
+Number of winners (always 0 here)

--- a/docs/events/max_credits_reached.md
+++ b/docs/events/max_credits_reached.md
@@ -10,4 +10,4 @@ title: max_credits_reached
 Credits have just been added to the machine, but the configured maximum
 number of credits has been reached.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/mc_ready.md
+++ b/docs/events/mc_ready.md
@@ -20,4 +20,4 @@ If you want to show slides that require images or video loaded from
 disk, use the event "init_done" instead which is posted once all the
 assets set to "preload" have been loaded.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/mc_reset_complete.md
+++ b/docs/events/mc_reset_complete.md
@@ -10,4 +10,4 @@ title: mc_reset_complete
 Posted on the MPF-MC only (e.g. not in MPF). This event is posted when
 the MPF-MC reset process is complete.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/mc_reset_phase_1.md
+++ b/docs/events/mc_reset_phase_1.md
@@ -10,4 +10,4 @@ title: mc_reset_phase_1
 Posted on the MPF-MC only (e.g. not in MPF). This event is used
 internally as part of the MPF-MC reset process.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/mc_reset_phase_2.md
+++ b/docs/events/mc_reset_phase_2.md
@@ -10,4 +10,4 @@ title: mc_reset_phase_2
 Posted on the MPF-MC only (e.g. not in MPF). This event is used
 internally as part of the MPF-MC reset process.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/mc_reset_phase_3.md
+++ b/docs/events/mc_reset_phase_3.md
@@ -10,4 +10,4 @@ title: mc_reset_phase_3
 Posted on the MPF-MC only (e.g. not in MPF). This event is used
 internally as part of the MPF-MC reset process.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/mode_name_started.md
+++ b/docs/events/mode_name_started.md
@@ -2,7 +2,7 @@
 title: mode_(name)_started
 ---
 
-# mode_(name)_started
+# mode_(name)\_started
 
 
 --8<-- "event.md"
@@ -11,6 +11,6 @@ Posted when a mode has started. The (name) part is replaced with the
 actual name of the mode, so the actual event posted is something like
 *mode_attract_started*, *mode_base_started*, etc.
 
-This is posted after the "mode_(name)_starting" event.
+This is posted after the "mode_(name)\_starting" event.
 
 *This event does not have any keyword arguments*

--- a/docs/events/mode_name_started.md
+++ b/docs/events/mode_name_started.md
@@ -13,4 +13,4 @@ actual name of the mode, so the actual event posted is something like
 
 This is posted after the "mode_(name)\_starting" event.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/mode_name_starting.md
+++ b/docs/events/mode_name_starting.md
@@ -12,4 +12,4 @@ The mode called (name) is starting.
 This is a queue event. The mode will not fully start until the queue is
 cleared.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/mode_name_starting.md
+++ b/docs/events/mode_name_starting.md
@@ -2,7 +2,7 @@
 title: mode_(name)_starting
 ---
 
-# mode_(name)_starting
+# mode_(name)\_starting
 
 
 --8<-- "event.md"

--- a/docs/events/mode_name_stopped.md
+++ b/docs/events/mode_name_stopped.md
@@ -2,7 +2,7 @@
 title: mode_(name)_stopped
 ---
 
-# mode_(name)_stopped
+# mode_(name)\_stopped
 
 
 --8<-- "event.md"

--- a/docs/events/mode_name_stopped.md
+++ b/docs/events/mode_name_stopped.md
@@ -11,4 +11,4 @@ Posted when a mode has stopped. The (name) part is replaced with the
 actual name of the mode, so the actual event posted is something like
 *mode_attract_stopped*, *mode_base_stopped*, etc.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/mode_name_stopping.md
+++ b/docs/events/mode_name_stopping.md
@@ -10,4 +10,4 @@ title: mode_(name)_stopping
 The mode called (name) is stopping. This is a queue event. The mode
 won't actually stop until the queue is cleared.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/mode_name_stopping.md
+++ b/docs/events/mode_name_stopping.md
@@ -2,7 +2,7 @@
 title: mode_(name)_stopping
 ---
 
-# mode_(name)_stopping
+# mode_(name)\_stopping
 
 
 --8<-- "event.md"

--- a/docs/events/mode_name_will_start.md
+++ b/docs/events/mode_name_will_start.md
@@ -13,4 +13,4 @@ like *mode_attract_will_start*, *mode_base_will_start*, etc.
 
 This is posted before the "mode_(name)\_starting" event.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/mode_name_will_start.md
+++ b/docs/events/mode_name_will_start.md
@@ -2,7 +2,7 @@
 title: mode_(name)_will_start
 ---
 
-# mode_(name)_will_start
+# mode_(name)\_will_start
 
 
 --8<-- "event.md"
@@ -11,6 +11,6 @@ Posted when a mode is about to start. The (name) part is replaced with
 the actual name of the mode, so the actual event posted is something
 like *mode_attract_will_start*, *mode_base_will_start*, etc.
 
-This is posted before the "mode_(name)_starting" event.
+This is posted before the "mode_(name)\_starting" event.
 
 *This event does not have any keyword arguments*

--- a/docs/events/mode_name_will_stop.md
+++ b/docs/events/mode_name_will_stop.md
@@ -14,4 +14,4 @@ like *mode_attract_will_stop*, *mode_base_will_stop*, etc.
 This is posted immediately before the "mode_(name)\_stopping"
 event.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/mode_name_will_stop.md
+++ b/docs/events/mode_name_will_stop.md
@@ -2,7 +2,7 @@
 title: mode_(name)_will_stop
 ---
 
-# mode_(name)_will_stop
+# mode_(name)\_will_stop
 
 
 --8<-- "event.md"
@@ -11,7 +11,7 @@ Posted when a mode is about to stop. The (name) part is replaced with
 the actual name of the mode, so the actual event posted is something
 like *mode_attract_will_stop*, *mode_base_will_stop*, etc.
 
-This is posted immediately before the "mode_(name)_stopping"
+This is posted immediately before the "mode_(name)\_stopping"
 event.
 
 *This event does not have any keyword arguments*

--- a/docs/events/motor_motor_reached_position.md
+++ b/docs/events/motor_motor_reached_position.md
@@ -11,4 +11,4 @@ Event is posted by [motors:](../config/motors.md)
 
 A motor device called (name) reached position (position) (device)
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/motor_motor_reached_position.md
+++ b/docs/events/motor_motor_reached_position.md
@@ -7,8 +7,8 @@ title: motor_(name)_reached_(position)
 
 --8<-- "event.md"
 
+Event is posted by [motors:](../config/motors.md)
+
 A motor device called (name) reached position (position) (device)
 
 *This event does not have any keyword arguments*
-
-Event is posted by [motors:](../config/motors.md)

--- a/docs/events/multi_player_ball_started.md
+++ b/docs/events/multi_player_ball_started.md
@@ -9,4 +9,4 @@ title: multi_player_ball_started
 
 A new ball has started, and this is a multiplayer game.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/multiball_lock_multiball_lock_full.md
+++ b/docs/events/multiball_lock_multiball_lock_full.md
@@ -2,7 +2,7 @@
 title: multiball_lock_(name)_full
 ---
 
-# multiball_lock_(name)_full
+# multiball_lock_(name)\_full
 
 
 --8<-- "event.md"
@@ -15,8 +15,8 @@ The multiball lock device (name) is now full.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of balls currently locked in this device.
+The number of balls currently locked in this device.
 
 Event is posted by [multiball_locks:](../config/multiball_locks.md)

--- a/docs/events/multiball_lock_multiball_lock_full.md
+++ b/docs/events/multiball_lock_multiball_lock_full.md
@@ -7,6 +7,8 @@ title: multiball_lock_(name)_full
 
 --8<-- "event.md"
 
+Event is posted by [multiball_locks:](../config/multiball_locks.md)
+
 The multiball lock device (name) is now full.
 
 ## Keyword arguments
@@ -18,5 +20,3 @@ only respond to certain combinations of the arguments below.)
 #### `balls`:
 
 The number of balls currently locked in this device.
-
-Event is posted by [multiball_locks:](../config/multiball_locks.md)

--- a/docs/events/multiball_lock_multiball_lock_locked_ball.md
+++ b/docs/events/multiball_lock_multiball_lock_locked_ball.md
@@ -2,7 +2,7 @@
 title: multiball_lock_(name)_locked_ball
 ---
 
-# multiball_lock_(name)_locked_ball
+# multiball_lock_(name)\_locked_ball
 
 
 --8<-- "event.md"
@@ -15,8 +15,8 @@ The multiball lock device (name) has just locked one additional ball.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`total_balls_locked`
+#### `total_balls_locked`:
 
-:   The current total number of balls this device has locked.
+The current total number of balls this device has locked.
 
 Event is posted by [multiball_locks:](../config/multiball_locks.md)

--- a/docs/events/multiball_lock_multiball_lock_locked_ball.md
+++ b/docs/events/multiball_lock_multiball_lock_locked_ball.md
@@ -7,6 +7,8 @@ title: multiball_lock_(name)_locked_ball
 
 --8<-- "event.md"
 
+Event is posted by [multiball_locks:](../config/multiball_locks.md)
+
 The multiball lock device (name) has just locked one additional ball.
 
 ## Keyword arguments
@@ -18,5 +20,3 @@ only respond to certain combinations of the arguments below.)
 #### `total_balls_locked`:
 
 The current total number of balls this device has locked.
-
-Event is posted by [multiball_locks:](../config/multiball_locks.md)

--- a/docs/events/multiball_multiball_ended.md
+++ b/docs/events/multiball_multiball_ended.md
@@ -7,8 +7,8 @@ title: multiball_(name)_ended
 
 --8<-- "event.md"
 
+Event is posted by [multiballs:](../config/multiballs.md)
+
 The multiball called (name) has just ended.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [multiballs:](../config/multiballs.md)

--- a/docs/events/multiball_multiball_ended.md
+++ b/docs/events/multiball_multiball_ended.md
@@ -11,4 +11,4 @@ Event is posted by [multiballs:](../config/multiballs.md)
 
 The multiball called (name) has just ended.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/multiball_multiball_ended.md
+++ b/docs/events/multiball_multiball_ended.md
@@ -2,7 +2,7 @@
 title: multiball_(name)_ended
 ---
 
-# multiball_(name)_ended
+# multiball_(name)\_ended
 
 
 --8<-- "event.md"

--- a/docs/events/multiball_multiball_grace_period.md
+++ b/docs/events/multiball_multiball_grace_period.md
@@ -2,7 +2,7 @@
 title: multiball_(name)_grace_period
 ---
 
-# multiball_(name)_grace_period
+# multiball_(name)\_grace_period
 
 
 --8<-- "event.md"

--- a/docs/events/multiball_multiball_grace_period.md
+++ b/docs/events/multiball_multiball_grace_period.md
@@ -7,9 +7,9 @@ title: multiball_(name)_grace_period
 
 --8<-- "event.md"
 
+Event is posted by [multiballs:](../config/multiballs.md)
+
 The multiball ball save called (name) has just entered its grace period
 time.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [multiballs:](../config/multiballs.md)

--- a/docs/events/multiball_multiball_grace_period.md
+++ b/docs/events/multiball_multiball_grace_period.md
@@ -12,4 +12,4 @@ Event is posted by [multiballs:](../config/multiballs.md)
 The multiball ball save called (name) has just entered its grace period
 time.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/multiball_multiball_hurry_up.md
+++ b/docs/events/multiball_multiball_hurry_up.md
@@ -12,4 +12,4 @@ Event is posted by [multiballs:](../config/multiballs.md)
 The multiball ball save called (name) has just entered its hurry up
 mode.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/multiball_multiball_hurry_up.md
+++ b/docs/events/multiball_multiball_hurry_up.md
@@ -7,9 +7,9 @@ title: multiball_(name)_hurry_up
 
 --8<-- "event.md"
 
+Event is posted by [multiballs:](../config/multiballs.md)
+
 The multiball ball save called (name) has just entered its hurry up
 mode.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [multiballs:](../config/multiballs.md)

--- a/docs/events/multiball_multiball_hurry_up.md
+++ b/docs/events/multiball_multiball_hurry_up.md
@@ -2,7 +2,7 @@
 title: multiball_(name)_hurry_up
 ---
 
-# multiball_(name)_hurry_up
+# multiball_(name)\_hurry_up
 
 
 --8<-- "event.md"

--- a/docs/events/multiball_multiball_lost_ball.md
+++ b/docs/events/multiball_multiball_lost_ball.md
@@ -2,7 +2,7 @@
 title: multiball_(name)_lost_ball
 ---
 
-# multiball_(name)_lost_ball
+# multiball_(name)\_lost_ball
 
 
 --8<-- "event.md"

--- a/docs/events/multiball_multiball_lost_ball.md
+++ b/docs/events/multiball_multiball_lost_ball.md
@@ -7,8 +7,8 @@ title: multiball_(name)_lost_ball
 
 --8<-- "event.md"
 
+Event is posted by [multiballs:](../config/multiballs.md)
+
 The multiball called (name) has lost a ball after ball save expired.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [multiballs:](../config/multiballs.md)

--- a/docs/events/multiball_multiball_lost_ball.md
+++ b/docs/events/multiball_multiball_lost_ball.md
@@ -11,4 +11,4 @@ Event is posted by [multiballs:](../config/multiballs.md)
 
 The multiball called (name) has lost a ball after ball save expired.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/multiball_multiball_shoot_again.md
+++ b/docs/events/multiball_multiball_shoot_again.md
@@ -7,6 +7,8 @@ title: multiball_(name)_shoot_again
 
 --8<-- "event.md"
 
+Event is posted by [multiballs:](../config/multiballs.md)
+
 A ball has drained during the multiball called (name) while the ball
 save timer for that multiball was running, so a ball (or balls) will be
 saved and re-added into play.
@@ -20,5 +22,3 @@ only respond to certain combinations of the arguments below.)
 #### `balls`:
 
 The number of balls that are being saved.
-
-Event is posted by [multiballs:](../config/multiballs.md)

--- a/docs/events/multiball_multiball_shoot_again.md
+++ b/docs/events/multiball_multiball_shoot_again.md
@@ -2,7 +2,7 @@
 title: multiball_(name)_shoot_again
 ---
 
-# multiball_(name)_shoot_again
+# multiball_(name)\_shoot_again
 
 
 --8<-- "event.md"
@@ -17,8 +17,8 @@ saved and re-added into play.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of balls that are being saved.
+The number of balls that are being saved.
 
 Event is posted by [multiballs:](../config/multiballs.md)

--- a/docs/events/multiball_multiball_shoot_again_ended.md
+++ b/docs/events/multiball_multiball_shoot_again_ended.md
@@ -11,5 +11,5 @@ Event is posted by [multiballs:](../config/multiballs.md)
 
 Shoot again for multiball called (name) has ended.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"
 

--- a/docs/events/multiball_multiball_shoot_again_ended.md
+++ b/docs/events/multiball_multiball_shoot_again_ended.md
@@ -7,8 +7,9 @@ title: multiball_(name)_shoot_again_ended
 
 --8<-- "event.md"
 
+Event is posted by [multiballs:](../config/multiballs.md)
+
 Shoot again for multiball called (name) has ended.
 
 *This event does not have any keyword arguments*
 
-Event is posted by [multiballs:](../config/multiballs.md)

--- a/docs/events/multiball_multiball_shoot_again_ended.md
+++ b/docs/events/multiball_multiball_shoot_again_ended.md
@@ -2,7 +2,7 @@
 title: multiball_(name)_shoot_again_ended
 ---
 
-# multiball_(name)_shoot_again_ended
+# multiball_(name)\_shoot_again_ended
 
 
 --8<-- "event.md"

--- a/docs/events/multiball_multiball_started.md
+++ b/docs/events/multiball_multiball_started.md
@@ -2,7 +2,7 @@
 title: multiball_(name)_started
 ---
 
-# multiball_(name)_started
+# multiball_(name)\_started
 
 
 --8<-- "event.md"
@@ -15,8 +15,8 @@ The multiball called (name) has just started.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of balls in this multiball
+The number of balls in this multiball
 
 Event is posted by [multiballs:](../config/multiballs.md)

--- a/docs/events/multiball_multiball_started.md
+++ b/docs/events/multiball_multiball_started.md
@@ -7,6 +7,8 @@ title: multiball_(name)_started
 
 --8<-- "event.md"
 
+Event is posted by [multiballs:](../config/multiballs.md)
+
 The multiball called (name) has just started.
 
 ## Keyword arguments
@@ -18,5 +20,3 @@ only respond to certain combinations of the arguments below.)
 #### `balls`:
 
 The number of balls in this multiball
-
-Event is posted by [multiballs:](../config/multiballs.md)

--- a/docs/events/multiplayer_game.md
+++ b/docs/events/multiplayer_game.md
@@ -13,4 +13,4 @@ multiplayer game.
 This event is typically used to switch the score display from the single
 player layout to the multiplayer layout.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/name_timeout.md
+++ b/docs/events/name_timeout.md
@@ -15,4 +15,4 @@ Timeouts are disabled by default but you can set logic_block_timeout to
 enable them. They will run from start of your logic block until it is
 stopped.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/name_timeout.md
+++ b/docs/events/name_timeout.md
@@ -7,6 +7,8 @@ title: (logic_block_name)_timeout
 
 --8<-- "event.md"
 
+Event is posted by [counters:](../config/counters.md), [accruals:](../config/accruals.md), and [sequences:](../config/sequences.md)
+
 The logic block called (logic_block_name) has just timeouted.
 
 Timeouts are disabled by default but you can set logic_block_timeout to
@@ -14,9 +16,3 @@ enable them. They will run from start of your logic block until it is
 stopped.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [counters:](../config/counters.md)
-
-Event is posted by [accruals:](../config/accruals.md)
-
-Event is posted by [sequences:](../config/sequences.md)

--- a/docs/events/name_timeout.md
+++ b/docs/events/name_timeout.md
@@ -2,7 +2,7 @@
 title: (logic_block_name)_timeout
 ---
 
-# (logic_block_name)_timeout
+# (logic_block_name)\_timeout
 
 
 --8<-- "event.md"

--- a/docs/events/not_enough_credits.md
+++ b/docs/events/not_enough_credits.md
@@ -10,4 +10,4 @@ title: not_enough_credits
 A player has pushed the start button, but the game is not set to free
 play and there are not enough credits to start a game or add a player.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/player_add_request.md
+++ b/docs/events/player_add_request.md
@@ -11,4 +11,4 @@ Posted to request that an additional player be added to this game. Any
 registered handler can deny the player add request by returning *False*
 to this event.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/player_added.md
+++ b/docs/events/player_added.md
@@ -15,11 +15,11 @@ A new player was just added to this game
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`num`
+#### `num`:
 
-:   The number of the player that was just added. (e.g. Player 1 will
-    have *num=1*, Player 4 will have *num=4*, etc.)
+The number of the player that was just added. (e.g. Player 1 will
+have *num=1*, Player 4 will have *num=4*, etc.)
 
-`player`
+#### `player`:
 
-:   A reference to the instance of the Player() object.
+A reference to the instance of the Player() object.

--- a/docs/events/player_adding.md
+++ b/docs/events/player_adding.md
@@ -17,10 +17,10 @@ queue is cleared.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`number`
+#### `number`:
 
-:   The player number
+The player number
 
-`player`
+#### `player`:
 
-:   The player object for the player being added
+The player object for the player being added

--- a/docs/events/player_player_var.md
+++ b/docs/events/player_player_var.md
@@ -7,6 +7,8 @@ title: player_(player_var_name)
 
 --8<-- "event.md"
 
+Event is posted by [player_vars:](../config/player_vars.md)
+
 Posted when simpler types of player variables are added or change value.
 
 The actual event has (player_var_name) replaced with the name of the player
@@ -61,5 +63,3 @@ the current value.
 #### `value`:
 
 The new value of this player variable.
-
-Event is posted by [player_vars:](../config/player_vars.md)

--- a/docs/events/player_player_var.md
+++ b/docs/events/player_player_var.md
@@ -36,30 +36,30 @@ be posted, one for each change.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`change`
+#### `change`:
 
-:   If the player variable just changed, this will be the amount of the
-    change. If it's not possible to determine a numeric change (for
-    example, if this player variable is a string), then this *change*
-    value will be set to the boolean *True*.
+If the player variable just changed, this will be the amount of the
+change. If it's not possible to determine a numeric change (for
+example, if this player variable is a string), then this *change*
+value will be set to the boolean *True*.
 
-`kwargs`
+#### `kwargs`:
 
-:   Additional keyword arguments to include in the event args.
+Additional keyword arguments to include in the event args.
 
-`player_num`
+#### `player_num`:
 
-:   The player number this variable just changed for, starting with 1.
-    (e.g. Player 1 will have *player_num=1*, Player 4 will have
-    *player_num=4*, etc.)
+The player number this variable just changed for, starting with 1.
+(e.g. Player 1 will have *player_num=1*, Player 4 will have
+*player_num=4*, etc.)
 
-`prev_value`
+#### `prev_value`:
 
-:   The previous value of this player variable, e.g. what it was before
-    the current value.
+The previous value of this player variable, e.g. what it was before
+the current value.
 
-`value`
+#### `value`:
 
-:   The new value of this player variable.
+The new value of this player variable.
 
 Event is posted by [player_vars:](../config/player_vars.md)

--- a/docs/events/player_score.md
+++ b/docs/events/player_score.md
@@ -15,20 +15,18 @@ The player has scored. This is a built-in example version of the [player_(var_na
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`value`
+#### `value`:
 
-:   The score / amount of points the player has after this scoring event.
+The score / amount of points the player has after this scoring event.
 
-`prev_value`
+#### `prev_value`:
 
-:   The score / amount of points the player had before this scoring event.
+The score / amount of points the player had before this scoring event.
 
-`player_num`
+#### `player_num`:
 
-:   The player number who scored. Index starts with 1, so first player is 1.
+The player number who scored. Index starts with 1, so first player is 1.
 
-`change`
+#### `change`:
 
-:   The amout of how much the score changed.
-
-
+The amout of how much the score changed.

--- a/docs/events/player_turn_ended.md
+++ b/docs/events/player_turn_ended.md
@@ -18,10 +18,10 @@ balls and it's no longer their turn.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`number`
+#### `number`:
 
-:   The player number
+The player number
 
-`player`
+#### `player`:
 
-:   The player object whose turn is ending.
+The player object whose turn is ending.

--- a/docs/events/player_turn_ending.md
+++ b/docs/events/player_turn_ending.md
@@ -16,10 +16,10 @@ player's turn won't actually end until the queue is cleared.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`number`
+#### `number`:
 
-:   The player number
+The player number
 
-`player`
+#### `player`:
 
-:   The player object whose turn is ending.
+The player object whose turn is ending.

--- a/docs/events/player_turn_started.md
+++ b/docs/events/player_turn_started.md
@@ -17,10 +17,10 @@ again, this event is not posted a second time.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`number`
+#### `number`:
 
-:   The player number
+The player number
 
-`player`
+#### `player`:
 
-:   The player object whose turn is starting.
+The player object whose turn is starting.

--- a/docs/events/player_turn_starting.md
+++ b/docs/events/player_turn_starting.md
@@ -16,10 +16,10 @@ and the player's turn won't actually start until the queue is cleared.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`number`
+#### `number`:
 
-:   The player number
+The player number
 
-`player`
+#### `player`:
 
-:   The player object whose turn is starting.
+The player object whose turn is starting.

--- a/docs/events/player_turn_will_end.md
+++ b/docs/events/player_turn_will_end.md
@@ -18,10 +18,10 @@ and it's no longer their turn.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`number`
+#### `number`:
 
-:   The player number
+The player number
 
-`player`
+#### `player`:
 
-:   The player object whose turn is over.
+The player object whose turn is over.

--- a/docs/events/player_turn_will_start.md
+++ b/docs/events/player_turn_will_start.md
@@ -17,10 +17,10 @@ shoots again, this event is not posted a second time.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`number`
+#### `number`:
 
-:   The player number
+The player number
 
-`player`
+#### `player`:
 
-:   The player object whose turn is starting.
+The player object whose turn is starting.

--- a/docs/events/player_will_add.md
+++ b/docs/events/player_will_add.md
@@ -16,6 +16,6 @@ prior to the player_adding event.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`number`
+#### `number`:
 
-:   The new player number that will be added
+The new player number that will be added

--- a/docs/events/playfield_active.md
+++ b/docs/events/playfield_active.md
@@ -7,9 +7,9 @@ title: (playfield_name)_active
 
 --8<-- "event.md"
 
+Event is posted by [playfields:](../config/playfields.md)
+
 The playfield called (playfield_name) is now active, meaning there's at least one
 loose ball on it.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [playfields:](../config/playfields.md)

--- a/docs/events/playfield_active.md
+++ b/docs/events/playfield_active.md
@@ -12,4 +12,4 @@ Event is posted by [playfields:](../config/playfields.md)
 The playfield called (playfield_name) is now active, meaning there's at least one
 loose ball on it.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/playfield_active.md
+++ b/docs/events/playfield_active.md
@@ -2,7 +2,7 @@
 title: (playfield_name)_active
 ---
 
-# (playfield_name)_active
+# (playfield_name)\_active
 
 
 --8<-- "event.md"

--- a/docs/events/playfield_ball_count_change.md
+++ b/docs/events/playfield_ball_count_change.md
@@ -7,6 +7,8 @@ title: (playfield_name)_ball_count_change
 
 --8<-- "event.md"
 
+Event is posted by [playfields:](../config/playfields.md)
+
 The playfield with the name (playfield_name) has changed the number of balls that
 are live.
 
@@ -23,5 +25,3 @@ The current number of balls on the playfield.
 #### `change`:
 
 The change in balls from the last count.
-
-Event is posted by [playfields:](../config/playfields.md)

--- a/docs/events/playfield_ball_count_change.md
+++ b/docs/events/playfield_ball_count_change.md
@@ -2,7 +2,7 @@
 title: (playfield_name)_ball_count_change
 ---
 
-# (playfield_name)_ball_count_change
+# (playfield_name)\_ball_count_change
 
 
 --8<-- "event.md"
@@ -16,12 +16,12 @@ are live.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The current number of balls on the playfield.
+The current number of balls on the playfield.
 
-`change`
+#### `change`:
 
-:   The change in balls from the last count.
+The change in balls from the last count.
 
 Event is posted by [playfields:](../config/playfields.md)

--- a/docs/events/playfield_transfer_playfield_transfer_ball_transferred.md
+++ b/docs/events/playfield_transfer_playfield_transfer_ball_transferred.md
@@ -7,6 +7,8 @@ title: playfield_transfer_(playfield_transfer)_ball_transferred
 
 --8<-- "event.md"
 
+Event is posted by [playfield_transfers:](../config/playfield_transfers.md)
+
 The playfield_transfer called (playfield_transfer) transferred a ball
 from playfield (source) to playfield (target).
 
@@ -23,5 +25,3 @@ The source playfield.
 #### `target`:
 
 The target playfield.
-
-Event is posted by [playfield_transfers:](../config/playfield_transfers.md)

--- a/docs/events/playfield_transfer_playfield_transfer_ball_transferred.md
+++ b/docs/events/playfield_transfer_playfield_transfer_ball_transferred.md
@@ -2,7 +2,7 @@
 title: playfield_transfer_(playfield_transfer)_ball_transferred
 ---
 
-# playfield_transfer_(playfield_transfer)_ball_transferred
+# playfield_transfer_(playfield_transfer)\_ball_transferred
 
 
 --8<-- "event.md"
@@ -16,12 +16,12 @@ from playfield (source) to playfield (target).
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`source`
+#### `source`:
 
-:   The source playfield.
+The source playfield.
 
-`target`
+#### `target`:
 
-:   The target playfield.
+The target playfield.
 
 Event is posted by [playfield_transfers:](../config/playfield_transfers.md)

--- a/docs/events/reel_score_reel_advanced.md
+++ b/docs/events/reel_score_reel_advanced.md
@@ -11,4 +11,4 @@ Event is posted by [score_reels:](../config/score_reels.md)
 
 The reel (name) advanced to the next position.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/reel_score_reel_advanced.md
+++ b/docs/events/reel_score_reel_advanced.md
@@ -2,7 +2,7 @@
 title: reel_(name)_advanced
 ---
 
-# reel_(name)_advanced
+# reel_(name)\_advanced
 
 
 --8<-- "event.md"

--- a/docs/events/reel_score_reel_advanced.md
+++ b/docs/events/reel_score_reel_advanced.md
@@ -7,8 +7,8 @@ title: reel_(name)_advanced
 
 --8<-- "event.md"
 
+Event is posted by [score_reels:](../config/score_reels.md)
+
 The reel (name) advanced to the next position.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [score_reels:](../config/score_reels.md)

--- a/docs/events/request_to_start_game.md
+++ b/docs/events/request_to_start_game.md
@@ -15,4 +15,4 @@ Posting this event is the only way to start a game in MPF, since many
 systems have to "approve" the start. (Are the balls in the right
 places, are there enough credits, etc.)
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/reset_complete.md
+++ b/docs/events/reset_complete.md
@@ -9,4 +9,4 @@ title: reset_complete
 
 The machine reset process is complete
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/sequence_shot_hit.md
+++ b/docs/events/sequence_shot_hit.md
@@ -7,6 +7,8 @@ title: (sequence_shot_name)_hit
 
 --8<-- "event.md"
 
+Event is posted by [sequence_shots:](../config/sequence_shots.md)
+
 The sequence_shot called (sequence_shot_name) was just completed.
 
 ## Keyword arguments
@@ -21,5 +23,3 @@ only respond to certain combinations of the arguments below.)
 How much time has elapsed since the sequence shot started. (e.g. how long did this sequence shot take to complete?)
 
 You can use the elapsed parameter to troubleshoot sequence_shot timeouts or for estimating ball speed. The elapsed time posted in the sequence shot hit event can be easily used to trigger other things like a speed calculation.
-
-Event is posted by [sequence_shots:](../config/sequence_shots.md)

--- a/docs/events/sequence_shot_hit.md
+++ b/docs/events/sequence_shot_hit.md
@@ -2,7 +2,7 @@
 title: (sequence_shot_name)_hit
 ---
 
-# (sequence_shot_name)_hit
+# (sequence_shot_name)\_hit
 
 
 --8<-- "event.md"
@@ -15,9 +15,10 @@ The sequence_shot called (sequence_shot_name) was just completed.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`elapsed` (added in MPF 0.56.1)
+#### `elapsed`:
+*added in MPF 0.56.1*
 
-:   how much time has elapsed since the sequence shot started. (e.g. how long did this sequence shot take to complete?)
+How much time has elapsed since the sequence shot started. (e.g. how long did this sequence shot take to complete?)
 
 You can use the elapsed parameter to troubleshoot sequence_shot timeouts or for estimating ball speed. The elapsed time posted in the sequence shot hit event can be easily used to trigger other things like a speed calculation.
 

--- a/docs/events/shot_group_complete.md
+++ b/docs/events/shot_group_complete.md
@@ -2,7 +2,7 @@
 title: (shot_group_name)_complete
 ---
 
-# (shot_group_name)_complete
+# (shot_group_name)\_complete
 
 
 --8<-- "event.md"
@@ -16,8 +16,8 @@ state.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`state`
+#### `state`:
 
-:   name of the common state of all shots.
+name of the common state of all shots.
 
 Event is posted by [shot_groups:](../config/shot_groups.md)

--- a/docs/events/shot_group_complete.md
+++ b/docs/events/shot_group_complete.md
@@ -7,6 +7,8 @@ title: (shot_group_name)_complete
 
 --8<-- "event.md"
 
+Event is posted by [shot_groups:](../config/shot_groups.md)
+
 All the member shots in the shot group called (shot_group_name) are in the same
 state.
 
@@ -19,5 +21,3 @@ only respond to certain combinations of the arguments below.)
 #### `state`:
 
 name of the common state of all shots.
-
-Event is posted by [shot_groups:](../config/shot_groups.md)

--- a/docs/events/shot_group_hit.md
+++ b/docs/events/shot_group_hit.md
@@ -7,8 +7,8 @@ title: (shot_group_name)_hit
 
 --8<-- "event.md"
 
+Event is posted by [shot_groups:](../config/shot_groups.md)
+
 A member shots in the shot group called (shot_group_name) has been hit.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [shot_groups:](../config/shot_groups.md)

--- a/docs/events/shot_group_hit.md
+++ b/docs/events/shot_group_hit.md
@@ -2,7 +2,7 @@
 title: (shot_group_name)_hit
 ---
 
-# (shot_group_name)_hit
+# (shot_group_name)\_hit
 
 
 --8<-- "event.md"

--- a/docs/events/shot_group_hit.md
+++ b/docs/events/shot_group_hit.md
@@ -11,4 +11,4 @@ Event is posted by [shot_groups:](../config/shot_groups.md)
 
 A member shots in the shot group called (shot_group_name) has been hit.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/shot_group_state_complete.md
+++ b/docs/events/shot_group_state_complete.md
@@ -7,9 +7,9 @@ title: (shot_group_name)_(state)_complete
 
 --8<-- "event.md"
 
+Event is posted by [shot_groups:](../config/shot_groups.md)
+
 All the member shots in the shot group called (shot_group_name) are in the same
 state named (state).
 
 *This event does not have any keyword arguments*
-
-Event is posted by [shot_groups:](../config/shot_groups.md)

--- a/docs/events/shot_group_state_complete.md
+++ b/docs/events/shot_group_state_complete.md
@@ -2,7 +2,7 @@
 title: (shot_group_name)_(state)_complete
 ---
 
-# (shot_group_name)_(state)_complete
+# (shot_group_name)\_(state)\_complete
 
 
 --8<-- "event.md"

--- a/docs/events/shot_group_state_complete.md
+++ b/docs/events/shot_group_state_complete.md
@@ -12,4 +12,4 @@ Event is posted by [shot_groups:](../config/shot_groups.md)
 All the member shots in the shot group called (shot_group_name) are in the same
 state named (state).
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/shot_group_state_hit.md
+++ b/docs/events/shot_group_state_hit.md
@@ -2,7 +2,7 @@
 title: (shot_group_name)_(state)_hit
 ---
 
-# (shot_group_name)_(state)_hit
+# (shot_group_name)\_(state)\_hit
 
 
 --8<-- "event.md"

--- a/docs/events/shot_group_state_hit.md
+++ b/docs/events/shot_group_state_hit.md
@@ -11,4 +11,4 @@ Event is posted by [shot_groups:](../config/shot_groups.md)
 
 A member shot with state (state) in the shot group (shot_group_name) has been hit.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/shot_group_state_hit.md
+++ b/docs/events/shot_group_state_hit.md
@@ -7,8 +7,8 @@ title: (shot_group_name)_(state)_hit
 
 --8<-- "event.md"
 
+Event is posted by [shot_groups:](../config/shot_groups.md)
+
 A member shot with state (state) in the shot group (shot_group_name) has been hit.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [shot_groups:](../config/shot_groups.md)

--- a/docs/events/shot_hit.md
+++ b/docs/events/shot_hit.md
@@ -7,6 +7,8 @@ title: (shot_name)_hit
 
 --8<-- "event.md"
 
+Event is posted by [shots:](../config/shots.md)
+
 The shot called (shot_name) was just hit.
 
 Note that there are four events posted when a shot is hit, each with
@@ -26,5 +28,3 @@ The name of the profile that was active when hit.
 #### `state`:
 
 The name of the state the profile was in when it was hit
-
-Event is posted by [shots:](../config/shots.md)

--- a/docs/events/shot_hit.md
+++ b/docs/events/shot_hit.md
@@ -2,7 +2,7 @@
 title: (shot_name)_hit
 ---
 
-# (shot_name)_hit
+# (shot_name)\_hit
 
 
 --8<-- "event.md"
@@ -19,12 +19,12 @@ key in on the specific granularity you need.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`profile`
+#### `profile`:
 
-:   The name of the profile that was active when hit.
+The name of the profile that was active when hit.
 
-`state`
+#### `state`:
 
-:   The name of the state the profile was in when it was hit
+The name of the state the profile was in when it was hit
 
 Event is posted by [shots:](../config/shots.md)

--- a/docs/events/shot_profile_hit.md
+++ b/docs/events/shot_profile_hit.md
@@ -2,7 +2,7 @@
 title: (shot_name)_(profile)_hit
 ---
 
-# (shot_name)_(profile)_hit
+# (shot_name)\_(profile)\_hit
 
 
 --8<-- "event.md"
@@ -24,12 +24,12 @@ might result in this event being posted multiple times with different
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`profile`
+#### `profile`:
 
-:   The name of the profile that was active when hit.
+The name of the profile that was active when hit.
 
-`state`
+#### `state`:
 
-:   The name of the state the profile was in when it was hit
+The name of the state the profile was in when it was hit
 
 Event is posted by [shots:](../config/shots.md)

--- a/docs/events/shot_profile_hit.md
+++ b/docs/events/shot_profile_hit.md
@@ -7,6 +7,8 @@ title: (shot_name)_(profile)_hit
 
 --8<-- "event.md"
 
+Event is posted by [shots:](../config/shots.md)
+
 The shot called (shot_name) was just hit with the profile (profile) active.
 
 Note that there are four events posted when a shot is hit, each with
@@ -31,5 +33,3 @@ The name of the profile that was active when hit.
 #### `state`:
 
 The name of the state the profile was in when it was hit
-
-Event is posted by [shots:](../config/shots.md)

--- a/docs/events/shot_profile_state_hit.md
+++ b/docs/events/shot_profile_state_hit.md
@@ -7,6 +7,8 @@ title: (shot_name)_(profile)_(state)_hit
 
 --8<-- "event.md"
 
+Event is posted by [shots:](../config/shots.md)
+
 The shot called (shot_name) was just hit with the profile (profile) active in
 the state (state).
 
@@ -32,5 +34,3 @@ The name of the profile that was active when hit.
 #### `state`:
 
 The name of the state the profile was in when it was hit
-
-Event is posted by [shots:](../config/shots.md)

--- a/docs/events/shot_profile_state_hit.md
+++ b/docs/events/shot_profile_state_hit.md
@@ -2,7 +2,7 @@
 title: (shot_name)_(profile)_(state)_hit
 ---
 
-# (shot_name)\_(profile)\_(state)_hit
+# (shot_name)\_(profile)\_(state)\_hit
 
 
 --8<-- "event.md"
@@ -25,12 +25,12 @@ might result in this event being posted multiple times with different
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`profile`
+#### `profile`:
 
-:   The name of the profile that was active when hit.
+The name of the profile that was active when hit.
 
-`state`
+#### `state`:
 
-:   The name of the state the profile was in when it was hit
+The name of the state the profile was in when it was hit
 
 Event is posted by [shots:](../config/shots.md)

--- a/docs/events/shot_state_hit.md
+++ b/docs/events/shot_state_hit.md
@@ -7,6 +7,8 @@ title: (shot_name)_(state)_hit
 
 --8<-- "event.md"
 
+Event is posted by [shots:](../config/shots.md)
+
 The shot called (shot_name) was just hit while in the profile (state).
 
 Note that there are four events posted when a shot is hit, each with
@@ -31,5 +33,3 @@ The name of the profile that was active when hit.
 #### `state`:
 
 The name of the state the profile was in when it was hit
-
-Event is posted by [shots:](../config/shots.md)

--- a/docs/events/shot_state_hit.md
+++ b/docs/events/shot_state_hit.md
@@ -2,7 +2,7 @@
 title: (shot_name)_(state)_hit
 ---
 
-# (shot_name)_(state)_hit
+# (shot_name)\_(state)\_hit
 
 
 --8<-- "event.md"
@@ -24,12 +24,12 @@ might result in this event being posted multiple times with different
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`profile`
+#### `profile`:
 
-:   The name of the profile that was active when hit.
+The name of the profile that was active when hit.
 
-`state`
+#### `state`:
 
-:   The name of the state the profile was in when it was hit
+The name of the state the profile was in when it was hit
 
 Event is posted by [shots:](../config/shots.md)

--- a/docs/events/shutdown.md
+++ b/docs/events/shutdown.md
@@ -10,4 +10,4 @@ title: shutdown
 Posted when the machine is shutting down to give all modules a chance to
 shut down gracefully.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/single_player_ball_started.md
+++ b/docs/events/single_player_ball_started.md
@@ -9,4 +9,4 @@ title: single_player_ball_started
 
 A new ball has started, and this is a single player game.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/slam_tilt.md
+++ b/docs/events/slam_tilt.md
@@ -9,4 +9,4 @@ title: slam_tilt
 
 A slam tilt has just occurred.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/slide_slide_active.md
+++ b/docs/events/slide_slide_active.md
@@ -2,7 +2,7 @@
 title: slide_(name)_active
 ---
 
-# slide_(name)_active
+# slide_(name)\_active
 
 
 *MPF-MC Event*

--- a/docs/events/slide_slide_active.md
+++ b/docs/events/slide_slide_active.md
@@ -7,6 +7,8 @@ title: slide_(name)_active
 
 *MPF-MC Event*
 
+Event is posted by [slides:](../config/slides.md)
+
 A slide called (name) has just become active, meaning that it's now
 showing as the current slide. This is useful for things like the
 widget_player where you want to target a widget for a specific slide,
@@ -15,5 +17,3 @@ into account what display they're playing on, so be sure to create
 machine-wide unique names when you're naming your slides.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [slides:](../config/slides.md)

--- a/docs/events/slide_slide_active.md
+++ b/docs/events/slide_slide_active.md
@@ -16,4 +16,4 @@ but you can only do so if that slide exists. Slide names do not take
 into account what display they're playing on, so be sure to create
 machine-wide unique names when you're naming your slides.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/slide_slide_created.md
+++ b/docs/events/slide_slide_created.md
@@ -23,4 +23,4 @@ Slide names do not take into account what display or slide frame
 they're playing on, so be sure to create machine-wide unique names when
 you're naming your slides.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/slide_slide_created.md
+++ b/docs/events/slide_slide_created.md
@@ -7,6 +7,8 @@ title: slide_(name)_created
 
 *MPF-MC Event*
 
+Event is posted by [slides:](../config/slides.md)
+
 A slide called (name) has just been created.
 
 This means that this slide now exists, but it's not necessarily the
@@ -22,5 +24,3 @@ they're playing on, so be sure to create machine-wide unique names when
 you're naming your slides.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [slides:](../config/slides.md)

--- a/docs/events/slide_slide_created.md
+++ b/docs/events/slide_slide_created.md
@@ -2,7 +2,7 @@
 title: slide_(name)_created
 ---
 
-# slide_(name)_created
+# slide_(name)\_created
 
 
 *MPF-MC Event*

--- a/docs/events/slide_slide_removed.md
+++ b/docs/events/slide_slide_removed.md
@@ -2,7 +2,7 @@
 title: slide_(name)_removed
 ---
 
-# slide_(name)_removed
+# slide_(name)\_removed
 
 
 *MPF-MC Event*

--- a/docs/events/slide_slide_removed.md
+++ b/docs/events/slide_slide_removed.md
@@ -22,4 +22,4 @@ Slide names do not take into account what display or slide frame
 they're playing on, so be sure to create machine-wide unique names when
 you're naming your slides.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/slide_slide_removed.md
+++ b/docs/events/slide_slide_removed.md
@@ -7,6 +7,8 @@ title: slide_(name)_removed
 
 *MPF-MC Event*
 
+Event is posted by [slides:](../config/slides.md)
+
 A slide called (name) has just been removed.
 
 This event is posted whenever a slide is removed, regardless of whether
@@ -21,5 +23,3 @@ they're playing on, so be sure to create machine-wide unique names when
 you're naming your slides.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [slides:](../config/slides.md)

--- a/docs/events/spinner_spinner_active.md
+++ b/docs/events/spinner_spinner_active.md
@@ -2,7 +2,7 @@
 title: spinner_(name)_active
 ---
 
-# spinner_(name)_active
+# spinner_(name)\_active
 
 
 --8<-- "event.md"
@@ -18,8 +18,8 @@ not already active.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`label`
+#### `label`:
 
-:   The label of the switch that triggered the activation
+The label of the switch that triggered the activation
 
 Event is posted by [spinners:](../config/spinners.md)

--- a/docs/events/spinner_spinner_active.md
+++ b/docs/events/spinner_spinner_active.md
@@ -7,6 +7,8 @@ title: spinner_(name)_active
 
 --8<-- "event.md"
 
+Event is posted by [spinners:](../config/spinners.md)
+
 The idle spinner (name) was just hit and became active.
 
 This event will post whenever a spinner switch is hit and the spinner is
@@ -21,5 +23,3 @@ only respond to certain combinations of the arguments below.)
 #### `label`:
 
 The label of the switch that triggered the activation
-
-Event is posted by [spinners:](../config/spinners.md)

--- a/docs/events/spinner_spinner_hit.md
+++ b/docs/events/spinner_spinner_hit.md
@@ -2,7 +2,7 @@
 title: spinner_(name)_hit
 ---
 
-# spinner_(name)_hit
+# spinner_(name)\_hit
 
 
 --8<-- "event.md"
@@ -17,12 +17,12 @@ This event will post whenever a spinner switch is hit.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`hits`
+#### `hits`:
 
-:   The number of switch hits the spinner has had since it became active
+The number of switch hits the spinner has had since it became active
 
-`label`
+#### `label`:
 
-:   The label of the switch that was hit
+The label of the switch that was hit
 
 Event is posted by [spinners:](../config/spinners.md)

--- a/docs/events/spinner_spinner_hit.md
+++ b/docs/events/spinner_spinner_hit.md
@@ -7,6 +7,8 @@ title: spinner_(name)_hit
 
 --8<-- "event.md"
 
+Event is posted by [spinners:](../config/spinners.md)
+
 The spinner (name) was just hit.
 
 This event will post whenever a spinner switch is hit.
@@ -24,5 +26,3 @@ The number of switch hits the spinner has had since it became active
 #### `label`:
 
 The label of the switch that was hit
-
-Event is posted by [spinners:](../config/spinners.md)

--- a/docs/events/spinner_spinner_idle.md
+++ b/docs/events/spinner_spinner_idle.md
@@ -7,6 +7,8 @@ title: spinner_(name)_idle
 
 --8<-- "event.md"
 
+Event is posted by [spinners:](../config/spinners.md)
+
 The spinner (name) is now idle
 
 This event will post whenever a spinner has not received hits and its
@@ -22,5 +24,3 @@ only respond to certain combinations of the arguments below.)
 #### `hits`:
 
 The number of switch hits the spinner had while it was active
-
-Event is posted by [spinners:](../config/spinners.md)

--- a/docs/events/spinner_spinner_idle.md
+++ b/docs/events/spinner_spinner_idle.md
@@ -2,7 +2,7 @@
 title: spinner_(name)_idle
 ---
 
-# spinner_(name)_idle
+# spinner_(name)\_idle
 
 
 --8<-- "event.md"
@@ -19,8 +19,8 @@ post.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`hits`
+#### `hits`:
 
-:   The number of switch hits the spinner had while it was active
+The number of switch hits the spinner had while it was active
 
 Event is posted by [spinners:](../config/spinners.md)

--- a/docs/events/spinner_spinner_inactive.md
+++ b/docs/events/spinner_spinner_inactive.md
@@ -2,7 +2,7 @@
 title: spinner_(name)_inactive
 ---
 
-# spinner_(name)_inactive
+# spinner_(name)\_inactive
 
 
 --8<-- "event.md"
@@ -18,8 +18,8 @@ active_ms has timed out.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`hits`
+#### `hits`:
 
-:   The number of switch hits the spinner had while it was active
+The number of switch hits the spinner had while it was active
 
 Event is posted by [spinners:](../config/spinners.md)

--- a/docs/events/spinner_spinner_inactive.md
+++ b/docs/events/spinner_spinner_inactive.md
@@ -7,6 +7,8 @@ title: spinner_(name)_inactive
 
 --8<-- "event.md"
 
+Event is posted by [spinners:](../config/spinners.md)
+
 The spinner (name) is no longer receiving hits
 
 This event will post whenever a spinner has not received hits and its
@@ -21,5 +23,3 @@ only respond to certain combinations of the arguments below.)
 #### `hits`:
 
 The number of switch hits the spinner had while it was active
-
-Event is posted by [spinners:](../config/spinners.md)

--- a/docs/events/spinner_spinner_label_active.md
+++ b/docs/events/spinner_spinner_label_active.md
@@ -14,4 +14,4 @@ The idle spinner (name) was just hit and became active.
 This event will post whenever a spinner switch is hit and the spinner is
 not already active, but only if labels are defined for the spinner.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/spinner_spinner_label_active.md
+++ b/docs/events/spinner_spinner_label_active.md
@@ -2,7 +2,7 @@
 title: spinner_(name)_(label)_active
 ---
 
-# spinner_(name)_(label)_active
+# spinner_(name)\_(label)\_active
 
 
 --8<-- "event.md"

--- a/docs/events/spinner_spinner_label_active.md
+++ b/docs/events/spinner_spinner_label_active.md
@@ -7,11 +7,11 @@ title: spinner_(name)_(label)_active
 
 --8<-- "event.md"
 
+Event is posted by [spinners:](../config/spinners.md)
+
 The idle spinner (name) was just hit and became active.
 
 This event will post whenever a spinner switch is hit and the spinner is
 not already active, but only if labels are defined for the spinner.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [spinners:](../config/spinners.md)

--- a/docs/events/spinner_spinner_label_hit.md
+++ b/docs/events/spinner_spinner_label_hit.md
@@ -14,4 +14,4 @@ The spinner (name) was just hit on the switch labelled (label).
 This event will post whenever a spinner switch is hit and labels are
 defined for the spinner
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/spinner_spinner_label_hit.md
+++ b/docs/events/spinner_spinner_label_hit.md
@@ -7,11 +7,11 @@ title: spinner_(name)_(label)_hit
 
 --8<-- "event.md"
 
+Event is posted by [spinners:](../config/spinners.md)
+
 The spinner (name) was just hit on the switch labelled (label).
 
 This event will post whenever a spinner switch is hit and labels are
 defined for the spinner
 
 *This event does not have any keyword arguments*
-
-Event is posted by [spinners:](../config/spinners.md)

--- a/docs/events/spinner_spinner_label_hit.md
+++ b/docs/events/spinner_spinner_label_hit.md
@@ -2,7 +2,7 @@
 title: spinner_(name)_(label)_hit
 ---
 
-# spinner_(name)_(label)_hit
+# spinner_(name)\_(label)\_hit
 
 
 --8<-- "event.md"

--- a/docs/events/sw_playfield_active.md
+++ b/docs/events/sw_playfield_active.md
@@ -2,7 +2,7 @@
 title: sw_(playfield_name)_active
 ---
 
-# sw_(playfield_name)_active
+# sw_(playfield_name)\_active
 
 
 --8<-- "event.md"
@@ -16,8 +16,8 @@ from it.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`balls`
+#### `balls`:
 
-:   The number of balls that were just removed from this playfield.
+The number of balls that were just removed from this playfield.
 
 Event is posted by [playfields:](../config/playfields.md)

--- a/docs/events/sw_playfield_active.md
+++ b/docs/events/sw_playfield_active.md
@@ -7,6 +7,8 @@ title: sw_(playfield_name)_active
 
 --8<-- "event.md"
 
+Event is posted by [playfields:](../config/playfields.md)
+
 The playfield called (playfield_name) was active, though a ball was just removed
 from it.
 
@@ -19,5 +21,3 @@ only respond to certain combinations of the arguments below.)
 #### `balls`:
 
 The number of balls that were just removed from this playfield.
-
-Event is posted by [playfields:](../config/playfields.md)

--- a/docs/events/sw_tag.md
+++ b/docs/events/sw_tag.md
@@ -13,4 +13,4 @@ Posted when a switch with this tag becomes active. Note that this will
 only be posted if there is an event handler for it or if debug is set to
 True on this switch for performance reasons.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/sw_tag.md
+++ b/docs/events/sw_tag.md
@@ -7,10 +7,10 @@ title: sw_(tag)
 
 --8<-- "event.md"
 
+Event is posted by [switches:](../config/switches.md)
+
 Posted when a switch with this tag becomes active. Note that this will
 only be posted if there is an event handler for it or if debug is set to
 True on this switch for performance reasons.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [switches:](../config/switches.md)

--- a/docs/events/sw_tag_active.md
+++ b/docs/events/sw_tag_active.md
@@ -13,4 +13,4 @@ Posted when a switch with this tag becomes active. Note that this will
 only be posted if there is an event handler for it or if debug is set to
 True on this switch for performance reasons.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/sw_tag_active.md
+++ b/docs/events/sw_tag_active.md
@@ -7,10 +7,10 @@ title: sw_(tag)_active
 
 --8<-- "event.md"
 
+Event is posted by [switches:](../config/switches.md)
+
 Posted when a switch with this tag becomes active. Note that this will
 only be posted if there is an event handler for it or if debug is set to
 True on this switch for performance reasons.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [switches:](../config/switches.md)

--- a/docs/events/sw_tag_active.md
+++ b/docs/events/sw_tag_active.md
@@ -2,7 +2,7 @@
 title: sw_(tag)_active
 ---
 
-# sw_(tag)_active
+# sw_(tag)\_active
 
 
 --8<-- "event.md"

--- a/docs/events/sw_tag_inactive.md
+++ b/docs/events/sw_tag_inactive.md
@@ -7,10 +7,10 @@ title: sw_(tag)_inactive
 
 --8<-- "event.md"
 
+Event is posted by [switches:](../config/switches.md)
+
 Posted when a switch with this tag becomes inactive. Note that this will
 only be posted if there is an event handler for it or if debug is set to
 True on this switch for performance reasons.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [switches:](../config/switches.md)

--- a/docs/events/sw_tag_inactive.md
+++ b/docs/events/sw_tag_inactive.md
@@ -2,7 +2,7 @@
 title: sw_(tag)_inactive
 ---
 
-# sw_(tag)_inactive
+# sw_(tag)\_inactive
 
 
 --8<-- "event.md"

--- a/docs/events/sw_tag_inactive.md
+++ b/docs/events/sw_tag_inactive.md
@@ -13,4 +13,4 @@ Posted when a switch with this tag becomes inactive. Note that this will
 only be posted if there is an event handler for it or if debug is set to
 True on this switch for performance reasons.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/switch_active.md
+++ b/docs/events/switch_active.md
@@ -2,7 +2,7 @@
 title: (name)_active
 ---
 
-# (name)_active
+# (name)\_active
 
 
 --8<-- "event.md"

--- a/docs/events/switch_active.md
+++ b/docs/events/switch_active.md
@@ -7,10 +7,10 @@ title: (name)_active
 
 --8<-- "event.md"
 
+Event is posted by [switches:](../config/switches.md)
+
 Posted when this switch becomes active. Note that this will only be
 posted if there is an event handler for it or if debug is set to True on
 this switch for performance reasons.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [switches:](../config/switches.md)

--- a/docs/events/switch_active.md
+++ b/docs/events/switch_active.md
@@ -13,4 +13,4 @@ Posted when this switch becomes active. Note that this will only be
 posted if there is an event handler for it or if debug is set to True on
 this switch for performance reasons.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/switch_inactive.md
+++ b/docs/events/switch_inactive.md
@@ -7,10 +7,10 @@ title: (name)_inactive
 
 --8<-- "event.md"
 
+Event is posted by [switches:](../config/switches.md)
+
 Posted when this switch becomes inactive. Note that this will only be
 posted if there is an event handler for it or if debug is set to True on
 this switch for performance reasons.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [switches:](../config/switches.md)

--- a/docs/events/switch_inactive.md
+++ b/docs/events/switch_inactive.md
@@ -13,4 +13,4 @@ Posted when this switch becomes inactive. Note that this will only be
 posted if there is an event handler for it or if debug is set to True on
 this switch for performance reasons.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/switch_inactive.md
+++ b/docs/events/switch_inactive.md
@@ -2,7 +2,7 @@
 title: (name)_inactive
 ---
 
-# (name)_inactive
+# (name)\_inactive
 
 
 --8<-- "event.md"

--- a/docs/events/switch_switch_active.md
+++ b/docs/events/switch_switch_active.md
@@ -2,7 +2,7 @@
 title: switch_(name)_active
 ---
 
-# switch_(name)_active
+# switch_(name)\_active
 
 
 *MPF-MC Event*

--- a/docs/events/switch_switch_active.md
+++ b/docs/events/switch_switch_active.md
@@ -4,8 +4,9 @@ title: switch_(name)_active
 
 # switch_(name)\_active
 
-
 *MPF-MC Event*
+
+Event is posted by [switches:](../config/switches.md)
 
 Posted on MPF-MC only (e.g. not in MPF) when the MC receives a BCP
 "switch" active command. Useful for video modes and graphical menu
@@ -14,5 +15,3 @@ rather, only for switches that have been configured to send events to
 BCP.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [switches:](../config/switches.md)

--- a/docs/events/switch_switch_active.md
+++ b/docs/events/switch_switch_active.md
@@ -14,4 +14,4 @@ navigation. Note that this is not posted for every switch all the time,
 rather, only for switches that have been configured to send events to
 BCP.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/switch_switch_inactive.md
+++ b/docs/events/switch_switch_inactive.md
@@ -7,12 +7,12 @@ title: switch_(name)_inactive
 
 *MPF-MC Event*
 
+Event is posted by [switches:](../config/switches.md)
+
 Posted on MPF-MC only (e.g. not in MPF) when the MC receives a BCP
 "switch" inactive command. Useful for video modes and graphical menu
 navigation. Note that this is not posted for every switch all the time,
 rather, only for switches that have been configured to send events to
 BCP.
 
-*This event does not have any keyword arguments*
-
-Event is posted by [switches:](../config/switches.md)
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/switch_switch_inactive.md
+++ b/docs/events/switch_switch_inactive.md
@@ -2,7 +2,7 @@
 title: switch_(name)_inactive
 ---
 
-# switch_(name)_inactive
+# switch_(name)\_inactive
 
 
 *MPF-MC Event*

--- a/docs/events/text_input_key_abort.md
+++ b/docs/events/text_input_key_abort.md
@@ -2,7 +2,7 @@
 title: text_input_(key)_abort
 ---
 
-# text_input_(key)_abort
+# text_input_(key)\_abort
 
 
 *MPF-MC Event*
@@ -16,6 +16,6 @@ process was aborted.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`text`
+#### `text`:
 
-:   A string of the characters that were entered so far.
+A string of the characters that were entered so far.

--- a/docs/events/text_input_key_complete.md
+++ b/docs/events/text_input_key_complete.md
@@ -2,7 +2,7 @@
 title: text_input_(key)_complete
 ---
 
-# text_input_(key)_complete
+# text_input_(key)\_complete
 
 
 *MPF-MC Event*
@@ -16,6 +16,6 @@ text is finalized.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`text`
+#### `text`:
 
-:   A string of the final characters that were entered.
+A string of the final characters that were entered.

--- a/docs/events/tilt.md
+++ b/docs/events/tilt.md
@@ -9,4 +9,4 @@ title: tilt
 
 The player has tilted.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/tilt_clear.md
+++ b/docs/events/tilt_clear.md
@@ -11,4 +11,4 @@ Posted after a tilt, when the settling time has passed after the last
 tilt switch hit. This is used to hold the next ball start until the
 plumb bob has settled to prevent tilt throughs.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/tilt_warning.md
+++ b/docs/events/tilt_warning.md
@@ -15,10 +15,10 @@ A tilt warning just happened.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`warnings`
+#### `warnings`:
 
-:   The total number of warnings so far.
+The total number of warnings so far.
 
-`warnings_remaining`
+#### `warnings_remaining`:
 
-:   The remaining number of warnings until a tilt.
+The remaining number of warnings until a tilt.

--- a/docs/events/tilt_warning_number.md
+++ b/docs/events/tilt_warning_number.md
@@ -10,4 +10,4 @@ title: tilt_warning_(number)
 A tilt warning just happened. The number of this tilt warning is in the
 event name in the (number).
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/timed_switch_active.md
+++ b/docs/events/timed_switch_active.md
@@ -7,11 +7,10 @@ title: (timed_switch)_active
 
 --8<-- "event.md"
 
-Posted when one of the switches buttons has been active for `time`.
-
-*This event does not have any keyword arguments*
-
 Event is posted by [timed_switches:](../config/timed_switches.md)
 
-The event name can be changed by using the "events_when_active:"
-attribute.
+Posted when one of the switches buttons has been active for `time`.
+
+The event name can be changed by using the "events_when_active:" attribute.
+
+*This event does not have any keyword arguments*

--- a/docs/events/timed_switch_active.md
+++ b/docs/events/timed_switch_active.md
@@ -11,6 +11,6 @@ Event is posted by [timed_switches:](../config/timed_switches.md)
 
 Posted when one of the switches buttons has been active for `time`.
 
-The event name can be changed by using the "events_when_active:" attribute.
+The event name can be changed by using the `events_when_active:` attribute.
 
 --8<-- "event_no_keywords_notice.md"

--- a/docs/events/timed_switch_active.md
+++ b/docs/events/timed_switch_active.md
@@ -2,7 +2,7 @@
 title: (timed_switch)_active
 ---
 
-# (timed_switch)_active
+# (timed_switch)\_active
 
 
 --8<-- "event.md"

--- a/docs/events/timed_switch_active.md
+++ b/docs/events/timed_switch_active.md
@@ -13,4 +13,4 @@ Posted when one of the switches buttons has been active for `time`.
 
 The event name can be changed by using the "events_when_active:" attribute.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/timed_switch_released.md
+++ b/docs/events/timed_switch_released.md
@@ -7,12 +7,11 @@ title: (timed_switch)_released
 
 --8<-- "event.md"
 
+Event is posted by [timed_switches:](../config/timed_switches.md)
+
 Posted when one of the switches that has previously been active for more
 than `time` has been released.
 
+The event name can be changed by using the "events_when_released:" attribute.
+
 *This event does not have any keyword arguments*
-
-Event is posted by [timed_switches:](../config/timed_switches.md)
-
-The event name can be changed by using the "events_when_released:"
-attribute.

--- a/docs/events/timed_switch_released.md
+++ b/docs/events/timed_switch_released.md
@@ -12,6 +12,6 @@ Event is posted by [timed_switches:](../config/timed_switches.md)
 Posted when one of the switches that has previously been active for more
 than `time` has been released.
 
-The event name can be changed by using the "events_when_released:" attribute.
+The event name can be changed by using the `events_when_released:` attribute.
 
 --8<-- "event_no_keywords_notice.md"

--- a/docs/events/timed_switch_released.md
+++ b/docs/events/timed_switch_released.md
@@ -2,7 +2,7 @@
 title: (timed_switch)_released
 ---
 
-# (timed_switch)_released
+# (timed_switch)\_released
 
 
 --8<-- "event.md"

--- a/docs/events/timed_switch_released.md
+++ b/docs/events/timed_switch_released.md
@@ -14,4 +14,4 @@ than `time` has been released.
 
 The event name can be changed by using the "events_when_released:" attribute.
 
-*This event does not have any keyword arguments*
+--8<-- "event_no_keywords_notice.md"

--- a/docs/events/timer_timer_complete.md
+++ b/docs/events/timer_timer_complete.md
@@ -2,7 +2,7 @@
 title: timer_(name)_complete
 ---
 
-# timer_(name)_complete
+# timer_(name)\_complete
 
 
 --8<-- "event.md"
@@ -18,12 +18,12 @@ posted, depending on its settings.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`ticks`
+#### `ticks`:
 
-:   The current tick number this timer is at.
+The current tick number this timer is at.
 
-`ticks_remaining`
+#### `ticks_remaining`:
 
-:   The number of ticks in this timer remaining.
+The number of ticks in this timer remaining.
 
 Event is posted by [timers:](../config/timers.md)

--- a/docs/events/timer_timer_complete.md
+++ b/docs/events/timer_timer_complete.md
@@ -7,6 +7,8 @@ title: timer_(name)_complete
 
 --8<-- "event.md"
 
+Event is posted by [timers:](../config/timers.md)
+
 The timer named (name) has completed.
 
 Note that this timer may reset and start again after this event is
@@ -25,5 +27,3 @@ The current tick number this timer is at.
 #### `ticks_remaining`:
 
 The number of ticks in this timer remaining.
-
-Event is posted by [timers:](../config/timers.md)

--- a/docs/events/timer_timer_paused.md
+++ b/docs/events/timer_timer_paused.md
@@ -7,6 +7,8 @@ title: timer_(name)_paused
 
 --8<-- "event.md"
 
+Event is posted by [timers:](../config/timers.md)
+
 The timer named (name) has paused.
 
 ## Keyword arguments
@@ -22,5 +24,3 @@ The current tick number this timer is at.
 #### `ticks_remaining`:
 
 The number of ticks in this timer remaining.
-
-Event is posted by [timers:](../config/timers.md)

--- a/docs/events/timer_timer_paused.md
+++ b/docs/events/timer_timer_paused.md
@@ -2,7 +2,7 @@
 title: timer_(name)_paused
 ---
 
-# timer_(name)_paused
+# timer_(name)\_paused
 
 
 --8<-- "event.md"
@@ -15,12 +15,12 @@ The timer named (name) has paused.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`ticks`
+#### `ticks`:
 
-:   The current tick number this timer is at.
+The current tick number this timer is at.
 
-`ticks_remaining`
+#### `ticks_remaining`:
 
-:   The number of ticks in this timer remaining.
+The number of ticks in this timer remaining.
 
 Event is posted by [timers:](../config/timers.md)

--- a/docs/events/timer_timer_started.md
+++ b/docs/events/timer_timer_started.md
@@ -7,6 +7,8 @@ title: timer_(name)_started
 
 --8<-- "event.md"
 
+Event is posted by [timers:](../config/timers.md)
+
 The timer named (name) has just started.
 
 ## Keyword arguments
@@ -22,5 +24,3 @@ The current tick number this timer is at.
 #### `ticks_remaining`:
 
 The number of ticks in this timer remaining.
-
-Event is posted by [timers:](../config/timers.md)

--- a/docs/events/timer_timer_started.md
+++ b/docs/events/timer_timer_started.md
@@ -2,7 +2,7 @@
 title: timer_(name)_started
 ---
 
-# timer_(name)_started
+# timer_(name)\_started
 
 
 --8<-- "event.md"
@@ -15,12 +15,12 @@ The timer named (name) has just started.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`ticks`
+#### `ticks`:
 
-:   The current tick number this timer is at.
+The current tick number this timer is at.
 
-`ticks_remaining`
+#### `ticks_remaining`:
 
-:   The number of ticks in this timer remaining.
+The number of ticks in this timer remaining.
 
 Event is posted by [timers:](../config/timers.md)

--- a/docs/events/timer_timer_stopped.md
+++ b/docs/events/timer_timer_stopped.md
@@ -2,7 +2,7 @@
 title: timer_(name)_stopped
 ---
 
-# timer_(name)_stopped
+# timer_(name)\_stopped
 
 
 --8<-- "event.md"
@@ -18,12 +18,12 @@ it ended or because it was stopped early by some other event.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`ticks`
+#### `ticks`:
 
-:   The current tick number this timer is at.
+The current tick number this timer is at.
 
-`ticks_remaining`
+#### `ticks_remaining`:
 
-:   The number of ticks in this timer remaining.
+The number of ticks in this timer remaining.
 
 Event is posted by [timers:](../config/timers.md)

--- a/docs/events/timer_timer_stopped.md
+++ b/docs/events/timer_timer_stopped.md
@@ -7,6 +7,8 @@ title: timer_(name)_stopped
 
 --8<-- "event.md"
 
+Event is posted by [timers:](../config/timers.md)
+
 The timer named (name) has stopped.
 
 This event is posted any time the timer stops, whether it stops because
@@ -25,5 +27,3 @@ The current tick number this timer is at.
 #### `ticks_remaining`:
 
 The number of ticks in this timer remaining.
-
-Event is posted by [timers:](../config/timers.md)

--- a/docs/events/timer_timer_tick.md
+++ b/docs/events/timer_timer_tick.md
@@ -2,7 +2,7 @@
 title: timer_(name)_tick
 ---
 
-# timer_(name)_tick
+# timer_(name)\_tick
 
 
 --8<-- "event.md"
@@ -16,12 +16,12 @@ settings).
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`ticks`
+#### `ticks`:
 
-:   The new tick number this timer is at.
+The new tick number this timer is at.
 
-`ticks_remaining`
+#### `ticks_remaining`:
 
-:   The new number of ticks in this timer remaining.
+The new number of ticks in this timer remaining.
 
 Event is posted by [timers:](../config/timers.md)

--- a/docs/events/timer_timer_tick.md
+++ b/docs/events/timer_timer_tick.md
@@ -7,6 +7,8 @@ title: timer_(name)_tick
 
 --8<-- "event.md"
 
+Event is posted by [timers:](../config/timers.md)
+
 The timer named (name) has just counted down (or up, depending on its
 settings).
 
@@ -23,5 +25,3 @@ The new tick number this timer is at.
 #### `ticks_remaining`:
 
 The new number of ticks in this timer remaining.
-
-Event is posted by [timers:](../config/timers.md)

--- a/docs/events/timer_timer_time_added.md
+++ b/docs/events/timer_timer_time_added.md
@@ -7,6 +7,8 @@ title: timer_(name)_time_added
 
 --8<-- "event.md"
 
+Event is posted by [timers:](../config/timers.md)
+
 The timer named (name) has just had time added to it.
 
 ## Keyword arguments
@@ -26,5 +28,3 @@ How many ticks were just added.
 #### `ticks_remaining`:
 
 The new number of ticks in this timer remaining.
-
-Event is posted by [timers:](../config/timers.md)

--- a/docs/events/timer_timer_time_added.md
+++ b/docs/events/timer_timer_time_added.md
@@ -2,7 +2,7 @@
 title: timer_(name)_time_added
 ---
 
-# timer_(name)_time_added
+# timer_(name)\_time_added
 
 
 --8<-- "event.md"
@@ -15,16 +15,16 @@ The timer named (name) has just had time added to it.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`ticks`
+#### `ticks`:
 
-:   The new tick number this timer is at.
+The new tick number this timer is at.
 
-`ticks_added`
+#### `ticks_added`:
 
-:   How many ticks were just added.
+How many ticks were just added.
 
-`ticks_remaining`
+#### `ticks_remaining`:
 
-:   The new number of ticks in this timer remaining.
+The new number of ticks in this timer remaining.
 
 Event is posted by [timers:](../config/timers.md)

--- a/docs/events/timer_timer_time_subtracted.md
+++ b/docs/events/timer_timer_time_subtracted.md
@@ -7,6 +7,8 @@ title: timer_(name)_time_subtracted
 
 --8<-- "event.md"
 
+Event is posted by [timers:](../config/timers.md)
+
 The timer named (name) just had some ticks removed.
 
 ## Keyword arguments
@@ -27,5 +29,3 @@ The new number of ticks in this timer remaining.
 
 How many ticks were just subtracted from this timer.
 (This number will be positive, indicating the ticks subtracted.)
-
-Event is posted by [timers:](../config/timers.md)

--- a/docs/events/timer_timer_time_subtracted.md
+++ b/docs/events/timer_timer_time_subtracted.md
@@ -2,7 +2,7 @@
 title: timer_(name)_time_subtracted
 ---
 
-# timer_(name)_time_subtracted
+# timer_(name)\_time_subtracted
 
 
 --8<-- "event.md"
@@ -15,17 +15,17 @@ The timer named (name) just had some ticks removed.
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`ticks`
+#### `ticks`:
 
-:   The new current tick number this timer is at.
+The new current tick number this timer is at.
 
-`ticks_remaining`
+#### `ticks_remaining`:
 
-:   The new number of ticks in this timer remaining.
+The new number of ticks in this timer remaining.
 
-`ticks_subtracted`
+#### `ticks_subtracted`:
 
-:   How many ticks were just subtracted from this timer. (This number
-    will be positive, indicating the ticks subtracted.)
+How many ticks were just subtracted from this timer.
+(This number will be positive, indicating the ticks subtracted.)
 
 Event is posted by [timers:](../config/timers.md)

--- a/docs/events/twitch_bit_donation.md
+++ b/docs/events/twitch_bit_donation.md
@@ -15,14 +15,14 @@ A chat user has donated bits on Twitch
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`bits`
+#### `bits`:
 
-:   The number of bits donated
+The number of bits donated
 
-`message`
+#### `message`:
 
-:   Chat message text
+Chat message text
 
-`user`
+#### `user`:
 
-:   The chat user name who subscribed
+The chat user name who subscribed

--- a/docs/events/twitch_chat_message.md
+++ b/docs/events/twitch_chat_message.md
@@ -15,38 +15,38 @@ A chat message was received via Twitch
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`line_1`
+#### `line_1`:
 
-:   Split line 1
+Split line 1
 
-`line_2`
+#### `line_2`:
 
-:   Split line 2
+Split line 2
 
-`line_3`
+#### `line_3`:
 
-:   Split line 3
+Split line 3
 
-`line_4`
+#### `line_4`:
 
-:   Split line 4
+Split line 4
 
-`line_5`
+#### `line_5`:
 
-:   Split line 5
+Split line 5
 
-`line_6`
+#### `line_6`:
 
-:   Split line 6
+Split line 6
 
-`line_count`
+#### `line_count`:
 
-:   The number of lines that the text splitter produced
+The number of lines that the text splitter produced
 
-`message`
+#### `message`:
 
-:   Full chat message text
+Full chat message text
 
-`user`
+#### `user`:
 
-:   The chat user name who subscribed
+The chat user name who subscribed

--- a/docs/events/twitch_command.md
+++ b/docs/events/twitch_command.md
@@ -15,10 +15,10 @@ A user typed a line that begins with ! or ?
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`command`
+#### `command`:
 
-:   The text after the ! or ?
+The text after the ! or ?
 
-`user`
+#### `user`:
 
-:   The chat user who executed the command
+The chat user who executed the command

--- a/docs/events/twitch_raid.md
+++ b/docs/events/twitch_raid.md
@@ -15,10 +15,10 @@ Another Twitch user has raided your channel
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`raid_count`
+#### `raid_count`:
 
-:   The count of viewers in the raid
+The count of viewers in the raid
 
-`raid_user`
+#### `raid_user`:
 
-:   The user who raided
+The user who raided

--- a/docs/events/twitch_subscription.md
+++ b/docs/events/twitch_subscription.md
@@ -15,34 +15,34 @@ A chat user has subscribed or resubscribed on Twitch
 guide for details for how to create entries in your config file that
 only respond to certain combinations of the arguments below.)
 
-`gift`
+#### `gift`:
 
-:   True if this sub was gifted by another user
+True if this sub was gifted by another user
 
-`message`
+#### `message`:
 
-:   Chat message text
+Chat message text
 
-`months`
+#### `months`:
 
-:   The number of months that the user has been a subscriber
+The number of months that the user has been a subscriber
 
-`sub_plan`
+#### `sub_plan`:
 
-:   The subscription tier (Prime, 1000, 2000, 3000)
+The subscription tier (Prime, 1000, 2000, 3000)
 
-`sub_plan_name`
+#### `sub_plan_name`:
 
-:   The streamer specific name for the sub tier
+The streamer specific name for the sub tier
 
-`sub_recipient`
+#### `sub_recipient`:
 
-:   The user who is subscribing
+The user who is subscribing
 
-`subscriber_message`
+#### `subscriber_message`:
 
-:   The message the user typed when subscribing
+The message the user typed when subscribing
 
-`user`
+#### `user`:
 
-:   The chat user name who paid for the subscription
+The chat user name who paid for the subscription

--- a/docs/events/unexpected_ball_on_playfield.md
+++ b/docs/events/unexpected_ball_on_playfield.md
@@ -7,9 +7,9 @@ title: unexpected_ball_on_(playfield_name)
 
 --8<-- "event.md"
 
+Event is posted by [playfields:](../config/playfields.md)
+
 The playfield named (playfield_name) just had a switch hit, meaning a ball is on
 it, but that ball was not expected.
 
 *This event does not have any keyword arguments*
-
-Event is posted by [playfields:](../config/playfields.md)

--- a/docs/events/unexpected_ball_on_playfield.md
+++ b/docs/events/unexpected_ball_on_playfield.md
@@ -12,4 +12,5 @@ Event is posted by [playfields:](../config/playfields.md)
 The playfield named (playfield_name) just had a switch hit, meaning a ball is on
 it, but that ball was not expected.
 
-*This event does not have any keyword arguments*
+
+--8<-- "event_no_keywords_notice.md"

--- a/includes/event_no_keywords_notice.md
+++ b/includes/event_no_keywords_notice.md
@@ -1,0 +1,1 @@
+*This event does not have any keyword arguments*


### PR DESCRIPTION
I moved the posted-by line up to the top (instead of last/kinda in the keywords section), changed the keywords to each be h4s so that anchor-links can be made to them, moved the no-keywords notice to an include, and made misc fixes and tweaks