### PR TITLE
Updated command reference

### DIFF
--- a/docs/finalization/software.md
+++ b/docs/finalization/software.md
@@ -5,17 +5,17 @@ title: Tuning Software for Production
 # Tuning Software for Production
 
 
-## Run MPF in production mode
+## Run MPF in Production mode
 
 YAML is quite slow to parse and reading configs dominates the startup
 time of MPF and MPF-MC. This is mostly fine during development and we
 can partially mitigate the costs by caching. However, things are
 different when running a production machine as caching will not work on
 a cold boot with a typical read-only setup. Usually production machine
-setups use less beefy computers with slower disks which makes thinks
+setups use less beefy computers with slower disks which makes things
 even worse.
 
-Starting with version 0.54 MPF has a production mode which will use
+Starting with version 0.54, MPF has a production mode which will use
 pre-compiled config bundles for much faster start-up times.
 Additionally, this will disable some expensive config and runtime
 validations to increase performance. Furthermore this will reduce the

--- a/docs/running/commands/game.md
+++ b/docs/running/commands/game.md
@@ -146,3 +146,26 @@ Like `-x`, except it forces the
 
 Like `-x`, except it forces the
 [Virtual Pinball (VPX) platform](../../hardware/virtual/virtual_pinball_vpx.md).
+
+### -pit
+
+Run a platform integration test.
+
+### --json-logging
+
+Enable json logging to file.
+
+### -P (uppercase)
+
+Enable Production mode. This will suppress errors, wait for hardware on start
+and try to exit when startup fails. It is recommended to run this inside of a loop.
+See: [Software Finalization](../../finalization/software.md)
+
+### -p (lowercase)
+
+Pause on exit. This is useful if you spawn MPF in a transient shell window that would otherwise immediately close when MPF crashes with an error.
+
+### --syslog-address
+
+Log to the specified syslog address. This can be a domain socket such as `/dev/og` on Linux or `/var/run/syslog` on Mac.
+Alternatively, you an specify `host:port` for remote logging over UDP.

--- a/docs/running/commands/index.md
+++ b/docs/running/commands/index.md
@@ -46,10 +46,15 @@ your platform):
 $ mpf hardware firmware_update
 ```
 
+If you do not use any of the specific command names, you are defaulted to `game`.
+
+So `mpf` by itself is the same as `mpf game`.
+
 * [mpf both](both.md)
 * [mpf core](core.md)
 * [mpf diagnosis](diagnosis.md)
 * [mpf game](game.md)
+* [mpf (default)](mpf.md)
 * [mpf mc](mc.md)
 * [mpf imc](imc.md)
 * [mpf migrate](migrate.md)

--- a/docs/running/commands/index.md
+++ b/docs/running/commands/index.md
@@ -46,9 +46,9 @@ your platform):
 $ mpf hardware firmware_update
 ```
 
-If you do not use any of the specific command names, you are defaulted to `game`.
+If you do not use any of the specific command names, you are [defaulted](mpf.md) to `game`.
 
-So `mpf` by itself is the same as `mpf game`.
+So `$ mpf` by itself is the same as `$ mpf game`.
 
 * [mpf both](both.md)
 * [mpf core](core.md)

--- a/docs/running/commands/mpf.md
+++ b/docs/running/commands/mpf.md
@@ -28,3 +28,5 @@ or
 $ mpf game -c my_config
 $ mpf -c my_config
 ```
+
+For options and command reference, see: [mpf game](game.md)

--- a/docs/running/commands/mpf.md
+++ b/docs/running/commands/mpf.md
@@ -1,0 +1,30 @@
+---
+title: mpf (default) (command-line utility)
+---
+
+# `mpf (default)` (command-line utility)
+
+
+When you run the shell command `$ mpf` and you do not include the name of a command,
+the default of `game` will be used.
+
+So the following pairs are equivalent:
+
+```shell
+$ mpf game -btx
+$ mpf -btx
+```
+
+or
+
+```shell
+$ mpf game path/to/game_folder -P
+$ mpf path/to/game_folder -P
+```
+
+or
+
+```shell
+$ mpf game -c my_config
+$ mpf -c my_config
+```

--- a/docs/running/index.md
+++ b/docs/running/index.md
@@ -100,7 +100,8 @@ Here's a list of valid MPF commands. Click on any one of them for full
 details and command-line options.
 
 * [MPF command-line utility](mpf.md) (Starts the MPF game engine and other commands)
-* [mpf](commands/game.md) (Starts the MPF engine)
+* [mpf game](commands/game.md) (Starts the MPF engine)
+* [mpf (default)](commands/mpf.md) (Game is assumed when no command is given)
 * [mpf mc](commands/mc.md) (Starts the MPF Media Controller)
 * [mpf both](commands/both.md) (Starts both the MPF engine and media controller at the same time)
 * [mpf migrate](commands/migrate.md) (Migrates older config and show files to the current version)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - mpf core: running/commands/core.md
       - mpf diagnosis: running/commands/diagnosis.md
       - mpf game: running/commands/game.md
+      - mpf (default): running/commands/mpf.md
       - mpf mc: running/commands/mc.md
       - mpf imc: running/commands/imc.md
       - mpf migrate: running/commands/migrate.md


### PR DESCRIPTION
I added a page explaining that `mpf` with no command is the same as `mpf game`. I also found a handful of options for game (by digging in the mpf codebase) that were not documented, and added them - though I did not try them myself. Except -p, that option is great!

As far as I can tell, there is also no documentation for the machine folder path option for `mpf game`, e.g. when running the command `mpf game path/to/machine -x`. I want to dig into this more before writing specific docs on how it works -- I find all of the machine/config-specifying commands to be a little strange, since you don't provide paths to files, instead providing a filename that is assumed to be located inside <root>/config/ .