### PR TITLE
Change "``` mpf-config" and mc equivalent to yaml for colorized formatting

### DIFF
--- a/docs/config/accelerometers.md
+++ b/docs/config/accelerometers.md
@@ -27,7 +27,7 @@ Like other hardware devices, you create a sub-entry for each
 accelerometer, then under there you configure additional settings. For
 example:
 
-``` mpf-config
+``` yaml
 accelerometers:
   test_accelerometer:
     number: 1

--- a/docs/config/accruals.md
+++ b/docs/config/accruals.md
@@ -51,7 +51,7 @@ Step 3. But since you can enter more than one event for each step, you
 could think of those like *OR*s. So you have Step 1 (event1 *OR* event2)
 *AND* Step 2 (event3) *AND* Step 3 (event4 *OR* event5), like this:
 
-``` mpf-config
+``` yaml
 accruals:
   my_accrual:
     events:
@@ -70,7 +70,7 @@ to form complex logic.)
 
 For example:
 
-``` mpf-config
+``` yaml
 accruals:
   logic_block_1:
     events:

--- a/docs/config/achievement_groups.md
+++ b/docs/config/achievement_groups.md
@@ -24,7 +24,7 @@ the settings for that group.
 Here's an example achievement_groups section from Brooks & Dunn. (This
 is related to the example in the achievements config documentation.)
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 #! # create some empty achievements for the group
 #! achievements:

--- a/docs/config/achievements.md
+++ b/docs/config/achievements.md
@@ -22,7 +22,7 @@ that individual achievement.
 
 Here's an example achievements section from Brooks & Dunn:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 achievements:
   world_tour:

--- a/docs/config/animations.md
+++ b/docs/config/animations.md
@@ -22,7 +22,7 @@ animations with the same name.
 
 For example:
 
-``` mpf-config
+``` yaml
 animations:
   fade_in:
     property: opacity

--- a/docs/config/assets.md
+++ b/docs/config/assets.md
@@ -20,7 +20,7 @@ entry for it to your machine or mode config file.
 
 Let's take a look at an example:
 
-``` mpf-config
+``` yaml
 assets:
   images:
     default:

--- a/docs/config/auditor.md
+++ b/docs/config/auditor.md
@@ -22,7 +22,7 @@ its audits to `/audits/audits.yaml` in the folder for each machine.
 (Check out the documentation on the Auditor to see a sample audit log
 file.)
 
-``` mpf-config
+``` yaml
 auditor:
   save_events: ball_ended game_ended
   audit: shots switches events player

--- a/docs/config/autofire_coils.md
+++ b/docs/config/autofire_coils.md
@@ -18,7 +18,7 @@ on a switch activation in a pinball machine.
 
 Here's an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_left_sling:
     number: 1
@@ -109,7 +109,7 @@ of the coil for this device.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_left_sling:
     number: 1

--- a/docs/config/ball_devices.md
+++ b/docs/config/ball_devices.md
@@ -365,7 +365,7 @@ Additional ejectors:
 
 * mpf.devices.ball_device.event_ejector.EventEjector
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_ball_switch1:
 #!     number:

--- a/docs/config/ball_holds.md
+++ b/docs/config/ball_holds.md
@@ -25,7 +25,7 @@ used to hold balls from ball-to-ball or between players.
 
 Here's an example
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_ball1:
 #!     number:

--- a/docs/config/ball_saves.md
+++ b/docs/config/ball_saves.md
@@ -15,7 +15,7 @@ title: "ball_saves:"
 The `ball_saves:` section of your config is where you create [ball save
 devices](#). Here's an example:
 
-``` mpf-config
+``` yaml
 ball_saves:
   default:
     active_time: 10s

--- a/docs/config/bcp.md
+++ b/docs/config/bcp.md
@@ -19,7 +19,7 @@ There's a default `bcp:` section in the default `mpfconfig.yaml`
 system-wide defaults section that should be fine to get started, and
 then you can override it if needed for a specific situation:
 
-``` mpf-config
+``` yaml
 bcp:
   connections:
     local_display:

--- a/docs/config/bitmap_fonts.md
+++ b/docs/config/bitmap_fonts.md
@@ -45,7 +45,7 @@ associated font descriptor file) from True Type Fonts:
 
 Here's an example:
 
-``` mpf-config
+``` yaml
 bitmap_fonts:
   F1fuv:
     file: F1fuv.png

--- a/docs/config/blinkenlight_player.md
+++ b/docs/config/blinkenlight_player.md
@@ -24,7 +24,7 @@ that show step.
 
 Example from a config file:
 
-``` mpf-config
+``` yaml
 blinkenlight_player:
   some_event:
     my_blinkenlight1:
@@ -47,7 +47,7 @@ removed from the blinkenlight.
 
 Example blinkenlight player from a show:
 
-``` mpf-config
+``` yaml
 ##! show: test
 - time: 0
   blinkenlights:

--- a/docs/config/blinkenlights.md
+++ b/docs/config/blinkenlights.md
@@ -21,7 +21,7 @@ flash each of its colors in a cycle according to a given schedule.
 
 Here's an example section:
 
-``` mpf-config
+``` yaml
 #! lights:
 #!   l_left_ramp_arrow:
 #!     channels:

--- a/docs/config/bonus.md
+++ b/docs/config/bonus.md
@@ -25,7 +25,7 @@ bonus mode's mode configuration file.
 
 Here's an example from *Brooks 'n Dunn*:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 mode_settings:
   display_delay_ms: 4000

--- a/docs/config/coil_player.md
+++ b/docs/config/coil_player.md
@@ -24,7 +24,7 @@ coil actions in that show step.
 
 Example from a config file:
 
-``` mpf-config
+``` yaml
 coil_player:
   some_event: coil_1
   some_other_event:
@@ -50,7 +50,7 @@ The coil player's express config is the "pulse" action.
 
 Example coil player from a show:
 
-``` mpf-config
+``` yaml
 ##! show: test
 - time: 0
   coils:

--- a/docs/config/coils.md
+++ b/docs/config/coils.md
@@ -18,7 +18,7 @@ tags, and specify power levels for coils that get held on. This section
 *can* be used in your machine-wide config files. This section *cannot*
 be used in mode-specific config files. Here's an example section:
 
-``` mpf-config
+``` yaml
 coils:
   flipper_right_main:
     number: A0-B0-0

--- a/docs/config/counters.md
+++ b/docs/config/counters.md
@@ -16,7 +16,7 @@ The `counters:` section of your config is where you configure counter
 logic blocks. See also
 [counters](../game_logic/logic_blocks/counters.md). The structure of counter logic blocks is like this:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 counters:
   the_name_of_this_counter:
@@ -37,7 +37,7 @@ using something like `(YOUR_COUNTER_count)` in a slide or widget you can
 use a
 [variable_player](../config_players/variable_player.md) to restore the old behavior:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 variable_player:
   logicblock_YOUR_COUNTER_updated:
@@ -86,7 +86,7 @@ value.
 For instance in the following example `add_five_event` will add `5` to
 the counter:
 
-``` mpf-config
+``` yaml
 counters:
   counter_with_control_events:
     count_events: count_up

--- a/docs/config/credits.md
+++ b/docs/config/credits.md
@@ -20,7 +20,7 @@ credits mode, so be sure to read that for the details. This page just
 contains the settings which control how the credits mode behaves. Here's
 an example config:
 
-``` mpf-config
+``` yaml
 credits:
   max_credits: 12
   free_play: false
@@ -227,7 +227,7 @@ want any price breaks, then just add the first one.
 
 Here's an example:
 
-``` mpf-config
+``` yaml
 credits:
    # ...
   pricing_tiers:
@@ -269,7 +269,7 @@ A list of one or more events with settings which add credits based on
 MPF events. Like the pricing_tiers section, start each entry here with a
 minus sign and a space.
 
-``` mpf-config
+``` yaml
 credits:
    # ...
   events:

--- a/docs/config/displays.md
+++ b/docs/config/displays.md
@@ -23,7 +23,7 @@ DMD and also display an on-screen window, you'll actually have two
 Here's an example `displays:` section from *Demo Man* with two
 displays:
 
-``` mpf-config
+``` yaml
 displays:
   window:
     height: 200

--- a/docs/config/diverters.md
+++ b/docs/config/diverters.md
@@ -16,7 +16,7 @@ You create and configure your diverters in the *diverters:* section of
 your machine configuration file. Here's an example from *Star Trek: The
 Next Generation*:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_ball1:
 #!     number:

--- a/docs/config/dmds.md
+++ b/docs/config/dmds.md
@@ -26,7 +26,7 @@ Note that there are no *height* and *width* settings here. The pixel
 size of your DMD is determined by the size of the `source:` display
 which drives the content for this DMD.
 
-``` mpf-config
+``` yaml
 displays:
   dmd:
     width: 128

--- a/docs/config/drop_target_banks.md
+++ b/docs/config/drop_target_banks.md
@@ -16,7 +16,7 @@ Once you've configured your individual drop targets, you group them
 together into banks via the `drop_target_banks:` section of your config
 file. Here's an example from *Judge Dredd*:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   drop_target_j:
 #!     number:

--- a/docs/config/drop_targets.md
+++ b/docs/config/drop_targets.md
@@ -19,7 +19,7 @@ group them into banks in the `drop_target_banks:` section.) Here's an
 example from *Judge Dredd*, with five drop targets we've given names
 *J*, *U*, *D*, *G*, and *E*.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   drop_target_j:
 #!     number:

--- a/docs/config/dual_wound_coils.md
+++ b/docs/config/dual_wound_coils.md
@@ -18,7 +18,7 @@ be used anywhere in MPF.
 
 Here's an example:
 
-``` mpf-config
+``` yaml
 coils:
   c_hold:
     number:

--- a/docs/config/event_player.md
+++ b/docs/config/event_player.md
@@ -28,7 +28,7 @@ file, entries will only be active while that mode is active.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 event_player:
   ball_starting:
     - show_ball_start_animation

--- a/docs/config/extra_balls.md
+++ b/docs/config/extra_balls.md
@@ -23,7 +23,7 @@ details.
 
 Here's an example:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 extra_balls:
   my_mode_eb:

--- a/docs/config/fast.md
+++ b/docs/config/fast.md
@@ -18,7 +18,7 @@ that we have a how to guide which includes
 [all the FAST-specific settings](../hardware/fast/index.md) throughout your entire config file, so be sure to read that
 if you have FAST hardware.
 
-``` mpf-config
+``` yaml
 fast:
   ports: com3, com4, com5
 ```

--- a/docs/config/fast_switches.md
+++ b/docs/config/fast_switches.md
@@ -16,7 +16,7 @@ The `fast_switches:` section of your config is where you configure
 platform specific details about switches when using
 [fast hardware](../hardware/fast/index.md).
 
-``` mpf-config
+``` yaml
 switches:
   some_switch:
     number:

--- a/docs/config/flashers.md
+++ b/docs/config/flashers.md
@@ -18,7 +18,7 @@ to control them.
 
 Here is an example:
 
-``` mpf-config
+``` yaml
 # configure the flasher as coil
 coils:
   flasher_01:

--- a/docs/config/flippers.md
+++ b/docs/config/flippers.md
@@ -35,7 +35,7 @@ digging into the configuration options here.)
     enable relays to enable the flippers, and those are configured
     elsewhere. (See the How To guides for details.)
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_flipper_left:
 #!     number:
@@ -252,7 +252,7 @@ to adjust the power in service mode.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 coils:
   c_flipper_main:
     number:

--- a/docs/config/game.md
+++ b/docs/config/game.md
@@ -15,7 +15,7 @@ title: "game:"
 The `game:` section of the machine config holds settings related to the
 game play.
 
-``` mpf-config
+``` yaml
 game:
   balls_per_game: 3
   max_players: 4

--- a/docs/config/gis.md
+++ b/docs/config/gis.md
@@ -16,7 +16,7 @@ platform documentation for details about `subtype`).
 
 Here's an example from *Judge Dredd*:
 
-``` mpf-config
+``` yaml
 lights:
   gi01:    # lower backglass
     number: G01

--- a/docs/config/hardware.md
+++ b/docs/config/hardware.md
@@ -20,7 +20,7 @@ If you intend to use MPF with physical hardware, at a minimum you'll
 have a `platform:` and `driverboards:` section in your machine config,
 like this:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: fast
   driverboards: fast

--- a/docs/config/hardware_sound_player.md
+++ b/docs/config/hardware_sound_player.md
@@ -22,7 +22,7 @@ control external sound modules (e.g. in LISY).
 
 This is an example:
 
-``` mpf-config
+``` yaml
 hardware_sound_systems:
   default:
     label: Default external sound system

--- a/docs/config/images.md
+++ b/docs/config/images.md
@@ -33,7 +33,7 @@ specified for each asset.
 
 For example:
 
-``` mpf-config
+``` yaml
 images:
   insert_coin:
     load: preload

--- a/docs/config/info_lights.md
+++ b/docs/config/info_lights.md
@@ -21,7 +21,7 @@ to tell the player whose turn it is, what ball they're on, etc.
 Here's an example `info_lights:` section from a machine configuration
 file:
 
-``` mpf-config
+``` yaml
 #! lights:
 #!   match00:
 #!     number:

--- a/docs/config/instructions/dynamic_values.md
+++ b/docs/config/instructions/dynamic_values.md
@@ -19,7 +19,7 @@ scores a multiplier which is the number of shots made times 100k points.
 Without dynamic values, your variable_player (scoring) section would be
 static, like this:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 variable_player:
   shot_jackpot_hit:
@@ -31,7 +31,7 @@ holds the number of trolls hit that you want to multiply by 100,000 when
 the shot is made. You can use the "current_player" dynamic value in
 your variable_player config like this:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 variable_player:
   shot_jackpot_hit:
@@ -42,7 +42,7 @@ You can access other values dynamically as well, such as a timer ticking
 away a hurry-up or a counter to track how many times a multiplier switch
 has been hit
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 variable_player:
   collect_hurryup:
@@ -55,7 +55,7 @@ warnings.
 
 So instead of this:
 
-``` mpf-config
+``` yaml
 ##! mode: tilt
 # in your tilt mode
 tilt:
@@ -64,7 +64,7 @@ tilt:
 
 You would have this instead:
 
-``` mpf-config
+``` yaml
 # in your machine config
 settings:
   warnings_to_tilt:
@@ -190,7 +190,7 @@ Common mode properties are:
 
 ## Using if/else logic with dynamic values
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 counters:
   my_counter:

--- a/docs/config/instructions/gamma_correction.md
+++ b/docs/config/instructions/gamma_correction.md
@@ -54,7 +54,7 @@ The easiest way to show this slide on your physical DMD is to make a
 temporary addition to your machine config to add a slide player, like
 this:
 
-``` mpf-mc-config
+``` yaml
 slide_player:
   mode_attract_started:
     dmd_gamma_test:

--- a/docs/config/instructions/lists.md
+++ b/docs/config/instructions/lists.md
@@ -15,14 +15,14 @@ places we need lists. For example, device tags, logic block events,
 switches that make up shots, etc. For our explanation, we'll use a
 generic list item with generic configurations. Some examples:
 
-``` mpf-config
+``` yaml
 coils:
   flipperLeft:
     number: SD18
     tags: flipper, player   # this is a list
 ```
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   leftOutlane:
 #!     number:
@@ -34,7 +34,7 @@ shots:
     switch: leftOutlane, rightOutlane    #this is a list
 ```
 
-``` mpf-config
+``` yaml
 auditor:
   save_events:   # This config wants a list
     - game_started    # This is the first list item
@@ -42,7 +42,7 @@ auditor:
     - game_ended    # This is the third list item
 ```
 
-``` mpf-config
+``` yaml
 accruals:
   my_accrual:
     events:

--- a/docs/config/instructions/mode_config.md
+++ b/docs/config/instructions/mode_config.md
@@ -9,7 +9,7 @@ Modes usually start with a `mode:` section (see
 [mode](../mode.md)) which defines their
 priority and when they start or stop:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 mode:
   start_events: ball_starting

--- a/docs/config/instructions/tags.md
+++ b/docs/config/instructions/tags.md
@@ -20,7 +20,7 @@ up logic which fires when any device with a certain tag is activated, for exampl
 
 For example, look at this config where we add a couple of tags to the start button switch:
 
-``` mpf-config
+``` yaml
 switches:
   mygame_switch_button_start:
     number: 1
@@ -61,7 +61,7 @@ way. To start we will give 100 points for every hit of a pop bumper.
 
 Firstly we define the popbumper switches.
 
-``` mpf-config
+``` yaml
 switches:
   mygame_popbumper_left:
     number: 55
@@ -80,7 +80,7 @@ with tags.
 
 Example with events:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 variable_player:
   mygame_popbumper_left_active:
@@ -93,7 +93,7 @@ variable_player:
 
 Now with tags:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 variable_player:
   sw_mygame_popbumper:
@@ -120,7 +120,7 @@ ball search should not start.
 
 All we need to do is add a tag:
 
-``` mpf-config
+``` yaml
 switches:
   mygame_orbit_l:
     number: 55
@@ -137,7 +137,7 @@ example of this is a ball trough, as follows.
 
 ### Ball Device Tags
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_test1:
 #!     number: 1

--- a/docs/config/keyboard.md
+++ b/docs/config/keyboard.md
@@ -74,7 +74,7 @@ This section contains subsections which are a list of parameters that
 are posted along with the *event* or *mc_event* specified above. Using
 the following configuration file snippet as an example:
 
-``` mpf-mc-config
+``` yaml
 keyboard:
   4:
     event: advance_reel_test
@@ -107,7 +107,7 @@ keys on your keyboard forever whenever a ball is locked in a device.
 Default is *False*. You might want to create multiple entries for the
 same switch for different key combinations. For example:
 
-``` mpf-mc-config
+``` yaml
 #! keyboard:
   1:
     switch: trough1

--- a/docs/config/kickbacks.md
+++ b/docs/config/kickbacks.md
@@ -19,7 +19,7 @@ outlane.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_kickback:
     number: 1
@@ -87,7 +87,7 @@ of the coil for this device.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_kickback:
     number: 1

--- a/docs/config/kivy_config.md
+++ b/docs/config/kivy_config.md
@@ -21,7 +21,7 @@ documentation](https://kivy.org/docs/api-kivy.config.html#available-configuratio
 
 This is an example:
 
-``` mpf-config
+``` yaml
 kivy_config:
   kivy:
     desktop: 1

--- a/docs/config/light_player.md
+++ b/docs/config/light_player.md
@@ -20,7 +20,7 @@ title: "light_player:"
 The `light_player:` section of your config is where you can control
 lights in config or shows. Example in config:
 
-``` mpf-config
+``` yaml
 light_player:
   some_event:
     led1:
@@ -31,7 +31,7 @@ light_player:
       fade: 2000ms
 ```
 
-``` mpf-config
+``` yaml
 shows:
   rainbow:
     - lights:

--- a/docs/config/light_segment_displays_device.md
+++ b/docs/config/light_segment_displays_device.md
@@ -22,7 +22,7 @@ List of one (or more) values, each is a type: dictionary consisting of
 In this setting you provide a list of mapping for each segment. This is
 an example for a two 7-segment display:
 
-``` mpf-config
+``` yaml
 #! hardware:
 #!   segment_displays: light_segment_displays
 #! light_segment_displays:

--- a/docs/config/light_settings.md
+++ b/docs/config/light_settings.md
@@ -20,7 +20,7 @@ If you are using LEDs in your machine you probably want to set
 and off very sharply and might look flickery. For instance, Stern uses a
 value of about 40ms for LEDs on modern machines:
 
-``` mpf-config
+``` yaml
 light_settings:
   default_fade_ms: 40
 ```
@@ -30,7 +30,7 @@ Different color channels might achive different brightnesses and white
 might look pinkish or blueish for example. You can set a
 color_correction_profile to compensate for that:
 
-``` mpf-config
+``` yaml
 light_settings:
   default_color_correction_profile: correction_profile_less_red
   color_correction_profiles:
@@ -51,7 +51,7 @@ You can also define more than one profile and configure them per
 `color_correction_profile` setting. This might be useful if you use
 different types of lights in your machine:
 
-``` mpf-config
+``` yaml
 light_settings:
   default_color_correction_profile: correction_profile_less_red
   color_correction_profiles:

--- a/docs/config/lights.md
+++ b/docs/config/lights.md
@@ -43,7 +43,7 @@ into three channels.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 lights:
   my_led:
     number: 7   # might also be 8-7 or 8-1-0 depending on your platform
@@ -61,7 +61,7 @@ be also `number * 3` or a more complex conversion.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 lights:
   rainbow_star:
     type: rgb
@@ -86,7 +86,7 @@ by the hardware platform) figure out the channel number.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 lights:
   rainbow_star:    # this will use red: 9-29, green: 9-30 and blue: 9-31
     type: rgb
@@ -120,7 +120,7 @@ corresponding to the multi-color channels of an RGB or RGBW LED. Each
 channel entry can contain any of the `lights` parameters listed on this
 page, but at least `number` is required.
 
-``` mpf-config
+``` yaml
 lights:
   rainbow_star:
     type: rgb
@@ -206,7 +206,7 @@ which has to be configured in the `number` setting. It can be used if
 you got a light which is connected to a driver in your platform. That
 might be the case for [GIs](../mechs/lights/gis.md) for example. This is an example for a driver as light:
 
-``` mpf-config
+``` yaml
 coils:
   light_connected_to_a_driver:
     number: 42           # number depends on your platform
@@ -233,7 +233,7 @@ use the previous setting. To do this only specify the number of the
 first light in the chain and then link all consequent light using the
 previous setting:
 
-``` mpf-config
+``` yaml
 lights:
   led_0:
     number: 0
@@ -264,7 +264,7 @@ types of lights (such as RGBW LEDs) you can instead provide this
 internal address and the number of channels (i.e. using type). This is
 an example:
 
-``` mpf-config
+``` yaml
 lights:
   led_0:
     start_channel: 0-0

--- a/docs/config/logging.md
+++ b/docs/config/logging.md
@@ -15,7 +15,7 @@ title: "logging:"
 In the logging section you can configure which how verbose parts of MPFs
 should log.
 
-``` mpf-config
+``` yaml
 logging:
   console:
     asset_manager: none

--- a/docs/config/logic_blocks.md
+++ b/docs/config/logic_blocks.md
@@ -16,7 +16,7 @@ logic_blocks:
 
 just use:
 
-``` mpf-config
+``` yaml
 counters:
   your_counter:
     count_events: count_it_up

--- a/docs/config/machine.md
+++ b/docs/config/machine.md
@@ -15,7 +15,7 @@ title: "machine:"
 The `machine:` section of your config is where you configure defails
 about the number of balls in your machine.
 
-``` mpf-config
+``` yaml
 machine:
   balls_installed: 6
   min_balls: 3

--- a/docs/config/mode.md
+++ b/docs/config/mode.md
@@ -23,7 +23,7 @@ holds the settings for that specific mode.)
 
 Let's take a look at an example `mode:` section from a multiball mode:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 mode:
   start_events: ball_starting
@@ -218,7 +218,7 @@ AssertionError('Mode terra_2 is not supposed to run outside of game.',)
 To avoid this unexpected crash of MPF, add `game_ending` to the
 `stop_events:`
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 mode:
   start_events: mode_terra_2_start

--- a/docs/config/motors.md
+++ b/docs/config/motors.md
@@ -30,7 +30,7 @@ This is an example for a motorized drop target bank which is mounted to
 a camshaft. When the motor is running it constantly moves up and down.
 Two position switches are used to detect the current position.
 
-``` mpf-config
+``` yaml
 switches:
   s_motorized_drop_target_bank_position_up:
     number:
@@ -60,7 +60,7 @@ outputs. Again two position switches are used to detect the current
 position. In this setup the first and last switches are also considered
 as limit switches and the motor will stop once it hit one of them.
 
-``` mpf-config
+``` yaml
 switches:
   s_slimer_home:
     number: 8-1
@@ -90,7 +90,7 @@ Another example of such a device would be the claw in Stern Batman DK
 (or also Stern Batman 66). It has more position switches but the
 mechanics are similar:
 
-``` mpf-config
+``` yaml
 switches:
   s_claw_home:
     number:

--- a/docs/config/multiball_locks.md
+++ b/docs/config/multiball_locks.md
@@ -43,7 +43,7 @@ will add any additional balls it needs from the trough.)
 
 Here's an example:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_ball1:
 #!     number:

--- a/docs/config/multiballs.md
+++ b/docs/config/multiballs.md
@@ -23,7 +23,7 @@ Here's an example which contains several different multiball configs.
 (In the real world, you'd probably only have one multiball for each
 mode.)
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_ball1:
 #!     number:

--- a/docs/config/named_colors.md
+++ b/docs/config/named_colors.md
@@ -23,7 +23,7 @@ color strings).
 
 This is an example:
 
-``` mpf-config
+``` yaml
 named_colors:
   custom_blue: [24, 65, 226]
   troll_green: 4a9b22

--- a/docs/config/opp.md
+++ b/docs/config/opp.md
@@ -18,7 +18,7 @@ details.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: opp
   driverboards: gen2
@@ -55,7 +55,7 @@ One or more sub-entries. Each in the format of `string` : `string`
 
 This is an example:
 
-``` mpf-config
+``` yaml
 opp:
   ports: /dev/ttyOPP0, /dev/ttyOPP1
   chains:

--- a/docs/config/osc.md
+++ b/docs/config/osc.md
@@ -28,7 +28,7 @@ events. Defaults to empty.
 You can list all events which you want to be forwarded to your OSC
 remote. This is an example:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: osc
 

--- a/docs/config/pkone.md
+++ b/docs/config/pkone.md
@@ -18,7 +18,7 @@ Controller. Note that we have a how to guide which includes
 [all the PKONE-specific settings](../hardware/pkone/index.md) throughout your entire config file, so be sure to read that
 if you have Penny K Pinball PKONE hardware.
 
-``` mpf-config
+``` yaml
 pkone:
   port: com3
 ```

--- a/docs/config/playfield_transfers.md
+++ b/docs/config/playfield_transfers.md
@@ -18,7 +18,7 @@ devices which transfer balls between
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_transfer:
     number:

--- a/docs/config/playlist_player.md
+++ b/docs/config/playlist_player.md
@@ -24,7 +24,7 @@ information may be found in the
 
 Examples:
 
-``` mpf-config
+``` yaml
 playlist_player:
   play_attract_music:
     playlist:

--- a/docs/config/playlists.md
+++ b/docs/config/playlists.md
@@ -19,7 +19,7 @@ available if you're using MPF-MC for your media controller.)
 
 Here is an example:
 
-``` mpf-config
+``` yaml
 # ---------------------
 # SOUNDS::PLAYLIST
 # ---------------------

--- a/docs/config/pololu_maestro.md
+++ b/docs/config/pololu_maestro.md
@@ -18,7 +18,7 @@ serial port that a Pololu Maestro servo controller is connected to.
 When you attach a Pololu Maestro, two serial ports will appear. You want
 to specific the first (lower numbered) port here. For example:
 
-``` mpf-config
+``` yaml
 pololu_maestro:
   port: COM5
 ```

--- a/docs/config/queue_event_player.md
+++ b/docs/config/queue_event_player.md
@@ -26,7 +26,7 @@ This section is particularly useful with the
 
 Here's an example:
 
-``` mpf-config
+``` yaml
 queue_event_player:
   some_event:
     queue_event: my_queue

--- a/docs/config/queue_relay_player.md
+++ b/docs/config/queue_relay_player.md
@@ -18,7 +18,7 @@ processing continues.
 
 Here's an example:
 
-``` mpf-config
+``` yaml
 queue_relay_player:
   game_ending:
     post: start_my_mode

--- a/docs/config/random_event_player.md
+++ b/docs/config/random_event_player.md
@@ -20,7 +20,7 @@ title: "random_event_player:"
 The `random_event_player:` section of your config is where you can play
 a random event out of a list based on an event.
 
-``` mpf-config
+``` yaml
 # in your global config:
 random_event_player:
   play_random_event_global:

--- a/docs/config/raspberry_pi.md
+++ b/docs/config/raspberry_pi.md
@@ -17,7 +17,7 @@ Raspberry Pi running pigpio. See [Raspberry PI (pigpio)](../hardware/rpi.md) for
 
 This is an example:
 
-``` mpf-config
+``` yaml
 raspberry_pi:
   ip: localhost
   port: 8888

--- a/docs/config/rgb_dmds.md
+++ b/docs/config/rgb_dmds.md
@@ -27,7 +27,7 @@ the content for this DMD.
 
 Here's an example:
 
-``` mpf-config
+``` yaml
 displays:
   dmd:
     width: 128

--- a/docs/config/score_queue_player.md
+++ b/docs/config/score_queue_player.md
@@ -15,7 +15,7 @@ title: "score_queue_player:"
 The `score_queue_player:` section of your config is where you configure
 your SS style scoring. This is an example:
 
-``` mpf-config
+``` yaml
 coils:
   c_chime_1000:
     number:

--- a/docs/config/score_queues.md
+++ b/docs/config/score_queues.md
@@ -15,7 +15,7 @@ title: "score_queues:"
 The `score_queues:` section of your config is where you configure SS
 style scoring queues in MPF. This is an example:
 
-``` mpf-config
+``` yaml
 coils:
   c_chime_1000:
     number:

--- a/docs/config/segment_display_player.md
+++ b/docs/config/segment_display_player.md
@@ -126,7 +126,7 @@ Note, that if you have set a duration in a show, that this duration **in**cludes
 
 Example:
 
-``` mpf-config
+``` yaml
 #! segment_displays:
 #!   display1:
 #!     number: 1

--- a/docs/config/sequence_shots.md
+++ b/docs/config/sequence_shots.md
@@ -27,7 +27,7 @@ for the next, and so on. Once the last switch is activated, the shot is
 considered "hit" and the device posts `your_sequence_shot_hit` (if
 your shot is called `your_sequence_shot`).
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   top_right_opto:
 #!     number:
@@ -60,7 +60,7 @@ never hit a second time, then the second shot will not complete.
 
 Here is an example with events:
 
-``` mpf-config
+``` yaml
 sequence_shots:
   my_event_based_sequence_shot:
     event_sequence:
@@ -75,7 +75,7 @@ sequence_shots:
 
 And one with switches:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   seq2_1:
 #!     number:

--- a/docs/config/sequences.md
+++ b/docs/config/sequences.md
@@ -55,7 +55,7 @@ step, you could think of those like *OR*s. So you have Step 1 (event1
 *OR* event2) *AND THEN* Step 2 (event3) *AND THEN* Step 3 (event4 *OR*
 event5), like this:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 sequences:
   my_sequence:
@@ -75,7 +75,7 @@ to form complex logic.)
 
 For example:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 sequences:
   logic_block_1:

--- a/docs/config/servos.md
+++ b/docs/config/servos.md
@@ -20,7 +20,7 @@ positions.
 Here's an example `servos:` section, with two servos defined called
 *servo1* and *servo2*:
 
-``` mpf-config
+``` yaml
 servos:
   servo1:
     servo_min: 0.1
@@ -130,7 +130,7 @@ converted to floating point) : `string`
 This is a sub-section mapping of servo positions to MPF event names. For
 example:
 
-``` mpf-config
+``` yaml
 #! servos:
 #!   servo1:
 #!     number: 1
@@ -177,7 +177,7 @@ Note that by default, *ball_starting* is a reset event, so if you don't
 want the servo to reset on the start of each ball, you can override that
 like this:
 
-``` mpf-config
+``` yaml
 #! servos:
 #!   servo1:
 #!     number: 1

--- a/docs/config/settings.md
+++ b/docs/config/settings.md
@@ -18,7 +18,7 @@ which are configurable in
 
 This is an example:
 
-``` mpf-config
+``` yaml
 settings:
   replay_score:
     label: Replay Score

--- a/docs/config/shot_groups.md
+++ b/docs/config/shot_groups.md
@@ -17,7 +17,7 @@ config file.
 
 For example:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   lane_l:
 #!     number:

--- a/docs/config/shot_profiles.md
+++ b/docs/config/shot_profiles.md
@@ -18,7 +18,7 @@ shots.
 
 Here's an example:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 shot_profiles:
   my_default_profile:
@@ -123,7 +123,7 @@ This setting lets you specify a custom rotation pattern that's used
 when an event from this profile's rotation_events: section is posted.
 You enter it as a list of Ls and Rs, for example:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 shot_profiles:
   my_default_profile:

--- a/docs/config/shots.md
+++ b/docs/config/shots.md
@@ -39,7 +39,7 @@ groups at the same time.
 
 Here's a sample *shots:* section from a config file:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   lane_l:
 #!     number:
@@ -120,7 +120,7 @@ state is `0`.
 For instance in the following example `set_state_one` will set the state
 to `1`, which is the second state:
 
-``` mpf-config
+``` yaml
 shots:
   shot_with_control_events:
     control_events:
@@ -142,7 +142,7 @@ it might cause issues during multiball.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_my_shot:
 #!     number:
@@ -290,7 +290,7 @@ that's run when this shot is in a certain state.
 
 For example, consider the following shot config:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   switch1:
 #!     number:
@@ -321,7 +321,7 @@ could apply to any shot.
 For example, imagine if you wanted to create a shot to flash an LED
 between red and off. It might look like this:
 
-``` mpf-config
+``` yaml
 # show to flash an LED
 shows:
   flash_light:

--- a/docs/config/show_player.md
+++ b/docs/config/show_player.md
@@ -22,7 +22,7 @@ pause, (etc.) shows.
 
 Here is an example:
 
-``` mpf-config
+``` yaml
 show_player:
   some_event: your_show_name
   some_other_event: another_show
@@ -92,7 +92,7 @@ event that starts the show is a
 For example, the mode stopping events are queue events. So take a look
 at the following config:
 
-``` mpf-config
+``` yaml
 show_player:
   mode_my_mode_stopping:
     show_1:
@@ -235,7 +235,7 @@ on a series of events instead of a show that auto plays.
 
 For example:
 
-``` mpf-config
+``` yaml
 show_player:
   some_event:
     show_1:
@@ -288,7 +288,7 @@ Read what show tokens are [here](../shows/tokens.md).
 
 For example:
 
-``` mpf-config
+``` yaml
 show_player:
   some_event:
     show1:

--- a/docs/config/show_pools.md
+++ b/docs/config/show_pools.md
@@ -18,7 +18,7 @@ a configurable pattern called `type`.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 #! shows:
 #!   show1:
 #!     - duration: 1

--- a/docs/config/slide_player.md
+++ b/docs/config/slide_player.md
@@ -18,7 +18,7 @@ to be shown (or removed) based on events being posted.
 
 This is an example:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   slide1: []
 #!   slide2: []
@@ -65,7 +65,7 @@ Single value, type: one of the following options: play, remove. Default:
 For example, to remove *slide1* when the event *remove_slide_1* is
 posted:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   slide1: []
 slide_player:
@@ -76,7 +76,7 @@ slide_player:
 
 You can also specify a transition for the removal, like this:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   slide1: []
 slide_player:
@@ -110,7 +110,7 @@ and the slide will still be removed when the timer expires.
 If a `transition_out:` is specified, it will be applied when the slide
 expires:
 
-``` mpf-mc-config
+``` yaml
 slides:
   base:
     widgets:
@@ -229,7 +229,7 @@ is shown, and it will be "attached" to the slide and used when that
 slide is removed (either with the slide player or when a new slide is
 created with a higher priority than it).
 
-``` mpf-mc-config
+``` yaml
 slides:
   base:
     widgets:

--- a/docs/config/slides.md
+++ b/docs/config/slides.md
@@ -41,7 +41,7 @@ just add the
 two slides, one called *my_slide_1* and the other called *my_slide_2*,
 and they each only have a single widget.
 
-``` mpf-mc-config
+``` yaml
 slides:
   my_slide_1:
     type: text
@@ -60,7 +60,7 @@ add multiple widgets to a slide, just enter them like you entered a
 single widget, but use a dash (and a space) to dictate where a new
 widget starts, like this:
 
-``` mpf-mc-config
+``` yaml
 slides:
   my_slide_1:
     - type: text
@@ -90,7 +90,7 @@ slide settings under the slide along with the widgets.
 Here's an example. Note that the slide with multiple widgets is using
 the dash in the widgets: section to separate the individual widgets.
 
-``` mpf-mc-config
+``` yaml
 slides:
   my_slide_1:
     background_color: red
@@ -127,7 +127,7 @@ like a rectangle, but it's not, like this: `[]`.
 
 You can use this format to create a blank slide with no options:
 
-``` mpf-mc-config
+``` yaml
 slides:
   my_blank_slide: []
 ```
@@ -135,7 +135,7 @@ slides:
 Or you can use it to create a blank slide with options, but no widgets,
 like this:
 
-``` mpf-mc-config
+``` yaml
 slides:
   my_blank_slide:
     background_color: red

--- a/docs/config/smartmatrix.md
+++ b/docs/config/smartmatrix.md
@@ -17,7 +17,7 @@ devices.
 
 This is an example:
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 hardware:
   rgb_dmd: smartmatrix

--- a/docs/config/snux.md
+++ b/docs/config/snux.md
@@ -17,7 +17,7 @@ The `snux:` section of your config is where you configure the
 
 This is an example:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: virtual    # use your platform here
   driverboards: wpc

--- a/docs/config/sound_loop_player.md
+++ b/docs/config/sound_loop_player.md
@@ -25,7 +25,7 @@ MPF events are received.
 
 Examples:
 
-``` mpf-config
+``` yaml
 sound_loop_player:
   play_basic_beat:
     loops:

--- a/docs/config/sound_loop_sets.md
+++ b/docs/config/sound_loop_sets.md
@@ -29,7 +29,7 @@ references the sound asset named *kick*. This is the simplest sound loop
 set definition you can have. The volume of the *kick* sound will be
 taken from the sound asset definition.
 
-``` mpf-config
+``` yaml
 sound_loop_sets:
   basic_beat:
     sound: kick
@@ -40,7 +40,7 @@ sound_loop_sets:
 When specifying multiple layers use a dash (and a space) to dictate
 where a new layer starts, like this:
 
-``` mpf-config
+``` yaml
 sound_loop_sets:
   basic_beat:
     sound: kick

--- a/docs/config/sound_player.md
+++ b/docs/config/sound_player.md
@@ -22,7 +22,7 @@ to perform on sounds when MPF events are received.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 sound_player:
   mode_attract_started:
     song_01:
@@ -113,7 +113,7 @@ play a different sound but you don't also want the base mode to play
 the sound configured there (we don't want two simultaneous sounds for
 the jet bumper, just one).
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 sound_player:
   sw_jet_bumper_active:
@@ -123,7 +123,7 @@ sound_player:
 
 There is also a shorthand way (express config format):
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 sound_player:
   sw_jet_bumper_active: super_jet_bumper_sound|block

--- a/docs/config/sound_pools.md
+++ b/docs/config/sound_pools.md
@@ -26,7 +26,7 @@ available if you're using MPF-MC for your media controller.)
 
 Here's an example of a typical sound_pool configuration.
 
-``` mpf-config
+``` yaml
 sound_pools:
   drain_callout:
     type: random_force_all

--- a/docs/config/sound_system.md
+++ b/docs/config/sound_system.md
@@ -24,7 +24,7 @@ media controller.)
 
 Here's an example of a typical sound configuration.
 
-``` mpf-config
+``` yaml
 machine_vars:
   master_volume:
     initial_value: 0.8
@@ -132,7 +132,7 @@ DEPRECATED! Will removed in future MPF versions.
 Master volume has been moved to the machine variable `master_volume`.
 You can use the following snippet:
 
-``` mpf-config
+``` yaml
 machine_vars:
   master_volume:
     initial_value: 0.8

--- a/docs/config/sounds.md
+++ b/docs/config/sounds.md
@@ -25,7 +25,7 @@ FLAC (.flac) files.
 
 Here's an example:
 
-``` mpf-mc-config
+``` yaml
 ##! asset: sounds/extra_ball_12753.wav=../mc/sound/sounds/sound.ogg
 ##! asset: sounds/slingshot_01.ogg=../mc/sound/sounds/sound.ogg
 #! sound_system:
@@ -248,7 +248,7 @@ point on the user's next turn (using mode code).
 
 Here's a simple example utilizing markers:
 
-``` mpf-config
+``` yaml
 sounds:
   long_sound_1:
     volume: 0.8

--- a/docs/config/spike.md
+++ b/docs/config/spike.md
@@ -19,7 +19,7 @@ which includes
 [all the SPIKE-specific settings](../hardware/spike/index.md) throughout your entire config file, so be sure to read that
 if you have a SPIKE machine.
 
-``` mpf-config
+``` yaml
 hardware:
   platform: spike
 spike:

--- a/docs/config/spinners.md
+++ b/docs/config/spinners.md
@@ -15,7 +15,7 @@ title: "spinners:"
 Spinner devices provide accruals for switches that are hit in rapid
 succession, and post events based on timeouts after switch hits.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_orbit_spinner:
 #!     number:

--- a/docs/config/state_machines.md
+++ b/docs/config/state_machines.md
@@ -44,7 +44,7 @@ List all of your states here, with their applicable settings. Go to
 [state_machine_states:](state_machine_states.md) to see a full list of all settings under `states:`. For
 example:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 state_machines:
   my_state:
@@ -77,7 +77,7 @@ to the first step, when a given event is posted.
 
 List all your transitions here (we start with the same steps as above):
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 state_machines:
   my_state:

--- a/docs/config/steppers.md
+++ b/docs/config/steppers.md
@@ -16,7 +16,7 @@ The `steppers:` section of your config is where you configure steppers.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 # main config
 p_roc:
   use_separate_thread: true
@@ -140,7 +140,7 @@ converted to floating point) : `string`
 This is a sub-section mapping of stepper positions to MPF event names.
 For example:
 
-``` mpf-config
+``` yaml
 #! steppers:
 #!   my_stepper:
 #!     number: 1
@@ -195,7 +195,7 @@ converted to floating point) : `string`
 This is a sub-section mapping of relative stepper increments to MPF event names (as opposed to absolute rotational positions).
 For example:
 
-``` mpf-config
+``` yaml
 #! steppers:
 #!   my_stepper:
 #!     number: 1

--- a/docs/config/switch_player.md
+++ b/docs/config/switch_player.md
@@ -19,7 +19,7 @@ interactive testing purposes.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 #config_version=5
 switches:
   s_test1:

--- a/docs/config/switches.md
+++ b/docs/config/switches.md
@@ -16,7 +16,7 @@ The *switches:* section of the config files is used to map switch names
 to controller board inputs. You can map both direct and matrix switches.
 Here's an example section:
 
-``` mpf-config
+``` yaml
 switches:
   flipper_lwr_eos:
     number: SF1

--- a/docs/config/text_strings.md
+++ b/docs/config/text_strings.md
@@ -17,7 +17,7 @@ strings which can be used in slides or widgets.
 
 This is an example:
 
-``` mpf-mc-config
+``` yaml
 text_strings:
   greeting: HELLO PLAYER. THIS IS YOUR BALL (ball)
 slides:

--- a/docs/config/timed_switches.md
+++ b/docs/config/timed_switches.md
@@ -20,7 +20,7 @@ Here's an example. This example is actually built-in to MPF via the MPF
 default config file, so if you want to use these flipper cradle events,
 you don't have to enter them yourself as they're already there.
 
-``` mpf-config
+``` yaml
 timed_switches:
   flipper_cradle:
     switch_tags: left_flipper, right_flipper

--- a/docs/config/timer_control_events.md
+++ b/docs/config/timer_control_events.md
@@ -24,7 +24,7 @@ add. But other actions, like "start" or "stop" don't need values.
 
 Here's an example of control events in action:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 timers:
   my_timer:

--- a/docs/config/timers.md
+++ b/docs/config/timers.md
@@ -34,7 +34,7 @@ timers:
 Here's an example timers: section from the "Money Bags" mode in
 *Brooks 'n Dunn* which contains two timers:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 timers:
   mb_intro_timer:
@@ -69,7 +69,7 @@ flashing shot is hit.
 
 Here's another example of timers from *Demo Man's* skillshot mode:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 timers:
   mode_timer:

--- a/docs/config/track_player.md
+++ b/docs/config/track_player.md
@@ -28,7 +28,7 @@ controller.)
 
 This is an example:
 
-``` mpf-config
+``` yaml
 track_player:
   pause_music_track:
     music:

--- a/docs/config/twitch_client.md
+++ b/docs/config/twitch_client.md
@@ -18,14 +18,14 @@ built-in Twitch chat monitor.
 Before using this plugin you must install the irc library with
 `pip3 install irc`
 
-``` mpf-config
+``` yaml
 twitch_client:
   user: TwitchBotAccount
   password: oauth:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
   channel: ChatChannel
 ```
 
-``` mpf-config
+``` yaml
 machine_vars:
   twitch_user:
     initial_value: 'TwitchBotAccount'

--- a/docs/config/variable_player.md
+++ b/docs/config/variable_player.md
@@ -23,7 +23,7 @@ At the most basic level, you can use this to add to a player's score
 
 Here's an example which would work for player variables, but not for machine variables (see below why):
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 variable_player:
   target_1_hit:
@@ -70,7 +70,7 @@ You can include any player or machine variable under an event to add a numeric v
 to that variable. This example is for player variables and not for machine variables. (If the variable doesn't exist, it will set the
 player variable to that.) For player variables there is a simplified syntax, for example:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 variable_player:
   some_event:
@@ -87,7 +87,7 @@ vars.
 
 The fully expanded config for player variables look like this
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 variable_player:
   some_event:
@@ -130,7 +130,7 @@ then specify the value in the "int:" section. For example, if you want
 the example from the above section to reset the aliens player variable
 to 1 instead of adding 1 to the current value, it would look like this:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 variable_player:
   some_event:
@@ -159,7 +159,7 @@ you don't also want the base mode to score the 500 points on top of the
 Note that when you use block, you also have to include the `int:`,
 `float:`, or `string:` setting indented. For example:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 variable_player:
   ramp_1_hit:
@@ -170,7 +170,7 @@ variable_player:
 
 There is also a shorthand way:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 variable_player:
   ramp_1_hit:
@@ -203,7 +203,7 @@ takes priority over the `float:` setting so if both are present only the
 
 Single value, type: `integer`. Defaults to empty.
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 variable_player:
   add_score_to_player_2:
@@ -233,7 +233,7 @@ value. We use the variable_player section tied to the events posted when
 the player variable changes and conditional events to set the current
 name of the album value, like this:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 variable_player:
   player_album_value{value==1}:

--- a/docs/config/videos.md
+++ b/docs/config/videos.md
@@ -33,7 +33,7 @@ specified for each asset.
 
 For example:
 
-``` mpf-config
+``` yaml
 videos:
   intro_video:
     width: 100

--- a/docs/config/virtual_platform_start_active_switches.md
+++ b/docs/config/virtual_platform_start_active_switches.md
@@ -19,7 +19,7 @@ running `mpf -X`).
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_ball_switch1:
     number:

--- a/docs/config/virtual_segment_display_connector.md
+++ b/docs/config/virtual_segment_display_connector.md
@@ -16,7 +16,7 @@ The `virtual_segment_display_connector:` section of your config is where
 you configure the connector that establishes the link between segment
 displays and the virtual segment display emulator widgets in the MPF-MC.
 
-``` mpf-config
+``` yaml
 virtual_segment_display_connector:
   segment_displays: display1
 ```

--- a/docs/config/widget_player.md
+++ b/docs/config/widget_player.md
@@ -23,7 +23,7 @@ frames) based on events being posted.
 
 This is an example:
 
-``` mpf-mc-config
+``` yaml
 #! widgets:
 #!   widget_1: []
 widget_player:

--- a/docs/config/widget_styles.md
+++ b/docs/config/widget_styles.md
@@ -23,7 +23,7 @@ A widget will use the style `(name)_default` if no other style is
 specified. For instance, a default style for all
 [text widgets](../mc/widgets/text/index.md) would look like:
 
-``` mpf-mc-config
+``` yaml
 widget_styles:
   text_default:
     font_size: 21
@@ -35,7 +35,7 @@ widget_styles:
 You can also specify re-usable styles and apply them to widgets. In the
 following example, the text "HELLO" will render at font size 100:
 
-``` mpf-mc-config
+``` yaml
 widget_styles:
   big_style:
     font_size: 100
@@ -49,7 +49,7 @@ slides:
 You can supply multiple styles to a single widget, and they will be
 applied in the order given.
 
-``` mpf-mc-config
+``` yaml
 widget_styles:
   warning_text:
     font_size: 12

--- a/docs/config/window.md
+++ b/docs/config/window.md
@@ -15,7 +15,7 @@ title: "window:"
 The `window:` section of your config is where you configure the
 properties of the main on-screen window which is created by MPF-MC.
 
-``` mpf-config
+``` yaml
 window:
   width: 800
   height: 600

--- a/docs/config_players/blinkenlight_player.md
+++ b/docs/config_players/blinkenlight_player.md
@@ -33,7 +33,7 @@ that's used add or remove colors from a blinkenlight.
 
 This is an example of a blinkenlight player:
 
-``` mpf-config
+``` yaml
 blinkenlight_player:
   some_event:
     my_blinkenlight: red
@@ -117,7 +117,7 @@ want them to show the same colors at the same time.
 
 Let's say you have a blinkenlight that is set up like this:
 
-``` mpf-config
+``` yaml
 #! lights:
 #!   l_left_ramp_arrow:
 #!     channels:
@@ -315,7 +315,7 @@ removed from the blinkenlight.
 
 Example blinkenlight player from a show:
 
-``` mpf-config
+``` yaml
 ##! show: test
 - time: 0
   blinkenlights:
@@ -346,7 +346,7 @@ color will be removed.
 This is better explained with an example. Consider this
 `blinkenlight_player`:
 
-``` mpf-config
+``` yaml
 blinkenlight_player:
   some_event:
     my_blinkenlight: red
@@ -374,7 +374,7 @@ keyless color. Instead of using the full config and specifying an
 or `remove` in the express config to do the same thing. The following is
 equivalent to the example above:
 
-``` mpf-config
+``` yaml
 blinkenlight_player:
   some_event:
     my_blinkenlight: red

--- a/docs/config_players/coil_player.md
+++ b/docs/config_players/coil_player.md
@@ -11,7 +11,7 @@ that's used pulse, enable, or disable coils and drivers.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 coil_player:
   some_event: coil_1
   some_other_event:
@@ -37,7 +37,7 @@ The coil player's express config is the "pulse" action.
 
 Example coil player from a show:
 
-``` mpf-config
+``` yaml
 ##! show: test
 - time: 0
   coils:

--- a/docs/config_players/display_light_player.md
+++ b/docs/config_players/display_light_player.md
@@ -18,7 +18,7 @@ Video about display_light_player:
 
 To use this in a show you can use this:
 
-``` mpf-config
+``` yaml
 ##! show: test_show
 - display_lights:
     your_source_display:     # use any display defined in your machine
@@ -27,7 +27,7 @@ To use this in a show you can use this:
 
 Or standalone:
 
-``` mpf-config
+``` yaml
 display_light_player:
   your_event:
     your_source_display:
@@ -36,7 +36,7 @@ display_light_player:
 
 Then map your lights to a position on the display:
 
-``` mpf-config
+``` yaml
 lights:
   l_light1:
     number: 1

--- a/docs/config_players/event_player.md
+++ b/docs/config_players/event_player.md
@@ -17,7 +17,7 @@ Video about events in MPF:
 
 ## Basic Event Playing
 
-``` mpf-config
+``` yaml
 event_player:
   ball_starting:
     - cmd_flippers_enable
@@ -51,7 +51,7 @@ a target called "upper" to reset when a mode called "shoot_here"
 starts, you could create an entry like this in the shoot here mode's
 shoot_here.yaml mode configuration file:
 
-``` mpf-config
+``` yaml
 ##! mode: shoot_here
 event_player:
   mode_shoot_here_started: cmd_upper_target_reset
@@ -62,7 +62,7 @@ event_player:
 Events in the event player can be conditional, to allow precise control
 over when an event is played:
 
-``` mpf-config
+``` yaml
 ##! mode: base
 event_player:
   mode_base_started{current_player.score>10000}:
@@ -82,7 +82,7 @@ completed.
 Conditions can also be applied to events within a list, to allow one
 event to trigger a variable number of handlers:
 
-``` mpf-config
+``` yaml
 ##! mode: base
 event_player:
   reenable_nonrecruit_modes:
@@ -115,7 +115,7 @@ device states, mathematical calculations) in events.
 An event name can use parenthetical values to dynamically determine the
 event.
 
-``` mpf-config
+``` yaml
 event_player:
   mode_dynamo_started:
     # Player variables can be dropped into event names
@@ -149,7 +149,7 @@ An event post can include arguments to provide event handlers with
 additional information about the event. An event configured as an object
 will post the object properties as its arguments:
 
-``` mpf-config
+``` yaml
 event_player:
   mode_carchase_started:
     # Objects can be expanded for a key/value pair per line
@@ -163,7 +163,7 @@ You can go a step further and include dynamic values as the values for
 event arguments. To indicate that an argument's value is dynamic, use
 the `value:` property.
 
-``` mpf-config
+``` yaml
 event_player:
   mode_dynamo_started:
     set_dynamo_phase:
@@ -182,7 +182,7 @@ to explicitly define types for the value's format. Acceptable types are
 **int**, **float**, **bool**, and **string**. If no type is configured,
 the value will be posted as a string.
 
-``` mpf-config
+``` yaml
 event_player:
   mode_dynamo_started:
     # This event arg will be correctly typed
@@ -203,7 +203,7 @@ priorties for events to be posted. This can be useful in scenarios such
 as where a player variable must be updated prior to a condtional check,
 so that they happen in the desired order.
 
-``` mpf-config
+``` yaml
 event_player:
   mode_dynamo_started:
     reset_pv_tokens_collected_to_0

--- a/docs/config_players/index.md
+++ b/docs/config_players/index.md
@@ -87,7 +87,7 @@ example_player:
 
 For example (show_player; short syntax):
 
-``` mpf-config
+``` yaml
 show_player:
   event_which_is_posted_elsewhere:
     your_show: play
@@ -95,7 +95,7 @@ show_player:
 
 Another example (show_player; long syntax):
 
-``` mpf-config
+``` yaml
 show_player:
   event_which_is_posted_elsewhere:
     your_show:
@@ -115,7 +115,7 @@ example_player:
 
 An example (show_player):
 
-``` mpf-config
+``` yaml
 show_player:
   event_which_is_posted_elsewhere: your_show
 ```
@@ -135,7 +135,7 @@ example_player:
 
 An example (light_player):
 
-``` mpf-config
+``` yaml
 light_player:
   "{current_player.score > 1000000}":
     score_1M: white
@@ -163,7 +163,7 @@ note that instead of `example_player:` it becomes `examples:`.
 
 For example (show_player; short syntax):
 
-``` mpf-config
+``` yaml
 ##! show: test
 - duration: 2s
   shows:
@@ -172,7 +172,7 @@ For example (show_player; short syntax):
 
 Another example (show_player; long syntax):
 
-``` mpf-config
+``` yaml
 ##! show: test
 - duration: 2s
   shows:

--- a/docs/config_players/light_player.md
+++ b/docs/config_players/light_player.md
@@ -18,7 +18,7 @@ section.
 The `light_player:` section of your config is where you can control
 lights in config or shows. Example in config:
 
-``` mpf-config
+``` yaml
 #! lights:
 #!   led1:
 #!     number:
@@ -38,7 +38,7 @@ light_player:
 
 In shows, the light player is used via the `lights:` section of a step.
 
-``` mpf-config
+``` yaml
 #! lights:
 #!   l_light:
 #!     number:
@@ -56,7 +56,7 @@ show_player:
 
 ### Setting multiple lights
 
-``` mpf-config
+``` yaml
 lights:
   l_target1:
     number:
@@ -100,7 +100,7 @@ are referenced directly.
 
 ### Setting lights via tags
 
-``` mpf-config
+``` yaml
 #! lights:
 #!   l_drop1:
 #!     number:
@@ -153,7 +153,7 @@ There are two syntax to express fades. Short syntax which is
 a dict with two entries for `color` and `fade`. Here is an example for
 the short syntax:
 
-``` mpf-config
+``` yaml
 #! lights:
 #!   l_rgb:
 #!     number:
@@ -191,7 +191,7 @@ show_player:
 
 And an example with extended syntax:
 
-``` mpf-config
+``` yaml
 #! lights:
 #!   l_rgb:
 #!     number:

--- a/docs/config_players/random_event_player.md
+++ b/docs/config_players/random_event_player.md
@@ -11,7 +11,7 @@ that's used to post random events from a list of events.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 # in your global config:
 random_event_player:
   play_random_event_global:

--- a/docs/config_players/show_player.md
+++ b/docs/config_players/show_player.md
@@ -18,7 +18,7 @@ Video about shows:
 
 This is an example:
 
-``` mpf-config
+``` yaml
 show_player:
   some_event: your_show_name
   some_other_event: another_show
@@ -40,7 +40,7 @@ configure how it repeats. In that case, instead of putting the show name
 on the same line as the event, you can put the show name on a new line
 under the event, and then add additional settings under it, like this:
 
-``` mpf-config
+``` yaml
 show_player:
   some_event:
     your_show_name:
@@ -59,7 +59,7 @@ with a `speed: 2` and `sync_ms: 500`.
 
 You can also mix-and-match formats, like this:
 
-``` mpf-config
+``` yaml
 show_player:
   some_event: your_show_name
   some_other_event:
@@ -75,7 +75,7 @@ unique `key`. The show_player will use the show name as key for the show
 by default if you do not specify a `key` (fine in most cases). This way
 it refences the show when starting or stopping it:
 
-``` mpf-config
+``` yaml
 show_player:
   start_my_show:
     your_show_name: play
@@ -92,7 +92,7 @@ However, in some cases you want to play multiple instances of one show
 in a single show. You can manually assign keys to run distinct shows.
 That way you can also specifically stop them later:
 
-``` mpf-config
+``` yaml
 show_player:
   start_my_show1:
     your_show_name:

--- a/docs/config_players/slide_player.md
+++ b/docs/config_players/slide_player.md
@@ -27,7 +27,7 @@ Generically-speaking, there are two formats you can use for slide_player
 entries: "express" and "full" configs. Express configs will look
 like this:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   slide1: []
 #!   slide2: []
@@ -65,7 +65,7 @@ is posted, but it will also override the default settings and show the
 slide on the display target called *display1* and at a priority that's
 200 higher than the base priority.
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   slide_1: []
 #! displays:
@@ -97,7 +97,7 @@ defined called *slide_1* and you redefine it in your slide player like
 the example below, this new slide will become *slide_1* and the old one
 will be gone.
 
-``` mpf-mc-config
+``` yaml
 slide_player:
   some_event:
     slide_1:
@@ -114,7 +114,7 @@ You can also mix-and-match defining a slide in the slide player as well
 as adjusting properties of how the slide is shown. Just add multiple
 settings, like this:
 
-``` mpf-mc-config
+``` yaml
 slide_player:
   some_event:
     slide_1:
@@ -132,7 +132,7 @@ Remember that these slide player settings can also be used in show steps
 (in a `slides:` section). Any of the examples above apply, you just
 don't include the event name, like this:
 
-``` mpf-mc-config
+``` yaml
 ##! show: show1
 #show_version=5
 - time: 0

--- a/docs/config_players/sound_loop_player.md
+++ b/docs/config_players/sound_loop_player.md
@@ -13,7 +13,7 @@ available if you're using MPF-MC for your media controller.)
 
 Examples:
 
-``` mpf-config
+``` yaml
 sound_loop_player:
   play_basic_beat:
     loops:

--- a/docs/config_players/track_player.md
+++ b/docs/config_players/track_player.md
@@ -25,7 +25,7 @@ to all audio tracks in the sound system.
 
 Example:
 
-``` mpf-config
+``` yaml
 track_player:
   pause_music_track:
     music:
@@ -46,7 +46,7 @@ In shows, the track player is used via the `tracks:` section of a step.
 
 Example:
 
-``` mpf-config
+``` yaml
 shows:
   my_show_with_sound:
     - time: 0

--- a/docs/config_players/widget_player.md
+++ b/docs/config_players/widget_player.md
@@ -27,7 +27,7 @@ Generically-speaking, there are two formats you can use for
 widget_player entries: "express" and "full" configs. Express configs
 will look like this:
 
-``` mpf-mc-config
+``` yaml
 #! widgets:
 #!   widget1: []
 #!   widget2: []
@@ -67,7 +67,7 @@ is posted, but it will also override the default settings and add widget
 to the slide called *slide_2*, even if that's not the current slide
 that's showing.
 
-``` mpf-mc-config
+``` yaml
 #! widgets:
 #!   widget_1: []
 widget_player:

--- a/docs/cookbook/AFM_super_jets.md
+++ b/docs/cookbook/AFM_super_jets.md
@@ -218,7 +218,7 @@ our starting events for the mode itself, the values of the jet bumpers
 when Super Jets are active, and also a call to show a slide stating that
 Super Jets are active.
 
-``` mpf-config
+``` yaml
 ##! mode: super_jets
 mode:
   start_events: Super_Jets_Go, Super_Jets_Resume_Go

--- a/docs/cookbook/B66_gadget.md
+++ b/docs/cookbook/B66_gadget.md
@@ -68,7 +68,7 @@ mode to 'protect' earned, but unused gadgets from being reset in the
 rare cases when we may need to stop the mode that allows players to earn
 gadgets.
 
-``` mpf-config
+``` yaml
 #config_version=5
 
 modes:
@@ -217,7 +217,7 @@ playfields:
 Next, we can start setting up our gadget mode; below you see the
 contents of `gadget.yaml`
 
-``` mpf-config
+``` yaml
 ##! mode: gadget
 config:
   - logic_blocks.yaml
@@ -242,7 +242,7 @@ mode:
 
 Stepping through how we're using each setting:
 
-``` mpf-config
+``` yaml
 ##! mode: gadget
 config:
   - logic_blocks.yaml
@@ -254,7 +254,7 @@ config:
 The config section imports other config files; this is often easier to
 manage than on long config file.
 
-``` mpf-config
+``` yaml
 ##! mode: gadget
 #! mode:
 #!   start_events: ball_started
@@ -272,7 +272,7 @@ our mode-specific logic_blocks. In this case, we're using an
 [Accrual Logic Blocks](../game_logic/logic_blocks/accruals.md) to
 track when all of the letters have been hit.
 
-``` mpf-config
+``` yaml
 ##! mode: gadget
 accruals:
   gadget_accrual:
@@ -291,7 +291,7 @@ accruals:
 
 Stepping through once again:
 
-``` mpf-config
+``` yaml
 ##! mode: gadget
 accruals:
   gadget_accrual:
@@ -311,7 +311,7 @@ accruals:
 These two lines simply tell MPF that we have an accrual and we've named
 it "gadget_accrual".
 
-``` mpf-config
+``` yaml
 ##! mode: gadget
 #! accruals:
 #!   gadget_accrual:
@@ -333,7 +333,7 @@ like arrays, so I added a comment after each event to help me remember
 the index of each event. We'll need to reference these events and their
 index later.
 
-``` mpf-config
+``` yaml
 ##! mode: gadget
 #! accruals:
 #!   gadget_accrual:
@@ -353,7 +353,7 @@ index later.
 Once the player has hit all of the letters, we want the accrual to reset
 so that they can earn more Gadgets.
 
-``` mpf-config
+``` yaml
 ##! mode: gadget
 #! accruals:
 #!   gadget_accrual:
@@ -373,7 +373,7 @@ so that they can earn more Gadgets.
 We also have to tell MPF to leave our accrual enabled, even after it's
 completed.
 
-``` mpf-config
+``` yaml
 ##! mode: gadget
 #! accruals:
 #!   gadget_accrual:
@@ -401,7 +401,7 @@ complete, the game will award one of the neigbhoring targets if they are
 incomplete. To accomplish this, we'll use conditional events in our
 event player.
 
-``` mpf-config
+``` yaml
 ##! mode: gadget
 event_player:
   #plus one gadget when accrual is complete
@@ -441,7 +441,7 @@ event_player:
 There's a lot happening here, so let's get the easy stuff out of the
 way first:
 
-``` mpf-config
+``` yaml
 ##! mode: gadget
 #! event_player:
   award_gadget:
@@ -452,7 +452,7 @@ way first:
 The "award_gadget" event - triggered by the accrual completion, simply
 adds one to both `player_vars` we configured in step one.
 
-``` mpf-config
+``` yaml
 ##! mode: gadget
 #! event_player:
   s_gadget_a_active:
@@ -465,7 +465,7 @@ having not yet been hit. When the "a" switch is active, trigger the
 event "gadget_a_complete" if it hasn't been seen by the accrual. Note
 the `value[1]` which refers to the 2nd index of our accrual.
 
-``` mpf-config
+``` yaml
 ##! mode: gadget
 #! event_player:
 #!   s_gadget_a_active:
@@ -475,7 +475,7 @@ the `value[1]` which refers to the 2nd index of our accrual.
 Now, we trigger gadget_g1_complete if it hasn't been seen by the
 accrual AND "a" is already complete.
 
-``` mpf-config
+``` yaml
 ##! mode: gadget
 #! event_player:
 #!   s_gadget_a_active:
@@ -500,7 +500,7 @@ This show is "light_gadget_letter.yaml" and it's in the "shows"
 folder for the mode. It's pretty straightforward, but uses tokens and
 tags to be efficient.
 
-``` mpf-config
+``` yaml
 ##! show: light_gadget_letter
 - time: 0
   lights:
@@ -576,7 +576,7 @@ tags to be efficient.
 This show isn't terribly complicated, but let's look at some of the
 features.
 
-``` mpf-config
+``` yaml
 ##! show: light_gadget_letter
 - time: 0
   lights:
@@ -595,7 +595,7 @@ In a real Batman '66, we would simply flash the light because the
 inserts are yellow. However, since many custom games are using RGB LED,
 we'll allow for any color the builder prefers.
 
-``` mpf-config
+``` yaml
 ##! show: light_gadget_letter
 - time: +.05
   lights:
@@ -619,7 +619,7 @@ but it's not worth explaining here.
 Our show player is watching for events and triggering the appropriate
 shows.
 
-``` mpf-config
+``` yaml
 show_player:
   gadget_g1_complete:
     light_gadget_letter:
@@ -631,7 +631,7 @@ show_player:
         gadget_letter_final_color: yellow
 ```
 
-``` mpf-config
+``` yaml
 #! show_player:
   gadget_g1_complete:
     light_gadget_letter:
@@ -641,7 +641,7 @@ show_player:
 When the "gadget_g1_complete" event is triggered, start the
 "light_gadget_letter" show starts.
 
-``` mpf-config
+``` yaml
 #! show_player:
 #!   gadget_g1_complete:
 #!     light_gadget_letter:
@@ -652,7 +652,7 @@ When the "gadget_g1_complete" event is triggered, start the
 We'll add a key to the show so that we can keep re-using the same show
 for all the letters.
 
-``` mpf-config
+``` yaml
 #! show_player:
 #!   gadget_g1_complete:
 #!     light_gadget_letter:
@@ -668,7 +668,7 @@ Finally, we pass show tokens to the show to tell it what light and what
 color we want for the on steps and the final step. This repeats for all
 of the individual letters.
 
-``` mpf-config
+``` yaml
 show_player:
   reset_gadget_lights:
     light_gadget_letter:

--- a/docs/cookbook/TAF_mansion_awards.md
+++ b/docs/cookbook/TAF_mansion_awards.md
@@ -103,7 +103,7 @@ in terms of what we need to make this recipe work, but if you have a
 real Addams Family then you'll probably have a lot more than this in
 your machine config file.)
 
-``` mpf-config
+``` yaml
 #config_version=5
 modes:
   - mansion_awards
@@ -252,7 +252,7 @@ mansion achievements.
 You'll notice that most of them are almost identical. For example,
 here's the entry for Thing Multiball:
 
-``` mpf-config
+``` yaml
 ##! mode: mansion_awards
 achievements:
   thing_multiball:
@@ -325,7 +325,7 @@ Next we need to create an achievement group called "mansion_awards"
 which will group the 12 mansion achievements together. That will look
 like this:
 
-``` mpf-config
+``` yaml
 ##! mode: mansion_awards
 #! achievements:
 #!   9_mil:
@@ -499,7 +499,7 @@ The two modes we're going to create are:
 
 Let's look at the config for the "chair_lit_3s" mode:
 
-``` mpf-config
+``` yaml
 ##! mode: chair_lit_3s
 #config_version=5
 mode:
@@ -567,7 +567,7 @@ ball ends automatically.)
 
 Here's the config for this mode:
 
-``` mpf-config
+``` yaml
 ##! mode: chair_lit
 #config_version=5
 mode:
@@ -628,7 +628,7 @@ We'll tackle this in two parts.
 
 First, take a look at the Hit Cousin It and Mamuska achievements:
 
-``` mpf-config
+``` yaml
 ##! mode: mansion_awards
 achievements:
   hit_cousin_it:
@@ -672,7 +672,7 @@ one of those two.
 However, once the initial selection is made, we need a way to enable the
 remaining 10 mansion awards. For this we'll use a counter logic block:
 
-``` mpf-config
+``` yaml
 ##! mode: chair_lit
 # This is in the chair_lit mode config, NOT machine-wide config
 counters:
@@ -735,7 +735,7 @@ either start a mode or to play a show. Simple!
 This is pretty simple. Just add the events posted when one achievement
 is started to the complete events for the other. Here are the examples:
 
-``` mpf-config
+``` yaml
 ##! mode: mansion_awards
 achievements:
   6_mil:

--- a/docs/cookbook/carousel.md
+++ b/docs/cookbook/carousel.md
@@ -68,7 +68,7 @@ display a slide showing the name of the mode to the player.
 You can then use the carousel_\(item)\_selected event to
 start the mode that was selected by the player.
 
-``` mpf-mc-config
+``` yaml
 ##! mode: my_carousel
 # in mode my_carousel
 #config_version=5
@@ -146,7 +146,7 @@ buttons control the carousel right and left. When the Launch Button is
 pressed, the game starts the mode selected by the player and launches
 the ball.
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 ##! mode: carousel
 # put this in your modes/carousel/config/carousel.yaml
@@ -268,7 +268,7 @@ event_player:
 Then, each mode that the carousel can start is set up with the
 following.
 
-``` mpf-config
+``` yaml
 #config_version=5
 ##! mode: Doctor_1
 ##Example:  Doctor_1.yaml

--- a/docs/cookbook/dual_launch.md
+++ b/docs/cookbook/dual_launch.md
@@ -19,7 +19,7 @@ player round, the game can only kick up a ball in the default device.
 Here's what the hardware configuration for two plungers (and troughs)
 would look like:
 
-``` mpf-config
+``` yaml
 ##! no_fake_game
 #config_version=5
 switches:
@@ -103,7 +103,7 @@ the modes directory in your own game definitions. Let's look at the
 config file first
 ([mpf/modes/game/config/game.yaml](https://github.com/missionpinball/mpf/blob/dev/mpf/modes/game/config/game.yaml)):
 
-``` mpf-config
+``` yaml
 ##! mode: game
 #config_version=5
 mode:
@@ -224,7 +224,7 @@ doesn't work for your design.
 
 Here is a complete example:
 
-``` mpf-config
+``` yaml
 ##! no_fake_game
 #config_version=5
 switches:

--- a/docs/cookbook/fake_ball_save.md
+++ b/docs/cookbook/fake_ball_save.md
@@ -25,7 +25,7 @@ etc have an enable and disable event in their devices config file.
 
 This is an example for left sling:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_left_slingshot:
 #!     number:
@@ -47,7 +47,7 @@ In this example this mode had a multiball and the fake ball save is
 enabled when a multiball ends. In your mode it can be enabled whenever
 you want it to, mode start or when a shot is hit, etc.
 
-``` mpf-config
+``` yaml
 ##! mode: your_mode
 ball_saves:
   fake_MODE_NAME_ball_save:
@@ -67,7 +67,7 @@ show_player that flashes the shoot again light.
 
 We will call this mode ball_save_end_mode.
 
-``` mpf-config
+``` yaml
 ##! mode: your_mode
 mode:
   start_events:
@@ -108,7 +108,7 @@ what just happened. The queue_relay_player will hold the ball until the
 show is over. When this mode is ending you should enable the coils you
 disabled.
 
-``` mpf-mc-config
+``` yaml
 ##! mode: your_mode
 mode:
   start_events:

--- a/docs/cookbook/lanes_mode.md
+++ b/docs/cookbook/lanes_mode.md
@@ -51,7 +51,7 @@ we've given the lights and switches the same names (which is ok since
 they're different types of devices), so our `shots:` section looks like
 this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   indy_i:
 #!     number: 1
@@ -93,7 +93,7 @@ shots:
 Next, configure a `shot group`, which is where you can group individual
 shots together so you can interact with as a single group, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   indy_i:
 #!     number: 1
@@ -168,7 +168,7 @@ mode's active. In this tutorial we're going to configure them in the
 base mode as well but you could put that group in any other mode and
 load/unload it as you need it.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   indy_i:
 #!     number: 1
@@ -223,7 +223,7 @@ rotate lane shots to the right, regardless of which flipper button is
 pressed. In that case you'd only have an entry for rotate_right_events,
 but you'd add both the left and right flipper events, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   indy_i:
 #!     number: 1
@@ -286,7 +286,7 @@ shots to reset. To do that, go back into your `base.yaml`
 file and add another setting to your *indy_lanes* shot group for
 `reset_events:`, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   indy_i:
 #!     number: 1
@@ -382,7 +382,7 @@ scoring section to your base.yaml mode configuration. (Or you can add it
 to your machine-wide config if you want to keep all your scoring entries
 in one place.) It should look like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   indy_i:
 #!     number: 1
@@ -478,7 +478,7 @@ you complete the lanes. To do this, let's first create a light show
 (details in Steps A and B `here`) called
 \`indy_lanes_complete.yaml\`:
 
-``` mpf-config
+``` yaml
 ##! show: indy_lanes_complete
 - duration: 1
   lights:
@@ -500,7 +500,7 @@ show, go back to your `base.yaml` mode config and add a
 `light_player:` entry which plays this show when the lanes
 are complete, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   indy_i:
 #!     number: 1
@@ -621,7 +621,7 @@ are lots of options you can play with.
 
 This is a full example:
 
-``` mpf-config
+``` yaml
 # switches and lights in your machine config
 switches:
   indy_i:

--- a/docs/cookbook/long_presssing_start_to_end_game.md
+++ b/docs/cookbook/long_presssing_start_to_end_game.md
@@ -12,7 +12,7 @@ Related Config File Sections:
 The following snippet will end a running game by long-pressing the start
 button:
 
-``` mpf-config
+``` yaml
 timed_switches:
   game_cancel:
     switch_tags: start

--- a/docs/cookbook/multiple_timed_shots.md
+++ b/docs/cookbook/multiple_timed_shots.md
@@ -18,7 +18,7 @@ if the other two are running.
 
 This is a basic example:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 mode:
   start_events: start_my_mode

--- a/docs/cookbook/mystery_award.md
+++ b/docs/cookbook/mystery_award.md
@@ -24,7 +24,7 @@ runs with [ball_holds](../game_logic/ball_holds.md).
 Here is an example of how to use a scoop to hold a ball during a mystery
 award animation:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_ball1:
 #!     number:
@@ -70,7 +70,7 @@ Once mystery has been lit and the ball enters the device, you can use
 In the below example, there are four possible awards and the game will
 make sure each one is provided to avoid doubling-up.
 
-``` mpf-config
+``` yaml
 ##! mode: mystery_mode
 random_event_player:
   ball_hold_mystery_scoop_held_ball:
@@ -91,7 +91,7 @@ You can use anything to display an award such as a slide or video. In
 the below example, a video is used for each award and the scoop will
 eject the ball after the video has completed.
 
-``` mpf-mc-config
+``` yaml
 ##! mode: mystery_mode
 event_player:
   slide_award_1_slide_removed: end_mystery
@@ -133,7 +133,7 @@ slides:
 Here is the full example you can use in a mode as a template to start
 working on your own mystery award.
 
-``` mpf-mc-config
+``` yaml
 #! switches:
 #!   s_ball1:
 #!     number:

--- a/docs/cookbook/rollover_lanes_with_lane_change.md
+++ b/docs/cookbook/rollover_lanes_with_lane_change.md
@@ -48,7 +48,7 @@ use the I-N-D-Y lanes from the Indiana Jones pinball game. We'll assume
 that the machine has switches defined in the `switches:` config section
 for each of the top lanes, called `s_top_lane_1` through `s_top_lane_4`.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_top_lane_1:
 #!     number: 1
@@ -79,7 +79,7 @@ shots:
 We can create a [shot profile](../config/shot_profiles.md) for the top lanes that starts with the light on, and turns
 it off after the shot is hit.
 
-``` mpf-config
+``` yaml
 ##! mode: top_lanes
 shot_profiles:
   top_lane_profile:
@@ -105,7 +105,7 @@ show) for a specific shot, use the light that corresponds to that shot.
 We'll assume the machine has four lights defined in the `lights:`
 config section, called `l_top_lane_1` through `l_top_lane_4`
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_top_lane_1:
 #!     number: 1
@@ -159,7 +159,7 @@ together. In this case, we'll use our shot group to:
 * Trigger an event when all the shots are hit
 * Reset all the shots to be lit
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_top_lane_1:
 #!     number: 1
@@ -245,7 +245,7 @@ on *bonus_multiplier*.
 
 ## The full mode config code
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_top_lane_1:
 #!     number: 1

--- a/docs/cookbook/sequential_drop_banks.md
+++ b/docs/cookbook/sequential_drop_banks.md
@@ -33,7 +33,7 @@ the sequence resets when it's hit.
 Each shot also has `reset_events` configured, so that the entire
 sequence can be reset after completion.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drop_1:
 #!     number: 1
@@ -109,7 +109,7 @@ shows accept the `show_tokens` from our shots. In this case, it is the
 LED we wish to control. You can create your own shows to change LED
 color, play sounds, etc.
 
-``` mpf-config
+``` yaml
 ##! mode: sequential_drops
 
 shot_profiles:
@@ -141,7 +141,7 @@ starts and when the sequence completes. All logicblocks have a default
 completion event called *logicblock_(name)_complete* so we don't need
 to explicitly define any completion event.
 
-``` mpf-config
+``` yaml
 ##! mode: sequential_drops
 
 sequences:
@@ -177,7 +177,7 @@ reset coil for the target so that the target stays up.
 We can apply all of these rules based on the corresponding events, like
 follows.
 
-``` mpf-config
+``` yaml
 ##! mode: sequential_drops
 
 event_player:
@@ -200,7 +200,7 @@ event_player:
 The above configuration requires that each drop target coil has the
 corresponding reset events, as configured below.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drop_1:
 #!     number: 1
@@ -247,7 +247,7 @@ points for progression with the *logicblock_(name)_hit* event (when a
 lit target is hit) and the *logicblock_(name)_complete* event (when
 the full sequence is completed).
 
-``` mpf-config
+``` yaml
 ##! mode: sequential_drops
 
 variable_player:

--- a/docs/cookbook/skillshot_with_auto_rotate.md
+++ b/docs/cookbook/skillshot_with_auto_rotate.md
@@ -17,7 +17,7 @@ Skillshots are a self-contained set of rules, so it's wise to create a
 separate mode that can be started when a player's ball starts and ended
 after the skillshot is hit (or missed).
 
-``` mpf-config
+``` yaml
 #config_version=5
 modes:
   - skillshot_with_auto_rotate
@@ -59,7 +59,7 @@ that the first shot includes `advance_events: mode_skillshot_started` so
 that this shot will automatically light when the mode starts, as the
 first shot in the rotation.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_dropbank_1:
 #!     number: 1
@@ -134,7 +134,7 @@ advanced to the "lit" state and its light will flash. When any shot is
 hit, we'll check whether it is "lit" or not to know whether the
 skillshot should be awarded.
 
-``` mpf-config
+``` yaml
 ##! mode: skillshot_with_auto_rotate
 shot_profiles:
   skillshot_profile:
@@ -158,7 +158,7 @@ Shot groups are powerful because they control behavior of all the shots
 together. In this case, we'll use our shot group control the rotation
 of the shots, and a [timer](../config/timers.md) to trigger a rotation every half-second.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_dropbank_1:
 #!     number: 1
@@ -218,7 +218,7 @@ state is number 0 and the "on" state is number 1. The following code
 will only post the advance event for a shot if that shot is in state
 number 1, a.k.a. "on".
 
-``` mpf-config
+``` yaml
 ##! mode: skillshot_with_auto_rotate
 event_player:
   timer_skillshot_rotate_stopped:
@@ -244,7 +244,7 @@ with the state name of the shot that was hit. This way, we can check
 when *any* shot is hit rather than having to check each shot
 individually.
 
-``` mpf-config
+``` yaml
 ##! mode: skillshot_with_auto_rotate
 variable_player:
   skillshot_lit_hit:
@@ -265,7 +265,7 @@ will post before the *skillshot_lit_hit* event, so if we end the mode
 immediately then no score will be awarded. Instead, we add a 1 second
 delay after playfield activation before ending the mode.
 
-``` mpf-config
+``` yaml
 ##! mode: skillshot_with_auto_rotate
 event_player:
   # Add these lines after timer_skillshot_rotate_stopped (defined above)

--- a/docs/cookbook/skillshot_with_lane_change.md
+++ b/docs/cookbook/skillshot_with_lane_change.md
@@ -22,7 +22,7 @@ config section for each of the lanes, called `s_lane_left`,
 `s_lane_middle`, and `s_lane_right`. We'll also use corresponding
 lights `l_lane_left` etc. to indicate which lane is lit.
 
-``` mpf-config
+``` yaml
 #config_version=5
 modes:
   - skillshot_with_lane_change
@@ -56,7 +56,7 @@ shot_profiles:
 The first thing our mode needs is [shots:](../config/shots.md). Each lane will count as a shot, and for this example we'll
 have three lanes "left", "middle", and "right".
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_lane_left:
 #!     number: 1
@@ -107,7 +107,7 @@ don't want that here so we'll set `advance_on_hit: false`. Instead, we
 have explicit `advance_events` set on the shots so we can advance them
 for the lane change.
 
-``` mpf-config
+``` yaml
 ##! mode: skillshot_with_lane_change
 shot_profiles:
   skillshot_profile:
@@ -129,7 +129,7 @@ Shot groups are powerful because they control behavior of all the shots
 together. In this case, we'll use our shot group to rotate the lit
 shots.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_lane_left:
 #!     number: 1
@@ -166,7 +166,7 @@ The starting state of the shot profile is "off", so we need to pick
 one shot at random and advance it to its "lit" state. We'll use the
 [random_event_player:](../config/random_event_player.md) for this.
 
-``` mpf-config
+``` yaml
 ##! mode: skillshot_with_lane_change
 random_event_player:
   mode_skillshot_started:
@@ -186,7 +186,7 @@ with the state name of the shot that was hit. By using the shot group
 events, we can check when *any* shot is hit, rather than having to check
 each shot in the group individually.
 
-``` mpf-config
+``` yaml
 ##! mode: skillshot_with_lane_change
 variable_player:
   skillshot_lit_hit:
@@ -207,7 +207,7 @@ will post before the *skillshot_lit_hit* event, so if we end the mode
 immediately then no score will be awarded. Instead, we add a 1 second
 delay after playfield activation before ending the mode.
 
-``` mpf-config
+``` yaml
 ##! mode: skillshot_with_lane_change
 event_player:
   skillshot_hit: stop_mode_skillshot

--- a/docs/cookbook/top_lanes_with_multiplier.md
+++ b/docs/cookbook/top_lanes_with_multiplier.md
@@ -26,7 +26,7 @@ of ball bonuses. The counter value lb_JAM_complete_count is used as the
 count value in the JAM_lanes_done{count==2} within the variable_player
 conditional event statements.
 
-``` mpf-config
+``` yaml
 # in your machine config
 #! switches:
 #!   s_top_lane_J:

--- a/docs/events/overview/conditional.md
+++ b/docs/events/overview/conditional.md
@@ -53,7 +53,7 @@ your config files when you enter things that take action on events.
 For example, here's a section of a config file that would show a slide
 called "lets_go" when the *ball_started* event was posted:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   lets_go:
 #!     - type: text
@@ -81,7 +81,7 @@ AND if the parameters have certain values.
 
 For example:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   first_ball_intro:
 #!     - type: text
@@ -107,7 +107,7 @@ ball 1 is started for any player.)
 
 Of course you can use multiple entries with different values, like this:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   first_ball_intro:
 #!     - type: text
@@ -138,7 +138,7 @@ ball after Ball 1, the "lets_go" slide will be posted.
 
 You can also combine things here using `and` or `or`. For example:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   special_slide: []
 slide_player:
@@ -149,7 +149,7 @@ Now the "special_slide" will be shown for either ball 1 *or* ball 3.
 
 You can also combine with "and", for example:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   special_slide: []
 slide_player:
@@ -167,7 +167,7 @@ player variables from any player (x is the player index), `machine.` to
 access machine variables, `game.` game attributes, and `settings.` to
 access operator settings.
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   you_rule: []
 #!   you_stink: []
@@ -186,7 +186,7 @@ But wait, there's more!
 You can also use standard math operators (`+`, `-`, `*`, `/`, `//`,
 etc.) to evaluate whether the action should take place:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   uh_oh: []
 slide_player:
@@ -207,7 +207,7 @@ the `value` of a `counter` called `your_mode_counter` you would use
 `device.counters.your_mode_counter.value`. In the following example we
 show a slide when the value of the counter is above `5` in ball `3`
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   nearly_did_all_modes: []
 slide_player:
@@ -228,7 +228,7 @@ all) variables.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 #! lights:
 #!   led4:
 #!     number:

--- a/docs/events/overview/index.md
+++ b/docs/events/overview/index.md
@@ -18,7 +18,7 @@ For example, you might have a `variable_player:` entry in your config
 which watches for an event called *target1_hit*, and when it sees it, it
 adds 1000 points to the player's score, like this:
 
-``` mpf-config
+``` yaml
 ##! mode: base
 variable_player:
   target1_hit:
@@ -112,7 +112,7 @@ In the various
 
 For example, in a config file:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   my_slide:
 #!     - type: text
@@ -135,7 +135,7 @@ will be some word) which is where you can event event names that cause
 that action to happen. For example, you may have a drop target
 configured like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drop_target_1:
 #!     number: 1

--- a/docs/finalization/power.md
+++ b/docs/finalization/power.md
@@ -107,7 +107,7 @@ class shutdown_computer(Mode):
 Create a `shutdown_computer.yaml` file in the `/config` folder with the
 following code:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_left_flipper:
 #!     number:

--- a/docs/game_design/ball_end_modes.md
+++ b/docs/game_design/ball_end_modes.md
@@ -13,7 +13,7 @@ Ball end modes delay the ball ending process. If you want your own mode
 to delay the ball ending process you can start the with the following
 config:
 
-``` mpf-config
+``` yaml
 ##! mode: custom_bonus
 #config_version=5
 mode:

--- a/docs/game_design/game_end_modes.md
+++ b/docs/game_design/game_end_modes.md
@@ -11,7 +11,7 @@ modes typically exist which delay game ending and are built-in to MPF.
 
 If you want to implement your own game end mode use this template:
 
-``` mpf-config
+``` yaml
 ##! mode: custom_high_score
 #config_version=5
 mode:
@@ -34,7 +34,7 @@ last ball of every player (but you can also use `game_ending` as above).
 Put this into your base mode to start your custom mode on the end of
 ball three (or remove the condition to start if after every ball):
 
-``` mpf-config
+``` yaml
 ##! mode: base
 queue_relay_player:
   ball_ending{current_player.ball==3}:

--- a/docs/game_design/mode_layering.md
+++ b/docs/game_design/mode_layering.md
@@ -102,7 +102,7 @@ is to separate the various field mode behaviors into different yaml
 files and import all of them into the field helper mode. This keeps each
 file small while giving just a single mode to start and stop.
 
-``` mpf-config
+``` yaml
 ##! mode: field
 # modes/field/config/field.yaml
 
@@ -123,7 +123,7 @@ want to allow two or more missions to run concurrently. Giving every
 mission mode a few common event handlers allows the global mode to
 easily manage the transitions into and out of mission modes.
 
-``` mpf-config
+``` yaml
 ##! mode: trolls
 # modes/trolls/config/trolls.yaml
 
@@ -141,7 +141,7 @@ will automatically attempt to restart field when a mission mode stops,
 so we add a special handler: stop global mode when the ball ends, and
 only restart field mode if global isn't stopping.
 
-``` mpf-config
+``` yaml
 ##! mode: global
 # modes/global/config/global.yaml
 
@@ -170,7 +170,7 @@ event_player:
 **Wizard modes** replace global, and use a special set of event handlers
 just like the mission modes.
 
-``` mpf-config
+``` yaml
 ##! mode: madness
 # modes/madness/config/madness.yaml
 
@@ -186,7 +186,7 @@ handlers to manage the transition between global mode and wizard modes.
 Just like with global restarting field, base mode restarts global mode
 when a wizard mode stops (unless base mode itself is stopping).
 
-``` mpf-config
+``` yaml
 ##! mode: base
 # modes/base/config/base.yaml
 event_player:

--- a/docs/game_design/mode_selection.md
+++ b/docs/game_design/mode_selection.md
@@ -72,7 +72,7 @@ Batman DK (2008) or Stern Star Wars (2017).
 
 This is an example:
 
-``` mpf-config
+``` yaml
 ##! mode: left_ramp
 # mode: left_ramp
 mode:
@@ -162,7 +162,7 @@ There are multiple options to implement a selection carousel.
 One way to achieve mode selection you use a carousel mode which looks
 like this:
 
-``` mpf-config
+``` yaml
 ##! mode: carousel
 #config_version=5
 mode:
@@ -198,7 +198,7 @@ instance this might be combined with the example above by influencing
 the `starting_count:` or `count_complete_value:`
 using conditional events:
 
-``` mpf-config
+``` yaml
 ##! mode: qualify
 counters:
   left_ramp_qualify_counter:
@@ -214,7 +214,7 @@ You can define multiple
 [achievements](../config/achievements.md) and
 rotate them:
 
-``` mpf-config
+``` yaml
 #! lights:
 #!   l_left_ramp:
 #!     number:
@@ -309,7 +309,7 @@ This is a very flexible way to achieve this.
 Use this to delay the start of a player's first ball until they select
 a mode:
 
-``` mpf-config
+``` yaml
 ##! mode: start_selecton_on_ball_one
 #config_version=5
 mode:
@@ -333,7 +333,7 @@ extra balls). If you also want to trigger it on extra balls use
 Normally, pressing the start button will cause MPF to add another
 player. To suppress this during mode selection you can do the following:
 
-``` mpf-config
+``` yaml
 # Add the following to the game section of your machine's config.yaml
 # This will disable the start button for adding players
 game:

--- a/docs/game_design/wizard_modes.md
+++ b/docs/game_design/wizard_modes.md
@@ -22,7 +22,7 @@ One common approach for wizard modes is to have a counter that tracks
 shots to qualify the mode. In this example, hitting three shots will
 enable and immediately start the wizard mode:
 
-``` mpf-config
+``` yaml
 ##! mode: wizard_qualify
 # mode: wizard_qualify
 mode:

--- a/docs/game_logic/ball_saves/center_post.md
+++ b/docs/game_logic/ball_saves/center_post.md
@@ -23,7 +23,7 @@ logic. The diverter will already implement all that for us.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 # in your machine config
 coils:
   c_ball_save_post_up:

--- a/docs/game_logic/ball_saves/index.md
+++ b/docs/game_logic/ball_saves/index.md
@@ -29,7 +29,7 @@ different things.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 ball_saves:
   random_ball_save:
     active_time](5s

--- a/docs/game_logic/ball_search/configuring_ball_search.md
+++ b/docs/game_logic/ball_search/configuring_ball_search.md
@@ -8,7 +8,7 @@ title: How to configure Ball Search
 To enable ball search set `enable_ball_search` to True for
 your playfield(s). In most cases, this is as simple as this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_flipper_left:
 #!     number:
@@ -41,7 +41,7 @@ you to configure their order in ball search using the
 [example ball_search](../../examples/index.md)). By default flippers are not included in ball search.
 However, you might want to enable it for upper playfield flippers:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_flipper_left:
 #!     number:

--- a/docs/game_logic/ball_start_end.md
+++ b/docs/game_logic/ball_start_end.md
@@ -21,7 +21,7 @@ delay the ball start and the ball will eject instantly.
 This might be useful to start music, flash some lights or start
 background shows:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 # in your mode
 mode:
@@ -48,7 +48,7 @@ This can simply be embedded in any mode (e.g. in your base mode).
 
 It is also very common to start a ball save on eject:
 
-``` mpf-config
+``` yaml
 playfields:
   playfield:
     default_source_device: bd_plunger
@@ -136,7 +136,7 @@ will never see the `ball_ended` event in a game mode. This approach will
 not delay the ball end and the next ball might eject in the meantime.
 Use it for very short sounds or light flashes:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 # in your mode
 mode:
@@ -173,7 +173,7 @@ To delay start and end of a ball use the following mode. It uses a
 be used to show longer sequences and delaying the game flow in the
 meantime:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 # in your mode
 mode:

--- a/docs/game_logic/bonus/configuring_bonus.md
+++ b/docs/game_logic/bonus/configuring_bonus.md
@@ -64,7 +64,7 @@ Most modern pinball machines have bonus scores based on multiple things.
 Use a [variable_player:](../../config/variable_player.md) to count
 some bonuses:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 variable_player:
   ramp_shot_hit:
@@ -78,7 +78,7 @@ variable_player:
 Now go back into your bonus mode folder open up `bonus.yaml` config file
 (which should be empty at this point), and enter a basic config:
 
-``` mpf-mc-config
+``` yaml
 ##! mode: bonus
 #config_version=5
 mode_settings:

--- a/docs/game_logic/bonus/index.md
+++ b/docs/game_logic/bonus/index.md
@@ -46,7 +46,7 @@ multiplied by the *score*. This makes it very easy to award, for
 example, 200 points for every time the player captured a castle (tracked
 by the player variable "castles_captured").
 
-``` mpf-config
+``` yaml
 ##! mode: bonus
 #config_version=5
 mode_settings:
@@ -60,7 +60,7 @@ For advanced score calculation, the *score* value can utilize all of
 MPF's
 [dynamic and placeholder variables](../../config/instructions/dynamic_values.md).
 
-``` mpf-config
+``` yaml
 ##! mode: bonus
 #config_version=5
 mode_settings:
@@ -87,7 +87,7 @@ After all awards in the entries list have been posted, a final
 *bonus_total* event will post with the total amount awarded as bonus.
 This event can be used to show a final slide.
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 #! slides:
 #!   bonus_start_slide: []

--- a/docs/game_logic/combo_switches.md
+++ b/docs/game_logic/combo_switches.md
@@ -43,7 +43,7 @@ long they have to be held, and how long they have to be released.
 MPF's `mpfconfig.yaml` (the built-in machine config that's merged in
 with all machine configs) includes the following section:
 
-``` mpf-config
+``` yaml
 combo_switches:
   both_flippers:
     tag_1: left_flipper
@@ -63,7 +63,7 @@ default config.
 
 Here is an example of using flipper_cancel to cancel a show:
 
-``` mpf-mc-config
+``` yaml
 switches:
   s_flipper_left:
     tags: left_flipper

--- a/docs/game_logic/credits.md
+++ b/docs/game_logic/credits.md
@@ -54,7 +54,7 @@ add a section called `credits:`, and then under there, indent a few
 spaces (it doesn't matter how many, 2 or 4 or whatever you prefer) and
 add a section called `categories:`. Your file should now look like this:
 
-``` mpf-config
+``` yaml
 # in your machine wide config
 switches:
   s_coin_left:
@@ -148,7 +148,7 @@ the credits mode to the list of modes that are used in your machine. To
 do this, add `- credits` to the modes: section in your machine-wide
 config, like this:
 
-``` mpf-config
+``` yaml
 modes:
   - base
   - bonus
@@ -173,7 +173,7 @@ look at the built-in `credits` mode's config (at
 `mpf/modes/credits/config/credits.yaml`), you'll see it has the
 following `mode:` section:
 
-``` mpf-config
+``` yaml
 ##! mode: credits
 mode:
   code: mpf.modes.credits.code.credits.Credits
@@ -205,7 +205,7 @@ totally blank, add the required `#config_version=5` to the top line.
 There are several credit-related things you need to show the player on
 your display. Here are some settings you can use as a starting point:
 
-``` mpf-mc-config
+``` yaml
 switches:
   s_coin_left:
     number:
@@ -417,7 +417,7 @@ tiers. Luckily, there is the
 [more settings](../config/settings.md). Let us
 add two settings and use them in the credits config:
 
-``` mpf-config
+``` yaml
 # in your machine wide config
 switches:
   s_coin_left:
@@ -495,7 +495,7 @@ Here's the complete credits config file from the Demo Man sample game.
 
 This is an example:
 
-``` mpf-mc-config
+``` yaml
 # in your machine wide config
 #! displays:
 #!   window:

--- a/docs/game_logic/extra_balls.md
+++ b/docs/game_logic/extra_balls.md
@@ -23,7 +23,7 @@ limit the maximum number of extra balls.
 Some games (especially EMs) award extra balls based on the score. This
 is an example:
 
-``` mpf-config
+``` yaml
 ##! mode: base
 # in your base mode
 extra_balls:

--- a/docs/game_logic/high_scores/high_scores_in_ems.md
+++ b/docs/game_logic/high_scores/high_scores_in_ems.md
@@ -15,7 +15,7 @@ which allows a player to enter initials. To use the existing
 [high score mode](../../index.md) we can preset
 player initials using [player_vars:](../../config/player_vars.md).
 
-``` mpf-config
+``` yaml
 player_vars:
   initials:
     value_type: str

--- a/docs/game_logic/high_scores/index.md
+++ b/docs/game_logic/high_scores/index.md
@@ -36,7 +36,7 @@ high score mode without entering initials.
 
 This is an example (for machines with display):
 
-``` mpf-mc-config
+``` yaml
 ##! mode: my_mode
 #! variable_player:
 #!   score_100:
@@ -270,7 +270,7 @@ Additionally, there will be `loop1_label`, `loop1_value` and
 high scores. This is an example of an attract mode which shows high
 scores:
 
-``` mpf-mc-config
+``` yaml
 # in your machine wide config file
 widget_styles:
   attract_mode_high_score_display_label:

--- a/docs/game_logic/logic_blocks/accruals.md
+++ b/docs/game_logic/logic_blocks/accruals.md
@@ -42,7 +42,7 @@ For example, let's say you had a mode where you wanted three shots to
 be hit, in any order, and when they were all hit, you lit another shot.
 You'd use an accrual logic block like this:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 accruals:
   name_of_my_logic_block:
@@ -90,7 +90,7 @@ For
 
 This is an example:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 accruals:
   test_accrual:

--- a/docs/game_logic/logic_blocks/counters.md
+++ b/docs/game_logic/logic_blocks/counters.md
@@ -41,7 +41,7 @@ down.
 Here's an example of a counter you could use to track progress towards
 super jets:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 counters:
   super_jets:
@@ -56,7 +56,7 @@ counters:
 And here's the logic block we use for the
 [Addams Family mansion awards](../../cookbook/TAF_mansion_awards.md) to make sure the mansions is initialized only once per game:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 counters:
   initialize_mansion:
@@ -86,7 +86,7 @@ For
 
 This is an example:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 counters:
   test_counter:

--- a/docs/game_logic/logic_blocks/integrating_logic_block_and_slides.md
+++ b/docs/game_logic/logic_blocks/integrating_logic_block_and_slides.md
@@ -18,7 +18,7 @@ counter to a player variable and then use that variable in your slide.
 
 This is an example:
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 
 ##! mode: my_mode

--- a/docs/game_logic/logic_blocks/integrating_logic_blocks_and_lights.md
+++ b/docs/game_logic/logic_blocks/integrating_logic_blocks_and_lights.md
@@ -15,7 +15,7 @@ You might want to enable lights based on the state of a counter. This is
 an example for integrating lights via light_player using subscriptions
 on the value of the counter:
 
-``` mpf-config
+``` yaml
 lights:
   l_chest_matrix_green_2:
     number:

--- a/docs/game_logic/logic_blocks/integrating_logic_blocks_and_shows.md
+++ b/docs/game_logic/logic_blocks/integrating_logic_blocks_and_shows.md
@@ -17,7 +17,7 @@ to control shows, lights, slides, and to restore them on the next ball.
 However it should not be used for scoring (to handle an event when the
 counter changes, consider the *(name)_hit* event instead).
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 counters:
   my_counter:
@@ -46,7 +46,7 @@ Another way to achieve the same thing is this:
 
 You can even achieve this a bit simpler than in the example. Like this:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 counters:
   my_counter:
@@ -74,7 +74,7 @@ show it stopped (but other behaviors are possible).
 
 `my_show` could look like this:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 #show_version=5
 - duration: -1
@@ -105,7 +105,7 @@ If you want something to happen only once when the logic_block advances
 (and not on mode restart) you should use the `_hit` event. E.g. for a
 callout use this:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 counters:
   my_counter:
@@ -133,7 +133,7 @@ being triggered by another event, using
 You can access the value directly from the device variable using
 `devices.counters.my_counter.value`:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 show_player:
   some_other_event{devices.counters.my_counter.value==0}: my_show_initial

--- a/docs/game_logic/logic_blocks/persisting_state_in_a_player_variable.md
+++ b/docs/game_logic/logic_blocks/persisting_state_in_a_player_variable.md
@@ -27,7 +27,7 @@ state of the logic block itself, which is an object with
 attributes. Note the difference in accessing the logic block state as a
 dynamic value vs. placeholder text:
 
-``` mpf-mc-config
+``` yaml
 ##! mode: my_mode
 counters:
   logic_block_1:

--- a/docs/game_logic/logic_blocks/scoring_based_on_logic_blocks.md
+++ b/docs/game_logic/logic_blocks/scoring_based_on_logic_blocks.md
@@ -12,7 +12,7 @@ Sometimes you want to score points based on the state of a logic block.
 This is a simple example with an accrual. Every event can increase the
 multiplier exactly once. Multiplier starts at 1 and goes up to 4.
 
-``` mpf-config
+``` yaml
 ##! mode: test
 mode:
   start_events: ball_started
@@ -73,7 +73,7 @@ variable_player:
 Similarly, you can use a counter to increase a multiplier. Every event
 listed can increase the multiplier multiple times.
 
-``` mpf-config
+``` yaml
 ##! mode: test
 mode:
   start_events: ball_started
@@ -133,7 +133,7 @@ variable_player:
 
 This also works with sequences.
 
-``` mpf-config
+``` yaml
 ##! mode: test
 mode:
   start_events: ball_started

--- a/docs/game_logic/logic_blocks/sequences.md
+++ b/docs/game_logic/logic_blocks/sequences.md
@@ -33,7 +33,7 @@ An example might be if you have to hit four shots in a specific order to
 complete a mode, like this example from the World Tour mode of *Brooks
 'n Dunn*:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 sequences:
   finish_world_tour:
@@ -84,7 +84,7 @@ For
 
 This is an example:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 sequences:
   test_sequence:

--- a/docs/game_logic/logic_blocks/state_machines.md
+++ b/docs/game_logic/logic_blocks/state_machines.md
@@ -31,7 +31,7 @@ Video about state machines:
 
 This is an example:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 state_machines:
   my_state:
@@ -81,7 +81,7 @@ variable your can use a
 [variable_player](../../config/variable_player.md). You can then use it on slides or in places where conditions
 do not work (yet).
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 state_machines:
   my_state:

--- a/docs/game_logic/match_mode.md
+++ b/docs/game_logic/match_mode.md
@@ -7,7 +7,7 @@ title: Match Mode
 
 To use the built-in MPF match mode add this config:
 
-``` mpf-mc-config
+``` yaml
 ##! mode: match
 # in modes/match/config/match.yaml
 queue_relay_player:

--- a/docs/game_logic/modes/index.md
+++ b/docs/game_logic/modes/index.md
@@ -78,7 +78,7 @@ Again, anything that's specified in a mode's configuration file is
 only active while that mode is active. So if you have a mode called
 "multiball" with the following entry in that mode's config file:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 variable_player:
   right_ramp_hit:

--- a/docs/game_logic/multiballs/multiball_with_multiple_lock_devices.md
+++ b/docs/game_logic/multiballs/multiball_with_multiple_lock_devices.md
@@ -34,7 +34,7 @@ event. After all the balls from the multiball drained all lock modes and
 the multiball mode will stop using the
 [multiball_(name)_ended](../../events/multiball_multiball_ended.md) event.
 
-``` mpf-config
+``` yaml
 coils:
   eject_coil1:
     number:

--- a/docs/game_logic/multiballs/multiball_with_virtual_ball_lock.md
+++ b/docs/game_logic/multiballs/multiball_with_virtual_ball_lock.md
@@ -11,7 +11,7 @@ device (as in the example) or any normal shot.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_middle_ramp:
     number:

--- a/docs/game_logic/players.md
+++ b/docs/game_logic/players.md
@@ -74,7 +74,7 @@ MPF.
 
 **Examples:**
 
-``` mpf-config
+``` yaml
 player_vars:
   current_mode:
     initial_value: Trees Attack
@@ -103,7 +103,7 @@ configuring the change you would like to make. In the current version of
 MPF, this is primarily done in the `variable_player:` section of your
 mode.
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 variable_player:
   # add 1 to bumper_hits
@@ -116,7 +116,7 @@ A mode carousel (mode selection by the player) was used by the player to
 select a mode ladder (a set of modes played in a sequence similar to
 scenes in GhostBusters). The apostrophes are not required but allowed.
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 variable_player:
   carousel_left_scoop_scene_selected:
@@ -132,7 +132,7 @@ see which mode ladder was in play and increments the custom player
 variable ladder_scene_1 to indicate the progress towards completing the
 mode.
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 variable_player:
   mode_is_complete{current_player.current_ladder=="Scene 1"}:
@@ -147,7 +147,7 @@ is displaying 3 variables on the main scoring screen of the base mode.
 The first two variables are of type "str" and the last variable is of
 type "int".
 
-``` mpf-mc-config
+``` yaml
 player_vars:
   current_ladder:
     initial_value: "Initial Ladder"

--- a/docs/game_logic/scoring/index.md
+++ b/docs/game_logic/scoring/index.md
@@ -14,7 +14,7 @@ player when a certain event is posted. This event could be a switch hit
 (i.e. for `s_your_switch` use the event
 `s_your_switch_active`).
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 variable_player:
   s_your_switch_active:
@@ -31,7 +31,7 @@ simplest way to implement multipliers is to use a
 keep the multiplier and multiply it to your scoring entries in
 [variable_player](../../config/variable_player.md). This is an example for simple scoring with multiplier:
 
-``` mpf-config
+``` yaml
 # set initial value for your multiplier player variable (to have it start
 # at 1 instead of 0)
 player_vars:
@@ -63,7 +63,7 @@ entry in config for every player.
 
 You can also reset the multiplier on every ball if you want:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 # in your mode:
 variable_player:
@@ -93,7 +93,7 @@ Sometimes you want to increase your multipliers after multiple events
 were posted. For instance, you might want to increase the multiplier
 after the player completed two shot_groups:
 
-``` mpf-config
+``` yaml
 # set initial value for your multiplier player variable (to have it start
 # at 1 instead of 0)
 player_vars:
@@ -132,7 +132,7 @@ You can also combine two (or more) multipliers (see
 [dynamic values](../../config/instructions/dynamic_values.md) for details about other possible placeholders and math
 operators):
 
-``` mpf-config
+``` yaml
 # set initial value for your multiplier player variables (to have it start
 # at 1 instead of 0)
 player_vars:
@@ -188,7 +188,7 @@ is active and the player made more than two loops (just for the sake of
 the example - you could also move the scoring into super_multiball and
 remove the first condition):
 
-``` mpf-config
+``` yaml
 # set initial value for your multiplier player variables (to have it start
 # at 1 instead of 0)
 player_vars:

--- a/docs/game_logic/scoring/ss_style_score_queues.md
+++ b/docs/game_logic/scoring/ss_style_score_queues.md
@@ -16,7 +16,7 @@ while adding the player score and wait after each digit. You can use
 [score_queue_player:](../../config/score_queue_player.md) to implement
 this in MPF.
 
-``` mpf-config
+``` yaml
 coils:
   c_chime_1000:
     number:

--- a/docs/game_logic/service_mode.md
+++ b/docs/game_logic/service_mode.md
@@ -17,7 +17,7 @@ during development.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 # include service mode in your modes list
 modes:
   - service

--- a/docs/game_logic/shots/index.md
+++ b/docs/game_logic/shots/index.md
@@ -76,7 +76,7 @@ It's important to understand, however, that in order to achieve these different 
 
 This is an example of a shot in a mode:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   lane_l:
 #!     number:
@@ -116,7 +116,7 @@ For
 
 This is an example:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   lane_l:
 #!     number:

--- a/docs/game_logic/shots/integrate_shots_with_shows_lights_sounds_widgets_or_slides.md
+++ b/docs/game_logic/shots/integrate_shots_with_shows_lights_sounds_widgets_or_slides.md
@@ -45,7 +45,7 @@ and display the widget we define a show and integrate it to our shots
 using a shot_profile. Eventually, we add a show_player to play
 animations and sounds when a shot is hit.
 
-``` mpf-mc-config
+``` yaml
 # this is in your machine-wide config
 # first we define some switches + lights
 switches:

--- a/docs/game_logic/shots/sequence_shots.md
+++ b/docs/game_logic/shots/sequence_shots.md
@@ -13,7 +13,7 @@ A sequence of switches which need to be hit in order with a timeout.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_ramp_entry:
     number: 1
@@ -46,7 +46,7 @@ on the [(sequence_shot_name)_hit](../../events/sequence_shot_hit.md) event of th
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_ramp_entry:
     number: 1

--- a/docs/game_logic/shots/shot_group.md
+++ b/docs/game_logic/shots/shot_group.md
@@ -13,7 +13,7 @@ Related Config File Sections:
 
 Example config for lane changing lights.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   lane_l:
 #!     number:

--- a/docs/game_logic/shots/shot_profiles.md
+++ b/docs/game_logic/shots/shot_profiles.md
@@ -13,7 +13,7 @@ Related Config File Sections:
 
 Shot profiles define how shots will behave when hit. This is an example:
 
-``` mpf-config
+``` yaml
 ##! mode: mode1
 shot_profiles:
   my_default_profile:

--- a/docs/game_logic/skill_shot.md
+++ b/docs/game_logic/skill_shot.md
@@ -22,7 +22,7 @@ Types of skill shots:
 
 A simple skill shot mode:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_lane_l:
 #!     number:

--- a/docs/game_logic/tilt/index.md
+++ b/docs/game_logic/tilt/index.md
@@ -41,7 +41,7 @@ for custom tilt logic or special modes.
 
 The minimal example is to just load the default `tilt` mode:
 
-``` mpf-config
+``` yaml
 modes:
   - tilt
 ```
@@ -51,7 +51,7 @@ modes:
 If you want to customize the mode you can also create a tilt mode inside
 your mode folder (config would be in `modes/tilt/config/tilt.yaml`):
 
-``` mpf-config
+``` yaml
 # in your machine config
 modes:
   - tilt
@@ -65,7 +65,7 @@ tilt:    # the following are the defaults only copy those if you want to change 
 
 ## Add operator settings to service mode
 
-``` mpf-config
+``` yaml
 # in your machine config
 modes:
   - tilt

--- a/docs/game_logic/tilt/overwrite_tilt_slides.md
+++ b/docs/game_logic/tilt/overwrite_tilt_slides.md
@@ -8,7 +8,7 @@ title: Overwriting Tilt Slides
 The [tilt mode](../../index.md) comes with very
 basic slides. You can overwrite them using the following config:
 
-``` mpf-mc-config
+``` yaml
 #! switches:
 #!   s_tilt:
 #!     number:

--- a/docs/game_logic/timers.md
+++ b/docs/game_logic/timers.md
@@ -35,7 +35,7 @@ The example config files section of the documentation contains
 If you want to use your timer in a slide you have to set the value to a
 player variable first:
 
-``` mpf-mc-config
+``` yaml
 ##! mode: your_mode
 # in your mode
 timers:
@@ -77,7 +77,7 @@ supports). Afterwards, you can use the variable in your slide.
 In this example, we'll display a count-down timer as minutes and seconds. Again, if you want to use your timer in a slide you have to set the value to a
 player variable first:
 
-``` mpf-mc-config
+``` yaml
 ##! mode: your_mode
 # in your mode
 timers:

--- a/docs/gmc/reference/slide_player.md
+++ b/docs/gmc/reference/slide_player.md
@@ -26,7 +26,7 @@ to be shown (or removed) based on events being posted.
 
 This is an example:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   slide1: []
 #!   slide2: []
@@ -92,7 +92,7 @@ Queues the slide for playback immediately. If an existing queued slide is playin
 For example, to remove *slide1* when the event *remove_slide_1* is
 posted:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   slide1: []
 slide_player:
@@ -103,7 +103,7 @@ slide_player:
 
 You can also specify a transition for the removal, like this:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   slide1: []
 slide_player:
@@ -129,7 +129,7 @@ and the slide will still be removed when the timer expires.
 When queueing a slide with the `action: queue` config, it's important to include an expiration time or else the queue will never advance.
 
 
-``` mpf-mc-config
+``` yaml
 slides:
   base:
     widgets:

--- a/docs/hardware/apc/connection.md
+++ b/docs/hardware/apc/connection.md
@@ -27,7 +27,7 @@ which is why we have to configure it similarly.
 
 Add/update the following sections in your machine config:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: lisy
 lisy:

--- a/docs/hardware/apc/index.md
+++ b/docs/hardware/apc/index.md
@@ -23,7 +23,7 @@ details.
 
 This is an example config:
 
-``` mpf-config
+``` yaml
 #config_version=5
 hardware:
   platform: lisy

--- a/docs/hardware/eli_dmd.md
+++ b/docs/hardware/eli_dmd.md
@@ -44,7 +44,7 @@ In MPF, RGB.DMD works just like
 for details). Can copy the following example (and replace `com12` with
 your com port):
 
-``` mpf-config
+``` yaml
 hardware:
   rgb_dmd: smartmatrix
 smartmatrix:

--- a/docs/hardware/fadecandy/index.md
+++ b/docs/hardware/fadecandy/index.md
@@ -114,7 +114,7 @@ To configure MPF to use FadeCandy LEDs, you can add an entry to the
 default platform for your LEDs and to instead use the `fadecandy`
 platform, like this:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: p_roc
   driverboards: pdb
@@ -145,7 +145,7 @@ The following diagram explains how the numbering works:
 
 Consider the following config:
 
-``` mpf-config
+``` yaml
 lights:
   l_led0:
     number: 0    # first LED on connector 0
@@ -199,7 +199,7 @@ fadecandy. The serial will be shown on the console of
 
 Then configure your lights as follows:
 
-``` mpf-config
+``` yaml
 lights:
   l_led0_0:
     number: 0-0    # first LED on connector 0
@@ -279,7 +279,7 @@ on the console of `fcserver` when connecting your fadecandy.
 
 Afterwards, configure your lights as follows:
 
-``` mpf-config
+``` yaml
 lights:
   l_led0_0:
     number: 0-0    # first LED on connector 0 on board 0
@@ -324,7 +324,7 @@ this is not true for RGBW or similar LEDs which do not work with this
 style of numbering. Luckily, you can chain them instead and have MPF
 calculate the internal channels for you:
 
-``` mpf-config
+``` yaml
 lights:
   led_0:
     start_channel: 0-0

--- a/docs/hardware/fadecandy/troubleshooting.md
+++ b/docs/hardware/fadecandy/troubleshooting.md
@@ -17,7 +17,7 @@ described in the
 [troubleshooting guide](../../troubleshooting/index.md) this is done by adding `debug: true` to your `fadecandy`
 config section:
 
-``` mpf-config
+``` yaml
 fadecandy:
   debug: true
 ```

--- a/docs/hardware/fast/config.md
+++ b/docs/hardware/fast/config.md
@@ -25,7 +25,7 @@ and WPC controllers.
 To use MPF with a FAST, you need to configure your platform as `fast` in
 your machine-wide config file, like this:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: fast
 

--- a/docs/hardware/fast/dmd.md
+++ b/docs/hardware/fast/dmd.md
@@ -42,7 +42,7 @@ one physical DMD.)
 To do this, create a section in your machine-wide config called `dmds:`,
 and then pick a name for the DMD, like this:
 
-``` mpf-config
+``` yaml
 dmds:
   my_dmd:
     shades: 16
@@ -106,7 +106,7 @@ Note that the [Using a traditional (single color) physical DMD](../../mc/display
 guide has more details on the window and slide settings used in this
 machine config.
 
-``` mpf-mc-config
+``` yaml
 hardware:
   platform: fast
 fast:

--- a/docs/hardware/fast/drivers.md
+++ b/docs/hardware/fast/drivers.md
@@ -37,7 +37,7 @@ the chain, then the dash, then the driver output number. Note that the
 position number starts with zero, so the first IO board in the chain is
 0, the second is 1, etc.
 
-``` mpf-config
+``` yaml
 coils:
   my_coil:
     number: 0-0    # first board, driver 0
@@ -78,7 +78,7 @@ setting to a coil definition and then specifying the power value from
 
 For example, consider the following configuration:
 
-``` mpf-config
+``` yaml
 coils:
   some_coil:
     number: 1-3
@@ -90,7 +90,7 @@ When MPF sends this coil a pulse command, the coil will be fired for
 30ms at 50% power. You can even combine default_pulse_power and
 default_hold_power, like this:
 
-``` mpf-config
+``` yaml
 coils:
   some_coil:
     number: 1-3
@@ -119,7 +119,7 @@ time).
 However, with FAST Pinball hardware, you can manually set a coil's
 recycle time by adding a `recycle_ms:` setting, like this:
 
-``` mpf-config
+``` yaml
 coils:
   slingshot_r:
     number: 1-4

--- a/docs/hardware/fast/leds.md
+++ b/docs/hardware/fast/leds.md
@@ -62,7 +62,7 @@ exactly three channels. However, this is not true for RGBW or similar
 LEDs which do not work with this style of numbering. Luckily, you can
 chain them instead and have MPF calculate the internal channels for you:
 
-``` mpf-config
+``` yaml
 lights:
   led_0:
     start_channel: 0      # you could also use number: 0
@@ -80,7 +80,7 @@ lights:
 
 Remember that each chain from the Nano will handle up to 64 RGB LEDs. You likely will have more than just 64 LEDs in your machine resulting in multiple chains. When configuring the `start_channel` or `number` for subsequent chains, remember to identify the number of the first LED in that chain starting with the first number LED supported in that chain. For example, your first chain should start with LED_0 and your second chain with LED_64, the third with LED_128 and the fourth with LED_192, like this:
 
-``` mpf-config
+``` yaml
 lights:
   led_0:
     start_channel: 0      # you could also use number: 0
@@ -122,7 +122,7 @@ to corrupt messages.
 
 To help combat this, there are two settings you can adjust:
 
-``` mpf-config
+``` yaml
 mpf:
   default_light_hw_update_hz: 50
 fast:

--- a/docs/hardware/fast/rgb_dmd.md
+++ b/docs/hardware/fast/rgb_dmd.md
@@ -14,7 +14,7 @@ for the [How to configure a "SmartMatrix" RGB LED DMD](../smartmatrix.md).
 You can copy the following example (and replace `com12` with your com
 port):
 
-``` mpf-config
+``` yaml
 hardware:
   rgb_dmd: smartmatrix
 smartmatrix:

--- a/docs/hardware/fast/switches.md
+++ b/docs/hardware/fast/switches.md
@@ -28,7 +28,7 @@ the chain, then the dash, then the switch input number. Note that the
 position number starts with zero, so the first IO board in the chain is
 0, the second is 1, etc.
 
-``` mpf-config
+``` yaml
 switches:
   my_switch:
     number: 0-0    # first board, switch 0
@@ -74,7 +74,7 @@ open and closed times.
 You can change any of these in the `fast:` section of your machine-wide
 config, like this:
 
-``` mpf-config
+``` yaml
 fast:
   default_quick_debounce_open: 2ms
   default_quick_debounce_close: 2ms
@@ -92,7 +92,7 @@ open and debounce closed settings on a per-switch basis. To do that,
 just add a `debounce_open:` and/or `debounce_close:` setting to an
 individual switch, like this:
 
-``` mpf-config
+``` yaml
 switches:
   my_switch:
     number: 1-0

--- a/docs/hardware/fast/troubleshooting.md
+++ b/docs/hardware/fast/troubleshooting.md
@@ -70,7 +70,7 @@ described in the
 [troubleshooting guide](../../troubleshooting/index.md) this is done by adding `debug: true` to your `fast` config
 section:
 
-``` mpf-config
+``` yaml
 fast:
   debug: true
 ```

--- a/docs/hardware/i2c_servo.md
+++ b/docs/hardware/i2c_servo.md
@@ -32,7 +32,7 @@ Overview video about [servos](../mechs/servos/index.md):
 Connect the controller to the I2C port and add the following config
 section:
 
-``` mpf-config
+``` yaml
 hardware:
   servo_controllers: i2c_servo_controller
 ```
@@ -44,7 +44,7 @@ different for some chips.
 
 Add your servos to config:
 
-``` mpf-config
+``` yaml
 servos:
   servo1:
     number: 0  # first servo on controller
@@ -56,7 +56,7 @@ config file reference.
 
 You can also provide an I2C address per servo:
 
-``` mpf-config
+``` yaml
 servos:
   servo_on_controller_63_0:
     number: 63-0  # first servo on board with ID 0x3F / 63

--- a/docs/hardware/light_segment_displays.md
+++ b/docs/hardware/light_segment_displays.md
@@ -72,7 +72,7 @@ light shows.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 hardware:
   segment_displays: light_segment_displays
 
@@ -131,7 +131,7 @@ segment_displays:
 Here is another example for a monochrome serial 16-segment display using
 a WS2811 controller on OPP:
 
-``` mpf-config
+``` yaml
 hardware:
   segment_displays: light_segment_displays
 

--- a/docs/hardware/lisy/connection.md
+++ b/docs/hardware/lisy/connection.md
@@ -115,7 +115,7 @@ to be able to connect to the LISY board.
 If you want to use the serial port, add/update the following sections in
 your machine config:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: lisy
 lisy:
@@ -152,7 +152,7 @@ cdc_acm: USB Abstract Control Model driver for USB modems and ISDN adapters
 Alternatively, if you want to connect using WiFi or Ethernet, add/update
 the following sections in your machine config:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: lisy
 lisy:

--- a/docs/hardware/lisy/drivers.md
+++ b/docs/hardware/lisy/drivers.md
@@ -17,7 +17,7 @@ will always enable with full power (which is fine in older machines and
 should not break things). However, you can still choose the pulse length
 using `pulse_ms`.
 
-``` mpf-config
+``` yaml
 coils:
   c_some_coil:
     number: 04
@@ -30,7 +30,7 @@ address those you have to add 100 to their number from the manual. For
 instance, to address a coil which is connected to the light output `05`
 use coil `105`:
 
-``` mpf-config
+``` yaml
 coils:
   c_coil_on_light_bank:
     number: 107

--- a/docs/hardware/lisy/flippers_slings_popbumpers.md
+++ b/docs/hardware/lisy/flippers_slings_popbumpers.md
@@ -18,7 +18,7 @@ switches (similar to fliptronics).
 All you have to do is to configure the `game_over_relay` (which is
 connected as light) in LISY1 and LISY80:
 
-``` mpf-config
+``` yaml
 digital_outputs:
   game_over_relay:
     number: 1
@@ -30,7 +30,7 @@ digital_outputs:
 In LISY35 the same relay is connected to a driver. You can use this
 example to enable flippers:
 
-``` mpf-config
+``` yaml
 digital_outputs:
   flipper_enabling_relay:
     type: driver

--- a/docs/hardware/lisy/lights.md
+++ b/docs/hardware/lisy/lights.md
@@ -15,7 +15,7 @@ number from the game manual.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 lights:
   your_light:
     number: 03

--- a/docs/hardware/lisy/segment_displays.md
+++ b/docs/hardware/lisy/segment_displays.md
@@ -13,7 +13,7 @@ Related Config File Sections:
 MPF can control all segment displays on your machine with LISY.
 Configure them like this:
 
-``` mpf-config
+``` yaml
 segment_displays:
   info_display:
     number: 0

--- a/docs/hardware/lisy/sound.md
+++ b/docs/hardware/lisy/sound.md
@@ -24,7 +24,7 @@ all the sounds of your game.
 You can configure the external LISY
 [hardware sound interface](../../config/hardware_sound_systems.md) like this:
 
-``` mpf-config
+``` yaml
 hardware_sound_systems:
   default:
     label: LISY
@@ -35,7 +35,7 @@ hardware_sound_systems:
 Any built-in sounds can be played using their number in the original
 game:
 
-``` mpf-config
+``` yaml
 #! hardware_sound_systems:
 #!   default:
 #!     label: LISY
@@ -61,7 +61,7 @@ is `/boot/mpfcfg/LISY1/xxx` and for LISY80 this is
 according to the appendix in the [LISY user
 manual](http://www.lisy80.com/english/documentation-lisy/)).
 
-``` mpf-config
+``` yaml
 #! hardware_sound_systems:
 #!   default:
 #!     label: LISY
@@ -80,7 +80,7 @@ hardware_sound_player:
 
 LISY can also do text-to-speech:
 
-``` mpf-config
+``` yaml
 #! hardware_sound_systems:
 #!   default:
 #!     label: LISY
@@ -98,7 +98,7 @@ hardware_sound_player:
 
 Similarly, you can change volume:
 
-``` mpf-config
+``` yaml
 #! hardware_sound_systems:
 #!   default:
 #!     label: LISY
@@ -122,7 +122,7 @@ hardware_sound_player:
 You can also use any of the actions above in a show instead of in a
 standalone [Hardware Sound player](../../config_players/hardware_sound_player.md):
 
-``` mpf-config
+``` yaml
 #! hardware_sound_systems:
 #!   default:
 #!     label: LISY

--- a/docs/hardware/lisy/switches_lisy1.md
+++ b/docs/hardware/lisy/switches_lisy1.md
@@ -29,7 +29,7 @@ pinmame does it:
 
 You can start with this config:
 
-``` mpf-config
+``` yaml
 switches:
   slam:
     number: 76

--- a/docs/hardware/lisy/switches_lisy80.md
+++ b/docs/hardware/lisy/switches_lisy80.md
@@ -33,7 +33,7 @@ and Gottlieb decided not to document them ;-). Those are the following
 
 You can start with this config:
 
-``` mpf-config
+``` yaml
 switches:
   tilt:
     number: 57

--- a/docs/hardware/lisy/troubleshooting.md
+++ b/docs/hardware/lisy/troubleshooting.md
@@ -38,7 +38,7 @@ described in the
 [troubleshooting guide](../../troubleshooting/index.md) this is done by adding `debug: true` to your `lisy` config
 section:
 
-``` mpf-config
+``` yaml
 lisy:
   debug: true
 ```

--- a/docs/hardware/mma8451.md
+++ b/docs/hardware/mma8451.md
@@ -17,7 +17,7 @@ on
 
 Configure using:
 
-``` mpf-config
+``` yaml
 hardware:
   accelerometers: mma8451
 accelerometers:

--- a/docs/hardware/multimorphic/accelerometer.md
+++ b/docs/hardware/multimorphic/accelerometer.md
@@ -16,7 +16,7 @@ use to determine whether the machine is level).
 To use the accelerometer on the P3-ROC, add it to your machine-wide
 config file like this:
 
-``` mpf-config
+``` yaml
 accelerometers:
   p3_roc_accelerometer:
     number: 1

--- a/docs/hardware/multimorphic/alpha_numeric.md
+++ b/docs/hardware/multimorphic/alpha_numeric.md
@@ -13,7 +13,7 @@ Related Config File Sections:
 The P-ROC includes support four alpha-numeric displays (0-3). You can
 configure them in MPF:
 
-``` mpf-config
+``` yaml
 segment_displays:
   display1:
     number: 0

--- a/docs/hardware/multimorphic/dmd.md
+++ b/docs/hardware/multimorphic/dmd.md
@@ -43,7 +43,7 @@ one physical DMD.)
 To do this, create a section in your machine-wide config called `dmds:`,
 and then pick a name for the DMD, like this:
 
-``` mpf-config
+``` yaml
 dmds:
   my_dmd:
     shades: 16
@@ -114,7 +114,7 @@ For details on this, you can search the P-ROC forums (now defunct) for
 these settings. Then you can set them in the `p_roc: dmd_timing_cycles:`
 section of your machine-wide config, like this:
 
-``` mpf-config
+``` yaml
 p_roc:
   dmd_timing_cycles: 90, 190, 50, 377
 ```
@@ -152,7 +152,7 @@ Note that the [Using a traditional (single color) physical DMD](../../mc/display
 guide has more details on the window and slide settings used in this
 machine config.
 
-``` mpf-mc-config
+``` yaml
 hardware:
   platform: p_roc
 p_roc:

--- a/docs/hardware/multimorphic/drivers.md
+++ b/docs/hardware/multimorphic/drivers.md
@@ -50,7 +50,7 @@ to represent the following on a PD-16 driver board:
 
 For example:
 
-``` mpf-config
+``` yaml
 coils:
   some_coil:
     number: A0-B1-6
@@ -64,7 +64,7 @@ coils:
 If you want to use burst switches as local outputs set DIP switch 1 to
 `on` on the P3-Roc. You can use those 64 output as direct outputs:
 
-``` mpf-config
+``` yaml
 coils:
   local_output0:
     number: direct-0    # direct driver 0
@@ -80,7 +80,7 @@ exactly the same way.
 You may also use outputs as `digital_outputs`. For instance, to control
 a motor driver circuit:
 
-``` mpf-config
+``` yaml
 digital_outputs:
   motor_left:
     number: direct-5
@@ -112,7 +112,7 @@ The P-Roc, P3-Roc and/or PD-16 have the ability to specify the "pulse
 time". Pulse time is the coil's initial kick time. For example,
 consider the following configuration:
 
-``` mpf-config
+``` yaml
 coils:
   some_coil:
     number:
@@ -126,7 +126,7 @@ When MPF sends this coil a pulse command, the coil will be fired for
 
 You can also set the power of pulses on your coil:
 
-``` mpf-config
+``` yaml
 coils:
   some_coil:
     number:
@@ -149,7 +149,7 @@ The P-Roc internally uses two parameters which determine how many
 milliseconds the coil will be on (pwm-on time) and off (pwm-off time).
 MPF will calculate those based on your power settings.
 
-``` mpf-config
+``` yaml
 coils:
   some_coil:
     number:
@@ -173,7 +173,7 @@ the P/P3-Roc) is `64ms`.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 coils:
   some_coil_with_recycle:
     number:

--- a/docs/hardware/multimorphic/leds.md
+++ b/docs/hardware/multimorphic/leds.md
@@ -48,7 +48,7 @@ RGB LED, you specify four parts, separated by dashes:
 You separate those with dashes, so an example PD-LED configuration might
 look like this:
 
-``` mpf-config
+``` yaml
 lights:
   l_led0:
     number: 8-0-1-2
@@ -70,7 +70,7 @@ This is almost the same as above but it addresses only one output
 (instead of three). You can use the channel syntax as for
 `l_led0` above:
 
-``` mpf-config
+``` yaml
 lights:
   l_led0:
     channels:
@@ -85,7 +85,7 @@ lights:
 You might connect different color channels to your PD-LED. For instance
 you might have only a red channel:
 
-``` mpf-config
+``` yaml
 lights:
   my_red_only_insert:
     channels:
@@ -95,7 +95,7 @@ lights:
 
 Or you can configure a white LED:
 
-``` mpf-config
+``` yaml
 lights:
   my_white_light:
     channels:
@@ -106,7 +106,7 @@ lights:
 Starting from MPF 0.54 you can also have MPF calculate the numbers for
 you:
 
-``` mpf-config
+``` yaml
 lights:
   led_0:
     start_channel: 8-0
@@ -147,7 +147,7 @@ Those LEDs are wired individually to the PD-LED.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 lights:
   l_led_1:
     number: 4-0-1-2
@@ -167,7 +167,7 @@ whether you hook it up between the PD-LED's output and ground, or
 between the output and 3.3v.) You can then use the config file to
 specify which type of LED you have, such as:
 
-``` mpf-config
+``` yaml
 lights:
   l_shoot_again:
     number: 8-60-61-62
@@ -228,7 +228,7 @@ enable a serial LEDs you need to configure your PD-LED board in your
 `p_roc` section. Assuming your PD-LED has the address 4 you can use the
 following config to enable all serial LEDs and and define a few:
 
-``` mpf-config
+``` yaml
 p_roc:
   pd_led_boards:
     4:

--- a/docs/hardware/multimorphic/lights.md
+++ b/docs/hardware/multimorphic/lights.md
@@ -33,7 +33,7 @@ that contains a bunch of letters and numbers which specify the specific
 columns and row outputs that make up each lamp. It's probably easiest to
 look at an example.
 
-``` mpf-config
+``` yaml
 lights:
   some_light:
     subtype: matrix
@@ -77,14 +77,14 @@ section of your machine-wide config.
 
 For P-ROC:
 
-``` mpf-config
+``` yaml
 p_roc:
   lamp_matrix_strobe_time: 100ms
 ```
 
 For P3-ROC:
 
-``` mpf-config
+``` yaml
 p_roc:
   lamp_matrix_strobe_time: 100ms
 ```

--- a/docs/hardware/multimorphic/platform.md
+++ b/docs/hardware/multimorphic/platform.md
@@ -20,14 +20,14 @@ In your machine-wide config file, set the platform.
 
 For the P-ROC:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: p_roc
 ```
 
 For the P3-ROC:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: p3_roc
 ```
@@ -40,7 +40,7 @@ driver boards you're using. If you're using the P-ROC driver boards
 
 For the P-ROC:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: p_roc
 
@@ -50,7 +50,7 @@ p_roc:
 
 For the P3-ROC:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: p3_roc
 
@@ -71,7 +71,7 @@ your machine-wide config.
 
 For the P-ROC or P3-Roc:
 
-``` mpf-config
+``` yaml
 p_roc:
   use_watchdog: true
   watchdog_time: 1s

--- a/docs/hardware/multimorphic/servos.md
+++ b/docs/hardware/multimorphic/servos.md
@@ -19,7 +19,7 @@ To enable servos you need to configure your PD-LED board in your `p_roc`
 section. Assuming your PD-LED has the ID 4 you can use the following
 config to enable all servos and and define two of them:
 
-``` mpf-config
+``` yaml
 p_roc:
   pd_led_boards:
     4:

--- a/docs/hardware/multimorphic/steppers.md
+++ b/docs/hardware/multimorphic/steppers.md
@@ -21,7 +21,7 @@ To enable steppers you need to configure your PD-LED board in your
 `p_roc` section. Assuming your PD-LED has the ID 4 you can use the
 following config to enable and define two steppers:
 
-``` mpf-config
+``` yaml
 p_roc:
   pd_led_boards:
     4:

--- a/docs/hardware/multimorphic/switches_p3_roc.md
+++ b/docs/hardware/multimorphic/switches_p3_roc.md
@@ -40,7 +40,7 @@ then the `bank number` (Bank A is 0, Bank B is 1), then the switch
 
 For example:
 
-``` mpf-config
+``` yaml
 switches:
   my_switch:
     number: A0-B0-0    # SW-16 board at address 0, Bank A, Switch 0
@@ -61,7 +61,7 @@ calcuation for you.
 
 For example:
 
-``` mpf-config
+``` yaml
 switches:
   my_switch:
     number: 0     # SW-16 board at address 0, Bank A, Switch 0
@@ -95,7 +95,7 @@ MPF.
 
 You can configure burst optos using the following syntax:
 
-``` mpf-config
+``` yaml
 switches:
   burst_opto_1_20:
     number: burst-1-20     # burst input with switch 1 and driver 20
@@ -130,7 +130,7 @@ PCBA-0003-0003).
 If you want to use burst switches as local inputs set DIP switch 2 to
 `on` on the P3-Roc. You can use those 64 inputs as direct inputs:
 
-``` mpf-config
+``` yaml
 switches:
   local_switch0:
     number: direct-0       # local input 0
@@ -174,7 +174,7 @@ Valid options are `normal`, `quick`, and `auto`.
 To disable debouncing for a switch, add `debounce: quick` to the switch
 config, like this:
 
-``` mpf-config
+``` yaml
 switches:
   my_switch:
     number: A0-B0-0
@@ -184,7 +184,7 @@ switches:
 To force debouncing to always be used (which is also the default on the
 P-ROC, so not really needed), configure it like this:
 
-``` mpf-config
+``` yaml
 switches:
   my_switch:
     number: A0-B0-0

--- a/docs/hardware/multimorphic/switches_p_roc.md
+++ b/docs/hardware/multimorphic/switches_p_roc.md
@@ -39,7 +39,7 @@ connector mappings.)
 Direct switches are configured in your machine config file by starting
 the number with "SD", like this:
 
-``` mpf-config
+``` yaml
 switches:
   my_switch:
     number: SD0
@@ -54,7 +54,7 @@ switches:
 If you're using a switch matrix, then the switch numbers are entered
 using the column number, then a slash, then the row number.
 
-``` mpf-config
+``` yaml
 switches:
   my_switch:
     number: 0/0    # column 0, row 0
@@ -130,7 +130,7 @@ Valid options are `normal`, `quick`, and `auto`.
 To disable debouncing for a switch, add `debounce: quick` to the switch
 config, like this:
 
-``` mpf-config
+``` yaml
 switches:
   my_switch:
     number: 0/0
@@ -140,7 +140,7 @@ switches:
 To force debouncing to always be used (which is also the default on the
 P-ROC, so not really needed), configure it like this:
 
-``` mpf-config
+``` yaml
 switches:
   my_switch:
     number: 0/0

--- a/docs/hardware/multimorphic/troubleshooting.md
+++ b/docs/hardware/multimorphic/troubleshooting.md
@@ -91,7 +91,7 @@ described in the
 [troubleshooting guide](../../troubleshooting/index.md) this is done by adding `debug: true` to your `p_roc` config
 section:
 
-``` mpf-config
+``` yaml
 p_roc:
   debug: true
 ```
@@ -105,7 +105,7 @@ If your hardware behaves different from the way you told it to in MPF or
 if you are seeing lags or delays it might be wise to turn on bus
 tracing.
 
-``` mpf-config
+``` yaml
 p_roc:
   debug: true
   trace_bus: true

--- a/docs/hardware/mypinballs/index.md
+++ b/docs/hardware/mypinballs/index.md
@@ -34,7 +34,7 @@ control up to six segment displays.
 
 Config looks like this:
 
-``` mpf-config
+``` yaml
 hardware:
   segment_displays: mypinballs
 mypinballs:
@@ -70,7 +70,7 @@ Part number:
 
 Config looks like this:
 
-``` mpf-config
+``` yaml
 hardware:
   segment_displays: mypinballs
 mypinballs:

--- a/docs/hardware/opp/cobrapin/cobrapin_serial_segment_displays.md
+++ b/docs/hardware/opp/cobrapin/cobrapin_serial_segment_displays.md
@@ -20,7 +20,7 @@ to segment display LEDs. Each LED channel is connected to a segment. You
 must add light_segment_displays as the segment_displays platform so MPF
 knows to send segment display commands to the light controller:
 
-``` mpf-config
+``` yaml
 hardware:
   segment_displays: light_segment_displays
 ```
@@ -34,7 +34,7 @@ creating a light_group using `neoseg_displays`. This is much easier
 than defining each light for each of the 120 segments in an 8-digit
 display.
 
-``` mpf-config
+``` yaml
 neoseg_displays:
   neoSeg_0:
     start_channel: 0-0-0
@@ -70,7 +70,7 @@ brightness of a NeoSeg display. This is especially handy when using
 NeoSeg displays of different colors since each color has a different
 default brightness. Use the whitepoint setting to vary the brightness:
 
-``` mpf-config
+``` yaml
 light_settings:
   color_correction_profiles:
     NeoSeg_orange:
@@ -82,7 +82,7 @@ light_settings:
 Once you have the light groups defined, you can arrange them into
 displays. The light group is a `neoseg_displays` object and the logical display a [`segment_displays`](../../../config/segment_displays.md) object. The  `segment_displays` object is not specific for Cobra serial segments, but being used for all kind of segment displays. You can combine multiple light groups into one logical display.  In other cases you might have a 1:1 mapping between light groups and segment displays. In the latter case it might seem to overcomplicate things but this concept gives you the flexibility you might need. These are the displays that can be targeted by a segment_display_player.
 
-``` mpf-config
+``` yaml
 segment_displays:
   neoSegTop:
     number: 1
@@ -114,7 +114,7 @@ Keep in mind that a `segment_display` is an own object regardless what `light_gr
 
 Below you find a complete example config file how to define your hardware. With this you can use a `segment_display_player` to diplay a certain text upon a given event.
 
-``` mpf-config
+``` yaml
 #config_version=5
 
 hardware:
@@ -201,7 +201,7 @@ light_settings:
 
 Below you find a complete example config file to display scored points. It is not using all possible hardware options like the example above, but it includes the display of a show on the LED segments. To keep this example simple the `neoseg_displays` object is mapped 1:1 to a `segment_displays` object.
 
-``` mpf-config
+``` yaml
 #config_version=5
 
 hardware:

--- a/docs/hardware/opp/cobrapin/index.md
+++ b/docs/hardware/opp/cobrapin/index.md
@@ -147,7 +147,7 @@ project. The config file is fully valid for the Cobra board connected to
 a Linux PC running MPF. If you have a Cobra board but run Windows or
 macOS you have to change the `ports`.
 
-``` mpf-config
+``` yaml
 #config_version=5
 
 hardware:
@@ -304,7 +304,7 @@ have all inputs internally connected.
 
 ## Example Config
 
-``` mpf-config
+``` yaml
 #config_version=5
 
 #CobraPin Example Config

--- a/docs/hardware/opp/config.md
+++ b/docs/hardware/opp/config.md
@@ -15,7 +15,7 @@ Related Config File Sections:
 To use MPF with OPP, you need to configure your platform as *opp*, like
 this:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: opp
 ```
@@ -49,7 +49,7 @@ If you're using an OPP controller, you need to add the serial port to
 your MPF config. So if you plug in the OPP controller and see a port
 such as *COM7* appear, you'd set your config like this:
 
-``` mpf-config
+``` yaml
 opp:
   ports: COM7
 ```

--- a/docs/hardware/opp/drivers.md
+++ b/docs/hardware/opp/drivers.md
@@ -23,7 +23,7 @@ to 11. Wing position 3 contains coil numbers 12 to 15. The coil is
 numbered using the position of the OPP card (starting at 0), then a
 '-', and finally the coil number on the card.
 
-``` mpf-config
+``` yaml
 coils:
   some_coil:
     number: 0-12
@@ -39,7 +39,7 @@ The OPP hardware also has the ability to specify the "pulse time".
 Pulse time is the coil's initial kick time. For example, consider the
 following configuration:
 
-``` mpf-config
+``` yaml
 coils:
   some_coil:
     number: 0-12
@@ -59,7 +59,7 @@ It can range from 0.0 to 1.0 and defines the time share the coil is on
 The period is fixed at 16ms for OPP. To set the hold power to 25%, set
 default_hold_power to .25 and OPP will use 4ms/16ms = 25%.
 
-``` mpf-config
+``` yaml
 coils:
   some_coil:
     number: 0-3
@@ -86,7 +86,7 @@ source.
 It can range from 0.0 to 1.0 and defines the time share the coil is on
 (0%-100%). Any value under 0.03125 will be forced to output 3.125%.
 
-``` mpf-config
+``` yaml
 coils:
   some_coil:
     number: 0-3
@@ -108,7 +108,7 @@ the recycle time. The time will be `default_pulse_ms * recycle_factor`.
 For instance, if you set a pulse time of `10ms` and a recycle_factor of
 two the coil will cool down for at least `20ms`. This is an example:
 
-``` mpf-config
+``` yaml
 coils:
   some_coil:
     number: 0-3

--- a/docs/hardware/opp/leds.md
+++ b/docs/hardware/opp/leds.md
@@ -15,7 +15,7 @@ mature.
 
 LEDs work similar to matrix lights (chain 0, board 1, LED 1):
 
-``` mpf-config
+``` yaml
 lights:
   some_led:
     number: 0-1-1
@@ -71,7 +71,7 @@ this is not true for RGBW or similar LEDs which do not work with this
 style of numbering. Luckily, you can chain them instead and have MPF
 calculate the internal channels for you:
 
-``` mpf-config
+``` yaml
 lights:
   led_0:
     start_channel: 0-0-0

--- a/docs/hardware/opp/lights.md
+++ b/docs/hardware/opp/lights.md
@@ -17,7 +17,7 @@ position 2 contains bulbs 16 to 23. Wing position 3 contains bulbs 24 to
 31. The bulb is numbered using the position of the OPP card (starting at
 0), then a '-', and finally the bulb number on the card.
 
-``` mpf-config
+``` yaml
 lights:
   some_light:
     number: 1-16

--- a/docs/hardware/opp/oppcombo/index.md
+++ b/docs/hardware/opp/oppcombo/index.md
@@ -48,7 +48,7 @@ In this example, coil `c_player1_reel10` has number `0-0-0` meaning:
 Coil `c_player1_reel100` is driven by the same card, second output (that is wing 0, pin 1)
 
 
-``` mpf-config
+``` yaml
 #config_version=6
 
 hardware:

--- a/docs/hardware/opp/switches.md
+++ b/docs/hardware/opp/switches.md
@@ -24,7 +24,7 @@ at 0), then a '-', and finally the switch number on the card.
 
 Enter them as a combination of board-switch, like `0-12`.
 
-``` mpf-config
+``` yaml
 switches:
   some_switch:
     number: 0-15
@@ -68,7 +68,7 @@ PC running mpf. If you have a Cobra board but run Windows or macOS you
 have to change the `ports`. If you run a completely different hardware
 you have to adapt the `hardware` section.
 
-``` mpf-config
+``` yaml
 #config_version=5
 
    hardware:

--- a/docs/hardware/opp/troubleshooting.md
+++ b/docs/hardware/opp/troubleshooting.md
@@ -48,7 +48,7 @@ described in the
 [troubleshooting guide](../../troubleshooting/index.md) this is done by adding `debug: true` to your `opp` config
 section:
 
-``` mpf-config
+``` yaml
 opp:
   debug: true
 ```
@@ -63,7 +63,7 @@ processor boards can't answer MPF's polls fast enough) you may want to
 change it. This can be done by simply adding the `poll_hz:` line to the
 `opp:` section:
 
-``` mpf-config
+``` yaml
 opp:
   ports: COM7
   poll_hz: 50    # defaults to 100

--- a/docs/hardware/osc.md
+++ b/docs/hardware/osc.md
@@ -34,7 +34,7 @@ Outgoing:
 
 This is an example:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: osc
 

--- a/docs/hardware/pin2dmd/index.md
+++ b/docs/hardware/pin2dmd/index.md
@@ -62,7 +62,7 @@ RGB DMDs that use the SmartMatrix platform.
 
 1.  Add `pin2dmd` to your hardware section:
 
-``` mpf-config
+``` yaml
 hardware:
   rgb_dmd: pin2dmd
 pin2dmd:
@@ -88,7 +88,7 @@ one physical DMD.)
 To do this, create a section in your machine-wide config called
 `rgb_dmds:`, and then pick a name for the DMD, like this:
 
-``` mpf-config
+``` yaml
 rgb_dmds:
   default:  # your DMD
     hardware_brightness: .5      # adjust the brightness of your display if it is too bright
@@ -113,7 +113,7 @@ the DMD knows what content to show. In MPF, you do this by mapping a
 physical DMD to an
 [MPF display](../../mc/displays/index.md).
 
-``` mpf-mc-config
+``` yaml
 displays:
   window:  # on screen window - useful for debugging without real hardware
     width: 600
@@ -154,7 +154,7 @@ Note that the [Using an RGB full-color LED DMD](../../mc/displays/rgb_dmd.md)
 guide has more details on the window and slide settings used in this
 machine config.
 
-``` mpf-mc-config
+``` yaml
 hardware:
   rgb_dmd: pin2dmd
 pin2dmd:

--- a/docs/hardware/pin2dmd/troubleshooting.md
+++ b/docs/hardware/pin2dmd/troubleshooting.md
@@ -17,7 +17,7 @@ described in the
 [troubleshooting guide](../../troubleshooting/index.md) this is done by adding `debug: true` to your `pin2dmd`
 config section:
 
-``` mpf-config
+``` yaml
 pin2dmd:
   debug: true
 ```
@@ -30,7 +30,7 @@ recommend to disable/remove it after finishing debugging.
 Your display is not showing your slides? Check if your brightness is set
 high enough. You can adjust brightness in your `rgb_dmds` section:
 
-``` mpf-config
+``` yaml
 rgb_dmds:
   default:  # your DMD
     brightness: .8      # adjust the brightness of your display if it is too bright or dim

--- a/docs/hardware/pkone/config.md
+++ b/docs/hardware/pkone/config.md
@@ -28,7 +28,7 @@ TODO: Finish this section
 To use MPF with a PKONE controller system, you need to configure your
 platform as `pkone` in your machine-wide config file, like this:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: pkone
 ```

--- a/docs/hardware/pkone/drivers.md
+++ b/docs/hardware/pkone/drivers.md
@@ -32,7 +32,7 @@ The `number:` setting for each coil/driver is its board's Address ID
 number in the PKONE chain, then the dash, then the coil/driver output
 number (1-10).
 
-``` mpf-config
+``` yaml
 coils:
   my_coil:
     number: 0-1    # Extension board with Address ID 0, coil/driver 1
@@ -63,7 +63,7 @@ setting to a coil definition and then specifying the power value from
 
 For example, consider the following configuration:
 
-``` mpf-config
+``` yaml
 coils:
   some_coil:
     number: 1-3
@@ -75,7 +75,7 @@ When MPF sends this coil a pulse command, the coil will be fired for
 30ms at 50% power. You can even combine default_pulse_power and
 default_hold_power, like this:
 
-``` mpf-config
+``` yaml
 coils:
   some_coil:
     number: 1-3
@@ -104,7 +104,7 @@ time).
 With Penny K Pinball hardware, you can manually set a coil's recycle
 time by adding a `recycle_ms:` setting, like this:
 
-``` mpf-config
+``` yaml
 coils:
   slingshot_r:
     number: 1-4

--- a/docs/hardware/pkone/leds.md
+++ b/docs/hardware/pkone/leds.md
@@ -66,7 +66,7 @@ configuration file and have MPF calculate the internal channel numbers
 for you (please note the `type` setting is required when using
 `start_channel`/`previous` settings):
 
-``` mpf-config
+``` yaml
 lights:
   led_0:
     start_channel: 0-1-0

--- a/docs/hardware/pkone/lights.md
+++ b/docs/hardware/pkone/lights.md
@@ -27,7 +27,7 @@ The `number:` setting for each simple LED is its board's Address ID
 number in the PKONE chain, then the dash, then the simple LED output
 number.
 
-``` mpf-config
+``` yaml
 lights:
   special_light:
     number: 0-1    # Lightshow board with Address ID 0, simple LED 1

--- a/docs/hardware/pkone/servos.md
+++ b/docs/hardware/pkone/servos.md
@@ -28,7 +28,7 @@ chain to the controller.
 The `number:` setting for each servo is its board's Address ID number
 in the PKONE chain, then the dash, then the servo output number (11-14).
 
-``` mpf-config
+``` yaml
 servos:
   servo_1:
     number: 0-11    # Extension board with Address ID 0, servo 11 (the first one)

--- a/docs/hardware/pkone/switches.md
+++ b/docs/hardware/pkone/switches.md
@@ -28,7 +28,7 @@ chain.
 The `number:` setting for each switch is its board's Address ID number
 in the PKONE chain, then the dash, then the switch input number (1-35).
 
-``` mpf-config
+``` yaml
 switches:
   my_switch:
     number: 0-0    # Extension board at address 0, switch 0

--- a/docs/hardware/pkone/troubleshooting.md
+++ b/docs/hardware/pkone/troubleshooting.md
@@ -42,7 +42,7 @@ described in the
 [troubleshooting guide](../../troubleshooting/index.md) this is done by adding `debug: true` to your `opp` config
 section:
 
-``` mpf-config
+``` yaml
 pkone:
   debug: true
 ```

--- a/docs/hardware/platform.md
+++ b/docs/hardware/platform.md
@@ -20,7 +20,7 @@ across all of MPF.
 
 For example:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: p_roc
   driverboards: pdb
@@ -40,7 +40,7 @@ For example, if you want to use a P-ROC as the default for everything
 except for LEDs, which you want to be FadeCandy, you would do it like
 this:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: p_roc
   driverboards: pdb
@@ -71,7 +71,7 @@ For example, if you're using a FAST Pinball controller which can
 control up to 256 LEDs, but you also want to add some more LEDs that
 will be attached to a FadeCandy, you could set up your config like this:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: fast
 lights:
@@ -88,7 +88,7 @@ platform (and the number 0 is a Fadecandy number).
 
 You could also invert this, like so:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: fast
   lights: fadecandy

--- a/docs/hardware/pololu_maestro.md
+++ b/docs/hardware/pololu_maestro.md
@@ -48,7 +48,7 @@ controllers.)
 To do this, add `servo_controllers: pololu_maestro` to the `hardware:`
 section of your machine-wide config file, like this:
 
-``` mpf-config
+``` yaml
 hardware:
   servo_controllers: pololu_maestro
 ```
@@ -67,14 +67,14 @@ You want to use the first one (the lower number).
 
 Add a section to your machine-wide config like this:
 
-``` mpf-config
+``` yaml
 pololu_maestro:
   port: COM5
 ```
 
 On Linux or Mac, it will probably look like this:
 
-``` mpf-config
+``` yaml
 pololu_maestro:
   port: /dev/ttyACM0
 ```
@@ -88,7 +88,7 @@ and then create sub entries in there for each servo you have.
 
 For example:
 
-``` mpf-config
+``` yaml
 servos:
   servo1:
     servo_min: 0.2

--- a/docs/hardware/pololu_tic.md
+++ b/docs/hardware/pololu_tic.md
@@ -40,7 +40,7 @@ Connect your stepper according to the Pololu manual.
 
 Afterwards, you can use steppers from MPF. This is an example:
 
-``` mpf-config
+``` yaml
 #config_version=5
 hardware:
   stepper_controllers: pololu_tic

--- a/docs/hardware/rpi.md
+++ b/docs/hardware/rpi.md
@@ -56,7 +56,7 @@ properly.
 
 This is an example config:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: rpi
 raspberry_pi:

--- a/docs/hardware/rpi_dmd.md
+++ b/docs/hardware/rpi_dmd.md
@@ -37,7 +37,7 @@ sudo make install-python PYTHON=$(which python3)
 
 This is an example config:
 
-``` mpf-mc-config
+``` yaml
 hardware:
   platform: rpi_dmd
 rpi_dmd:

--- a/docs/hardware/segment_display_transitions.md
+++ b/docs/hardware/segment_display_transitions.md
@@ -104,7 +104,7 @@ Transitions are specified as an additional property of a
 `segment_display_player:` config or the `segment_displays:` section of a
 show config. For example:
 
-``` mpf-config
+``` yaml
 #! segment_displays:
 #!   display1:
 #!     number: 1

--- a/docs/hardware/smartmatrix.md
+++ b/docs/hardware/smartmatrix.md
@@ -230,7 +230,7 @@ which port appears.
 
 So on Windows, you'll end up with something like:
 
-``` mpf-config
+``` yaml
 hardware:
   rgb_dmd: smartmatrix
 smartmatrix:
@@ -242,7 +242,7 @@ smartmatrix:
 
 And on Mac or Linux, it will look something like:
 
-``` mpf-config
+``` yaml
 hardware:
   rgb_dmd: smartmatrix
 smartmatrix:
@@ -274,7 +274,7 @@ one physical DMD.)
 To do this, create a section in your machine-wide config called
 `rgb_dmds:`, and then pick a name for the DMD, like this:
 
-``` mpf-config
+``` yaml
 rgb_dmds:
   smartmatrix_1:
     hardware_brightness: .17
@@ -340,7 +340,7 @@ Note that the [Using an RGB full-color LED DMD](../mc/displays/rgb_dmd.md)
 guide has more details on the window and slide settings used in this
 machine config.
 
-``` mpf-mc-config
+``` yaml
 hardware:
   rgb_dmd: smartmatrix
 displays:

--- a/docs/hardware/smbus.md
+++ b/docs/hardware/smbus.md
@@ -60,7 +60,7 @@ To configure MPF to use native I2C, you can add an entry to the
 default platform for your I2C devices and to instead use the `smbus2`
 platform, like this:
 
-``` mpf-config
+``` yaml
 hardware:
   i2c: smbus2
 ```

--- a/docs/hardware/snux.md
+++ b/docs/hardware/snux.md
@@ -290,7 +290,7 @@ hardware section of your machine-wide config. You configure the main
 platform as *p_roc*, but then for *driverboards* you configure it as
 *snux*, like this:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: virtual
   driverboards: wpc
@@ -305,7 +305,7 @@ driverboard. These options are set in the default *mpfconfig.yaml* file
 which means you don't have to add them to your own config file, but
 we're including them here just for completeness:
 
-``` mpf-config
+``` yaml
 coils:
   c_diag_led_driver:
     number: c24
@@ -334,7 +334,7 @@ via the Snux board, but they're technically separate settings since the
 architecture allows for future System 11 boards that may exist at some
 point. Here's the system11 configuration section from Pin\*Bot:
 
-``` mpf-config
+``` yaml
 system11:
   ac_relay_delay_ms: 75
   ac_relay_driver_number: c14
@@ -368,7 +368,7 @@ in the two System 11 machines we tested. (C14 in *Pin*Bot\* and C12 in
 
 The Snux board uses driver 23 to enable the flippers:
 
-``` mpf-config
+``` yaml
 digital_outputs:
   flipper_enable_relay:
     number: c23
@@ -417,7 +417,7 @@ switched solenoids which use the A/C relay, you also need to add an
 "A" or a "C" to the end of the driver number. Here's a snippet
 (incomplete) from the *Pin*Bot\* machine-wide config file:
 
-``` mpf-config
+``` yaml
 coils:
   outhole:
     number: c01a
@@ -471,7 +471,7 @@ column 1, 9-16 for column 2, etc. Basically since System 11 machines
 have an 8x8 lamp matrix, there should be no numbers 9 or 0 anywhere in
 your lamp numbers. Here's a snippet of the configuration from Pin\*Bot:
 
-``` mpf-config
+``` yaml
 lights:
   game_over_backbox:
     number: L11
@@ -508,7 +508,7 @@ So even though the manual says that the switch in column 5, row 6 is
 number 38, you actually enter "L56". Here's another snippet from
 *Pin*Bot\*:
 
-``` mpf-config
+``` yaml
 switches:
   left_outlane:
     number: S24
@@ -557,7 +557,7 @@ We have a separate How To guide which details how to setup a System 11
 aren't System 11), so you can read that for more details. The result
 though will look something like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   outhole:
 #!     number: 1
@@ -611,7 +611,7 @@ expected.
 
 This is an example code block with the main Sys11 elements in.
 
-``` mpf-config
+``` yaml
 hardware:
   platform: virtual
   driverboards: wpc

--- a/docs/hardware/spi_bit_bang.md
+++ b/docs/hardware/spi_bit_bang.md
@@ -26,7 +26,7 @@ they are much more efficient.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: your_platform, spi_bit_bang      # add your platform first here
 spi_bit_bang:

--- a/docs/hardware/spike/config.md
+++ b/docs/hardware/spike/config.md
@@ -25,7 +25,7 @@ To use MPF with a SPIKE hardware, you need to configure your platform as
 `spike` in your machine-wide config file. You'll also need to add a
 "spike:" section with some additional settings:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: spike
 spike:
@@ -83,7 +83,7 @@ nodes:
 Once you got your game running you can increase the speed using
 `runtime_baud`:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: spike
 spike:

--- a/docs/hardware/spike/connection.md
+++ b/docs/hardware/spike/connection.md
@@ -21,7 +21,7 @@ the SPIKE board. On a Windows computer, use the Device Manager to
 determine which COM port the cable has been assigned by Windows. Update
 you machine configuration with the correct COM port (example, COM5).
 
-``` mpf-config
+``` yaml
 spike:
   port: COM5
 ```

--- a/docs/hardware/spike/dmds.md
+++ b/docs/hardware/spike/dmds.md
@@ -17,7 +17,7 @@ provide sufficient throughput (at least 1.5Mbaud). This can be
 configured using `runtime_baud` (as described in
 [Config file reference](../../config/index.md)):
 
-``` mpf-config
+``` yaml
 hardware:
   platform: spike
 spike:
@@ -29,7 +29,7 @@ spike:
 
 Then configure your dmd like in this example:
 
-``` mpf-mc-config
+``` yaml
 displays:
   window:  # on screen window
     width: 600

--- a/docs/hardware/spike/drivers.md
+++ b/docs/hardware/spike/drivers.md
@@ -34,7 +34,7 @@ just have the node number and address number (with a dash between them).
 For example, the driver for the left flipper coil with the address
 `8-DR-0` would be entered into the MPF config as `8-0`, etc.
 
-``` mpf-config
+``` yaml
 coils:
   c_shaker:
     number: 1-10    # Node 1, coil 10

--- a/docs/hardware/spike/leds.md
+++ b/docs/hardware/spike/leds.md
@@ -55,7 +55,7 @@ node address and LED number.
 For example, the Shoot Again light with the address `8a-LP-47` would be
 entered as `number: 8-47`.
 
-``` mpf-config
+``` yaml
 lights:
   backlight:
     number: 0-0    # 0-0 is the special address for the backlight
@@ -108,7 +108,7 @@ Therefore, you can define a RGB light with multiple channels. What this
 does is create a new virtual RGB LED which is a grouping of the three
 LED channels into the RGB LED. Then you can use it like any light.
 
-``` mpf-config
+``` yaml
 lights:
   left_lane_arrow_rgb:
     channels:

--- a/docs/hardware/spike/steppers.md
+++ b/docs/hardware/spike/steppers.md
@@ -19,7 +19,7 @@ board). We guess that they are hardware-wise similar to the
 
 To configure a stepper in Spike you can use the following example:
 
-``` mpf-config
+``` yaml
 switches:
   s_stepper_home:
     number: 11-4

--- a/docs/hardware/spike/switches.md
+++ b/docs/hardware/spike/switches.md
@@ -27,7 +27,7 @@ letters for extension boards. Here's an example from Wrestlemania Pro:
 
 This would result in the following switch entries:
 
-``` mpf-config
+``` yaml
 switches:
   s_left_inlane:
     number: 11-0

--- a/docs/hardware/spike/troubleshooting.md
+++ b/docs/hardware/spike/troubleshooting.md
@@ -17,7 +17,7 @@ described in the
 [troubleshooting guide](../../troubleshooting/index.md) this is done by adding `debug: true` to your `spike` config
 section:
 
-``` mpf-config
+``` yaml
 spike:
   debug: true
 ```
@@ -52,7 +52,7 @@ ls /mnt
 
 Afterwards, add the following options to your spike config:
 
-``` mpf-config
+``` yaml
 spike:
   debug: true
   bridge_debug: true

--- a/docs/hardware/stepstick.md
+++ b/docs/hardware/stepstick.md
@@ -36,7 +36,7 @@ startup.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 #config_version=5
 hardware:
   stepper_controllers: step_stick

--- a/docs/hardware/trinamics.md
+++ b/docs/hardware/trinamics.md
@@ -18,7 +18,7 @@ to it.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: virtual
   stepper_controllers: trinamics_steprocker

--- a/docs/hardware/virtual/keyboard.md
+++ b/docs/hardware/virtual/keyboard.md
@@ -57,7 +57,7 @@ to start them.
 
 Here's an example of it in action:
 
-``` mpf-mc-config
+``` yaml
 keyboard:
   z:
     switch: left_flipper
@@ -130,7 +130,7 @@ keys on your keyboard, you can also specify key combinations along with
 the key entries. These are called "modifier keys," and MPF supports
 them in combination with regular keys, like this:
 
-``` mpf-mc-config
+``` yaml
 #! keyboard:
   t:
     switch: foo

--- a/docs/hardware/virtual/smart_virtual.md
+++ b/docs/hardware/virtual/smart_virtual.md
@@ -20,7 +20,7 @@ To understand why the smart virtual platform exists, consider this
 simple machine config for a trough, a plunger lane, and keyboard key
 mappings to simulate their switches:
 
-``` mpf-config
+``` yaml
 switches:
   s_trough1:
     number: s31
@@ -128,7 +128,7 @@ MPF will use the smart virtual platform anyone you run it.
 You can also manually specify the smart virtual interface in the machine
 config, like this:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: smart_virtual
 ```

--- a/docs/hardware/virtual/virtual.md
+++ b/docs/hardware/virtual/virtual.md
@@ -34,7 +34,7 @@ There are three ways you can use the virtual platform:
 You can manually specify the virtual platform in the machine config,
 like this:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: virtual
 ```

--- a/docs/hardware/virtual/virtual_pinball_vpx.md
+++ b/docs/hardware/virtual/virtual_pinball_vpx.md
@@ -39,7 +39,7 @@ python register_vpcom.py --register
 
 In your `config.yaml` configure virtual_pinball as your platform:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: virtual_pinball
 ```

--- a/docs/hardware/voltages_and_power/power_management.md
+++ b/docs/hardware/voltages_and_power/power_management.md
@@ -26,7 +26,7 @@ By default MPF assumes that you have only one single power supply unit
 for all your coils. If this is not true you can configure multiple PSUs
 and assign them to coils:
 
-``` mpf-config
+``` yaml
 psus:
   default:  # this is configured by default
     voltage: 48
@@ -54,7 +54,7 @@ coils on the other PSU.
 To give your PSU some breathing room MPF will apply some spacing between
 two pulses. This can be configured using `release_wait_ms`:
 
-``` mpf-config
+``` yaml
 psus:
   default:
     voltage: 48

--- a/docs/logs/CFE-ConfigValidator-1.md
+++ b/docs/logs/CFE-ConfigValidator-1.md
@@ -17,7 +17,7 @@ Certain devices enforce the latter.
 For instance, a [counter](../config/counters.md) can store its state in a player variable which is only
 possible in a game mode:
 
-``` mpf-config
+``` yaml
 ##! mode: my_game_mode
 mode:
   start_events: ball_started
@@ -33,7 +33,7 @@ counters:
 However, if you set `persist_state: False` in your counter it can also
 be used outside of a mode:
 
-``` mpf-config
+``` yaml
 ##! mode: attract
 mode:
   game_mode: false

--- a/docs/logs/CFE-ConfigValidator-12.md
+++ b/docs/logs/CFE-ConfigValidator-12.md
@@ -13,7 +13,7 @@ For instance, `show_tokens` in a
 [show_player](../config/show_player.md) has to
 be a dictionary:
 
-``` mpf-config
+``` yaml
 show_player:
   some_event:
     your_show_name:

--- a/docs/logs/CFE-ConfigValidator-13.md
+++ b/docs/logs/CFE-ConfigValidator-13.md
@@ -12,7 +12,7 @@ This error occurs when MPF expects a boolean value (i.e. `true` or
 For instance, the `debug` setting for a
 [switch](../config/switches.md) is a boolean:
 
-``` mpf-config
+``` yaml
 switches:
   s_flipper_left:
     number: 1

--- a/docs/logs/CFE-ConfigValidator-2.md
+++ b/docs/logs/CFE-ConfigValidator-2.md
@@ -11,7 +11,7 @@ device.
 
 For instance, a [switch](../config/switches.md) knows certain settings:
 
-``` mpf-config
+``` yaml
 switches:
   s_flipper_left:
     number: 1

--- a/docs/logs/CFE-ConfigValidator-6.md
+++ b/docs/logs/CFE-ConfigValidator-6.md
@@ -11,7 +11,7 @@ one of your settings in your config.
 
 For instance, a flipper device references a switch and a coil:
 
-``` mpf-config
+``` yaml
 switches:
   s_flipper_left:
     number:

--- a/docs/logs/CFE-ConfigValidator-9.md
+++ b/docs/logs/CFE-ConfigValidator-9.md
@@ -11,7 +11,7 @@ your config sections.
 
 For instance, every switch has to have a number in MPF:
 
-``` mpf-config
+``` yaml
 switches:
   s_ball_switch1:
     number: 1

--- a/docs/logs/CFE-DeviceManager-3.md
+++ b/docs/logs/CFE-DeviceManager-3.md
@@ -13,7 +13,7 @@ For instance, the settings of a
 [switch](../config/switches.md) are a
 dictionary (switches -> s_flipper_left).
 
-``` mpf-config
+``` yaml
 switches:
   s_flipper_left:
     number: 1

--- a/docs/logs/CFE-Smart_Virtual_Platform-1.md
+++ b/docs/logs/CFE-Smart_Virtual_Platform-1.md
@@ -17,7 +17,7 @@ This error occurs when you use a switch in
 
 This is how it should look:
 
-``` mpf-config
+``` yaml
 switches:
   s_ball_switch1:
     number:
@@ -33,7 +33,7 @@ virtual_platform_start_active_switches:
 
 Alternatively, this could be a comma separated list:
 
-``` mpf-config
+``` yaml
 switches:
   s_ball_switch1:
     number:

--- a/docs/logs/CFE-coils-1.md
+++ b/docs/logs/CFE-coils-1.md
@@ -18,7 +18,7 @@ address your coil and it cannot continue without a number.
 
 This is how a coil should look:
 
-``` mpf-config
+``` yaml
 coils:
   your_coil:
     number: 1
@@ -34,7 +34,7 @@ later. This is a problem for your physical hardware controller but you
 can tell MPF to use the `virtual` hardware platform for one particular
 coil:
 
-``` mpf-config
+``` yaml
 coils:
   your_virtual_coil:
     number:

--- a/docs/logs/CFE-show-1.md
+++ b/docs/logs/CFE-show-1.md
@@ -19,7 +19,7 @@ your global config folder.
 
 This is how a file show should look:
 
-``` mpf-config
+``` yaml
 ##! show: flash_red
 #show_version=5
 - duration: 1
@@ -38,7 +38,7 @@ MPF uses the filename as show name. See
 
 This is how a show inside your config should look:
 
-``` mpf-config
+``` yaml
 shows:
   flash_red:
     - duration: 1

--- a/docs/machines/wpc.md
+++ b/docs/machines/wpc.md
@@ -55,7 +55,7 @@ In order to use MPF in a WPC machine, you need to configure the
 
 If you're using a FAST WPC controller, it will look like this:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: fast
 fast:
@@ -64,7 +64,7 @@ fast:
 
 And if you're using a P-ROC:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: p_roc
 p_roc:
@@ -94,7 +94,7 @@ of switch:
 Matrix switches start with the letter `S`, followed by the switch
 number. For example:
 
-``` mpf-config
+``` yaml
 switches:
   s_left_slingshot:
     number: s41
@@ -127,7 +127,7 @@ if the numbers are wrong.
 Direct switches (which are typically the coin and front door switches)
 are entered with the `SD` prefix, then the number, like this:
 
-``` mpf-config
+``` yaml
 switches:
   s_left_coin:
     number: sd1
@@ -159,7 +159,7 @@ Fliptronics switches are used for other things.
 
 You would use Fliptronics switches in your config like this:
 
-``` mpf-config
+``` yaml
 switches:
   s_flipper_lower_right_eos:
     number: sf1
@@ -187,7 +187,7 @@ To configure the regular coils (from the "Solenoid / Flasher" table in
 your machine's operator's manual, enter the letter `C` followed by the
 solenoid number, like this:
 
-``` mpf-config
+``` yaml
 coils:
   c_trough_eject:
     number: c01
@@ -229,7 +229,7 @@ and diverters).
 
 An example in your config might be:
 
-``` mpf-config
+``` yaml
 coils:
   c_flipper_left_main:
     number: fllm
@@ -256,7 +256,7 @@ coils:
 Lights are configured with the letter `L` followed by the lamp number
 from the manual:
 
-``` mpf-config
+``` yaml
 lights:
   l_ball_save:
     number: l11
@@ -286,7 +286,7 @@ to use them.
 
 GI strings are configured with `G` followed by the number, like this:
 
-``` mpf-config
+``` yaml
 lights:
   gi_back_panel:
     number: g01
@@ -315,7 +315,7 @@ Since flashers in WPC machines are technically drivers (coils), they are
 also configured with the letter `C` followed by their number similar to
 `coils`.
 
-``` mpf-config
+``` yaml
 coils:
   f_claw:
     number: c17

--- a/docs/mc/displays/adding_dot_look_to_lcd.md
+++ b/docs/mc/displays/adding_dot_look_to_lcd.md
@@ -12,7 +12,7 @@ display, like this:
 
 The final sections of the machine config to make this happen are here:
 
-``` mpf-mc-config
+``` yaml
 displays:
   window:
     width: 800
@@ -70,7 +70,7 @@ represents your on-screen window. This should be set to the size of the
 screen window at the native resolution of the monitor or LCD where it's
 being shown.
 
-``` mpf-mc-config
+``` yaml
 displays:
   window:
     width: 800
@@ -121,7 +121,7 @@ slide that will be shown in the window. In this case, the slide will
 only have a single widget, and that widget will be the Color DMD widget
 which will be used render the virtual DMD into the window.
 
-``` mpf-mc-config
+``` yaml
 slides:
   window_slide:
     - type: display
@@ -156,7 +156,7 @@ happening in your machine.
 
 We're calling our first slide "dmd_slide":
 
-``` mpf-mc-config
+``` yaml
 slides:
   dmd_slide:
     - type: text
@@ -188,7 +188,7 @@ slides we just created to be shown. In this example, we're using the
 since that's the event that's posted by the media controller once
 it's been initialized and ready to go.
 
-``` mpf-mc-config
+``` yaml
 #! displays:
 #!   window:
 #!     width: 800

--- a/docs/mc/displays/alpha_numeric.md
+++ b/docs/mc/displays/alpha_numeric.md
@@ -25,7 +25,7 @@ your hardware).
 If you don't have or want phyiscal segment displays you can also
 emulate them using the following slides:
 
-``` mpf-mc-config
+``` yaml
 slides:
   segment_displays:
     widgets:

--- a/docs/mc/displays/dmd.md
+++ b/docs/mc/displays/dmd.md
@@ -47,7 +47,7 @@ The first part of the config file above is where you create your logical
 displays like we covered in the [Welcome to The Mission Pinball Framework!](../../index.md)
 section.
 
-``` mpf-mc-config
+``` yaml
 displays:
   window:
     width: 600
@@ -83,7 +83,7 @@ Next, we have a `window:` section which holds the settings for the
 actual on screen window itself. In this case we're just configuring it
 to be 800x600, with a window title of "Mission Pinball Framework".
 
-``` mpf-mc-config
+``` yaml
 window:
   width: 600
   height: 200
@@ -120,7 +120,7 @@ to show. In this case, we've decided to name that slide
 "window_slide_1". (Of course you can call this slide whatever you
 want.)
 
-``` mpf-mc-config
+``` yaml
 slides:
   window_slide_1:
 ##! test
@@ -136,7 +136,7 @@ The first widget will be a
 [dmd effect](../widgets/display/effects.md) which is a widget which renders a logical display onto a
 slide in a way that makes it look like a DMD:
 
-``` mpf-mc-config
+``` yaml
 #! displays:
 #!   window:
 #!     width: 600
@@ -191,7 +191,7 @@ Next, we also added two more widgets to this slide---a text widget with
 the title of the machine, and a gray rectangle that's slightly larger
 than the DMD to give it a nice border.
 
-``` mpf-mc-config
+``` yaml
 #! displays:
 #!   window:
 #!     width: 600
@@ -232,7 +232,7 @@ Now we have a nice slide with the virtual DMD on it, but if you run MPF,
 you still won't see it because we didn't tell MPF to show that slide
 in the window. So that's what we're doing here:
 
-``` mpf-mc-config
+``` yaml
 #! displays:
 #!   window:
 #!     width: 600

--- a/docs/mc/displays/index.md
+++ b/docs/mc/displays/index.md
@@ -20,7 +20,7 @@ and then come back here for the nitty-gritty details later.
 Here's a very simple example that creates a display called "window"
 with a height and width of 800x600:
 
-``` mpf-mc-config
+``` yaml
 displays:
   window:
     width: 800
@@ -30,7 +30,7 @@ displays:
 You can name your display whatever you want. For example, here's a
 display called "potato" which is 100x100:
 
-``` mpf-mc-config
+``` yaml
 displays:
   potato:
     width: 100
@@ -41,7 +41,7 @@ You can add multiple displays to your config. Here's an example with a
 display called "lcd" which is 1366x768, and a second display called
 "playfield" which is 640x480:
 
-``` mpf-mc-config
+``` yaml
 displays:
   lcd:
     width: 1366

--- a/docs/mc/displays/lcd.md
+++ b/docs/mc/displays/lcd.md
@@ -16,7 +16,7 @@ or The Hobbit.
 Here's what the final version of the relevant sections of your machine
 config file will look like. We'll step through everything one-by-one.
 
-``` mpf-mc-config
+``` yaml
 displays:
   window:
     height: 600
@@ -37,7 +37,7 @@ window:
 The first part of the config file is where you create your display
 called "window" and set its size:
 
-``` mpf-mc-config
+``` yaml
 displays:
   window:
     width: 800

--- a/docs/mc/displays/multiple_screens.md
+++ b/docs/mc/displays/multiple_screens.md
@@ -28,7 +28,7 @@ rarely used to render multiple windows. The simplest solution to this
 problem is to extend the MC window to span both (or more) screens. This
 can be achieved using the following config:
 
-``` mpf-mc-config
+``` yaml
 kivy_config:
   kivy:
     desktop: 1

--- a/docs/mc/displays/rgb_dmd.md
+++ b/docs/mc/displays/rgb_dmd.md
@@ -45,7 +45,7 @@ physical RGB DMD with an on screen window too will look like this:
 Next, add the DMD display to your list of displays in your machine-wide
 config file:
 
-``` mpf-mc-config
+``` yaml
 displays:
   window:
     width: 600
@@ -87,7 +87,7 @@ You can make the width and height anything you want. In this case we're
 just configuring it to be 600x200 with a window title of "Mission
 Pinball Framework".
 
-``` mpf-mc-config
+``` yaml
 window:
   width: 600
   height: 200
@@ -124,7 +124,7 @@ to show. In this case, we've decided to name that slide
 "window_slide_1". (Of course you can call this slide whatever you
 want.)
 
-``` mpf-mc-config
+``` yaml
 slides:
   window_slide_1:
 ##! test
@@ -140,7 +140,7 @@ The first widget will be a
 [color_dmd effect](../widgets/display/effects.md) which is a widget which renders a logical display onto a
 slide in a way that makes it look like a DMD:
 
-``` mpf-mc-config
+``` yaml
 #! displays:
 #!   window:
 #!     width: 600
@@ -189,7 +189,7 @@ Next, we also added two more widgets to this slide---a text widget with
 the title of the machine, and a gray rectangle that's slightly larger
 than the DMD to give it a nice border.
 
-``` mpf-mc-config
+``` yaml
 #! displays:
 #!   window:
 #!     width: 600
@@ -231,7 +231,7 @@ Now we have a nice slide with the virtual DMD on it, but if you run MPF,
 you still won't see it because we didn't tell MPF to show that slide
 in the window. So that's what we're doing here:
 
-``` mpf-mc-config
+``` yaml
 #! displays:
 #!   window:
 #!     width: 600

--- a/docs/mc/slides/creating_slides.md
+++ b/docs/mc/slides/creating_slides.md
@@ -28,7 +28,7 @@ Let's look at each of these options.
 The main way to do it is in the "slides" section of a config file,
 like this:
 
-``` mpf-mc-config
+``` yaml
 slides:
   some_slide:
     - type: text
@@ -106,7 +106,7 @@ section of the documentation.
 
 You can define slides in the slide_player like this:
 
-``` mpf-mc-config
+``` yaml
 slide_player:
   some_event:
     my_slide_1:
@@ -144,7 +144,7 @@ in one of the "_player" sections of the config (like the
 So here's an example of a slide created within a show for use within a
 specific step in that show:
 
-``` mpf-mc-config
+``` yaml
 #! show_player:
 #!   start_show: my_show
 ##! show: my_show

--- a/docs/mc/slides/multiplayer_display.md
+++ b/docs/mc/slides/multiplayer_display.md
@@ -33,7 +33,7 @@ In this example, we have a large score for the current player, show the
 player's custom-variable "level" in the lower-left, and their current
 ball number in the lower-right
 
-``` mpf-mc-config
+``` yaml
 slides:
   base_slide: []
 slide_player:
@@ -92,7 +92,7 @@ interfere with other slide behavior (e.g. bonus slides and start/end of
 turn slides). We'll keep it clean and manually clear the score slide at
 the end of each ball.
 
-``` mpf-mc-config
+``` yaml
 slides:
   base_slide:
     - type: text

--- a/docs/mc/slides/picture_in_picture.md
+++ b/docs/mc/slides/picture_in_picture.md
@@ -15,7 +15,7 @@ projected.
 Here is an example of setting up a window and four displays in a config
 file.
 
-``` mpf-mc-config
+``` yaml
 window:
   width: 1080
   height: 1300
@@ -51,7 +51,7 @@ the "insert" display will be drawn on top of the "lower" display.
 This gives you a "picture-in-picutre" where the "insert" will appear
 to be projected on top of the "lower" display.
 
-``` mpf-mc-config
+``` yaml
 slides:
   layout:
     background_color: blue

--- a/docs/mc/slides/showing_slides.md
+++ b/docs/mc/slides/showing_slides.md
@@ -28,7 +28,7 @@ that you basically say, "play THIS slide when THAT event happens".
 For example, if you want to play a slide named "good_job" when the
 event "left_lane_hit" is posted, you would set your config like this:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   good_job:
 #!     - type: text
@@ -43,7 +43,7 @@ slide_player:
 
 You can have as many event/slide combinations as you want, like this:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   good_job:
 #!     - type: text
@@ -68,7 +68,7 @@ slide name after the event name, you can also create a sub-entry with
 the slide name, then *another* sub-entry with additional options, like
 this:
 
-``` mpf-mc-config
+``` yaml
 #! displays:
 #!   dmd:
 #!     width: 128
@@ -90,7 +90,7 @@ slide_player:
 
 You can mix-and-match all of these in a single config, like this:
 
-``` mpf-mc-config
+``` yaml
 #! displays:
 #!   dmd:
 #!     width: 128
@@ -145,7 +145,7 @@ For example, if you want a slide called "happy_face" to play in a step
 in a show, you can do it like this (this is a snippet of a single step
 in a show):
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   happy_face:
 #!     - type: text
@@ -163,7 +163,7 @@ in a show):
 
 Again, you can use the sub-entry format to specify additional options:
 
-``` mpf-mc-config
+``` yaml
 #! displays:
 #!   playfield_screen:
 #!     width: 200

--- a/docs/mc/slides/split_screen.md
+++ b/docs/mc/slides/split_screen.md
@@ -20,7 +20,7 @@ this layout: one that covers the entire window area, and four smaller
 ones that will each be used for one of the four smaller quadrant
 displays.
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 window:
   width: 1280
@@ -68,7 +68,7 @@ we want to display in each quadrant.
     to fit in the widget boundaries, it is recommended you use the same size
     display widget as the source display for the best visual results.
 
-``` mpf-mc-config
+``` yaml
 #! displays:
 #!   window:
 #!     width: 1280
@@ -145,7 +145,7 @@ desired display when showing them. Here is our example from the previous
 steps that has now been extended to show a simple slide in each of the
 four quadrants:
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 window:
   width: 1280

--- a/docs/mc/slides/transitions.md
+++ b/docs/mc/slides/transitions.md
@@ -136,7 +136,7 @@ Options for the rise_in transition:
 Transitions are specified as an additional property of a `slide_player:`
 config or the `slides:` section of a show config. For example:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   slide1:
 #!     - type: text
@@ -161,7 +161,7 @@ the new slide in from the right.
 
 Transitions can be combined with other slide settings, like this:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   slide1:
 #!     - type: text
@@ -182,7 +182,7 @@ slide_player:
 You can also configure `transition_out:` settings which are transitions
 that will be applied to a slide when it is removed, like this:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   slide1:
 #!     - type: text

--- a/docs/mc/sound/basic_setup.md
+++ b/docs/mc/sound/basic_setup.md
@@ -32,7 +32,7 @@ simultaneously so that is what we have configured in the example below.
 
 Example:
 
-``` mpf-config
+``` yaml
 sound_system:
   tracks:
     music:
@@ -84,7 +84,7 @@ the `track:` setting accordingly.
 
 `assets:` section in machine configuration file:
 
-``` mpf-config
+``` yaml
 assets:
   sounds:
     default:
@@ -128,7 +128,7 @@ The master volume ranges from 0.0 (silent) to 1.0 (full), and defaults
 to 0.5 (50%). You can set your own default volume by overriding the
 machine variable settings in your machine config file.
 
-``` mpf-config
+``` yaml
 machine_vars:
   master_volume:
     initial_value: 0.25   # Set this to any value you want
@@ -166,7 +166,7 @@ default). In my `sounds:` section of my machine configuration file (see
 [sounds:](../../config/sounds.md) in the
 documentation for more details) I can put the following text:
 
-``` mpf-config
+``` yaml
 sounds:
   triangle:
     file: 22783__franciscopadilla__80-mute-triangle.wav
@@ -185,7 +185,7 @@ from various sources rather than trying to adjust the levels in each
 sound file using audio editing software. Building on the example above,
 let's set the volume of the *triangle* sound in our config file:
 
-``` mpf-config
+``` yaml
 sounds:
   triangle:
     file: 22783__franciscopadilla__80-mute-triangle.wav
@@ -226,7 +226,7 @@ these settings.
 
 Example `sounds:` configuration demonstrating most common settings:
 
-``` mpf-config
+``` yaml
 sounds:
   triangle:
     file: 22783__franciscopadilla__80-mute-triangle.wav
@@ -275,7 +275,7 @@ example (`song_01`) to play infinitely when the *attract* mode starts
 and stop when the *attract* mode stops. Create the following entries in
 the `sound_player:` section of the machine config file:
 
-``` mpf-config
+``` yaml
 sound_player:
   mode_attract_started:
     song_01:

--- a/docs/mc/sound/tips_tricks.md
+++ b/docs/mc/sound/tips_tricks.md
@@ -191,7 +191,7 @@ The basic concept is to add an event to the video that is triggered when
 the video is played and one when the video is stopped. Those events are
 then added to the `track_player` section of your config file:
 
-``` mpf-mc-config
+``` yaml
 track_player:
   my_video_is_playing:
     music:
@@ -226,7 +226,7 @@ period. Instead of using the target hit event to trigger the sound, the
 target hit event will trigger the counter which in turn will post a hit
 event that can be used to trigger the sound. Here is an example:
 
-``` mpf-mc-config
+``` yaml
 coils:
   reset_drop_targets:
     number: 1

--- a/docs/mc/sound/tracks.md
+++ b/docs/mc/sound/tracks.md
@@ -56,7 +56,7 @@ The following types of audio tracks are available in MPF:
 
 Example track configuration:
 
-``` mpf-config
+``` yaml
 sound_system:
   buffer: 2048
   frequency: 44100

--- a/docs/mc/sound/variations.md
+++ b/docs/mc/sound/variations.md
@@ -44,7 +44,7 @@ name to remember (`triangle_01`) using the `file:` setting (or you could
 simply rename the file to *triangle_01.wav* and omit the *file:*
 setting):
 
-``` mpf-config
+``` yaml
 sounds:
   triangle_01:
     file: 13147__looppool__triangle1.wav
@@ -60,7 +60,7 @@ add them to the `sounds:` section in the machine configuration file (I
 named the sound variations *triangle_02*, *triangle_03*, and
 *triangle_04*:
 
-``` mpf-config
+``` yaml
 sounds:
   triangle_01:
     file: 13147__looppool__triangle1.wav
@@ -80,7 +80,7 @@ put them all into a single sound pool object so we can treat them as a
 single sound. To do so, we need to add a `sound_pools:` section to our
 machine configuration file as follows:
 
-``` mpf-config
+``` yaml
 sound_pools:
   triangle:
     type: random
@@ -104,7 +104,7 @@ It's very easy to do. We can add weights to each sound in the pool that
 specify the probability of each sound being selected. Let's look at our
 `sound_pools:` section again:
 
-``` mpf-config
+``` yaml
 sound_pools:
   triangle:
     type: random
@@ -132,7 +132,7 @@ time. If the selection is random, excluded events will not be weighted
 in the distribution. If the selection is sequential, excluded events
 will simply be skipped.
 
-``` mpf-config
+``` yaml
 sound_pools:
   triangle:
     type: random

--- a/docs/mc/widgets/animation.md
+++ b/docs/mc/widgets/animation.md
@@ -29,7 +29,7 @@ This How To guide will show you how to do all of that.
 MPF animations are properties of widgets. For example, here's a basic
 widget with no animations:
 
-``` mpf-mc-config
+``` yaml
 slides:
   slide_1:
     widgets:
@@ -42,7 +42,7 @@ To add animations to a widget, you simply add an `animations:` setting
 to that widget, and then under there you add specific animation steps
 and settings. For example:
 
-``` mpf-mc-config
+``` yaml
 slides:
   slide_1:
     widgets:
@@ -220,7 +220,7 @@ you can animate multiple properties at once.
 For example, to make the text grow and shrink while also fading on and
 off:
 
-``` mpf-mc-config
+``` yaml
 slides:
   slide_1:
     widgets:
@@ -285,7 +285,7 @@ different animations to take place when different events occur. You can
 mix and match these as much as you want, including mixing the
 "special" animation trigger events with regular MPF events.
 
-``` mpf-mc-config
+``` yaml
 slides:
   slide1:
     widgets:
@@ -330,7 +330,7 @@ for each event.
 You can also use a property from your event. For instance, you can move
 a widget based on a player variable:
 
-``` mpf-mc-config
+``` yaml
 slides:
   slide1:
     widgets:
@@ -354,7 +354,7 @@ that animation to loop back to the beginning and keep repeating.
 Of course you can mix-and-match repeating animations with one time
 animations. For example:
 
-``` mpf-mc-config
+``` yaml
 slides:
   slide1:
     widgets:
@@ -401,7 +401,7 @@ degrees. Repeating the step fails to cause the widget to move because it
 is already at destination. To create continuously rotating widgets, a
 two step process is required:
 
-``` mpf-mc-config
+``` yaml
 slides:
   slide1:
     widgets:
@@ -443,7 +443,7 @@ shown in the following example. So you still have the step in the
 animation, it just isn't doing anything since the widget's property is
 already at the desired target value. For example:
 
-``` mpf-mc-config
+``` yaml
 slides:
   slide1:
     widgets:
@@ -483,7 +483,7 @@ Much like [named widgets](reusable_widgets.md), you can also create pre-defined 
 easily apply to any widget. You do this by adding those animations to
 the `animations:` section of your config, like this:
 
-``` mpf-mc-config
+``` yaml
 animations:
   fade_in:
     property: opacity
@@ -502,7 +502,7 @@ animations.
 For example, to configure a widget to fade in (assuming the widget was
 initially created with `opacity: 0`:
 
-``` mpf-mc-config
+``` yaml
 widgets:
   hello_widget:
     - type: text
@@ -515,7 +515,7 @@ Again remember this can be done anywhere you configure an animation. So
 if you later wanted to fade that text out when the event
 "timer_hurry_up_complete" is posted, you can do it like this:
 
-``` mpf-mc-config
+``` yaml
 widgets:
   hello_widget:
     - type: text
@@ -531,7 +531,7 @@ When working with named animations, you can chain together multiple
 named animations for a single event by specifying them as a list, like
 this:
 
-``` mpf-mc-config
+``` yaml
 widgets:
   hello_widget:
     - type: text
@@ -548,7 +548,7 @@ config.
 You can even use the same animation over and over in a sequence to
 repeat something a certain number of times. For example:
 
-``` mpf-mc-config
+``` yaml
 animations:
   pulse:
     - property: opacity
@@ -576,7 +576,7 @@ we animate a progress bar based on the player variable `progress` by
 hooking the width of the bar to the event `player_progress` which is
 posted when the value changes:
 
-``` mpf-mc-config
+``` yaml
 slides:
   green_slide:
     widgets:

--- a/docs/mc/widgets/bezier.md
+++ b/docs/mc/widgets/bezier.md
@@ -14,7 +14,7 @@ Here's an example:
 
 TODO This example just shows a blank slide in MPF 0.50?
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 slide_player:
   mc_ready:

--- a/docs/mc/widgets/bitmap_fonts.md
+++ b/docs/mc/widgets/bitmap_fonts.md
@@ -50,7 +50,7 @@ Some things to note:
 
 You can use the font in your config:
 
-``` mpf-mc-config
+``` yaml
 slides:
   slideBaseBackglass:
     widgets:

--- a/docs/mc/widgets/display/index.md
+++ b/docs/mc/widgets/display/index.md
@@ -23,7 +23,7 @@ the actual visual output of the logical display).
 
 Here's an example:
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 displays:
   window:
@@ -115,7 +115,7 @@ the [effects](effects.md) documentation.
 
 An example of a display widget with a dmd effect:
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 #! displays:
 #!   window:

--- a/docs/mc/widgets/dmd_fonts.md
+++ b/docs/mc/widgets/dmd_fonts.md
@@ -13,7 +13,7 @@ Text and Text Input widgets.
 If you don't use one of these fonts on your DMD and just show some
 text, here's what the results look like:
 
-``` mpf-mc-config
+``` yaml
 slides:
   my_slide:
     - type: text
@@ -40,7 +40,7 @@ low-res DMD.)
 
 `big` is 10 pixels tall.
 
-``` mpf-mc-config
+``` yaml
 slides:
   my_slide:
     - type: text
@@ -61,7 +61,7 @@ slides:
 
 `medium` is 7 pixels tall.
 
-``` mpf-mc-config
+``` yaml
 slides:
   my_slide:
     - type: text
@@ -86,7 +86,7 @@ Notice that this font has a color set and we're using it with a Color
 DMD. All three of these fonts (like any font) can be used on a mono or
 color DMD.
 
-``` mpf-mc-config
+``` yaml
 slides:
   my_slide:
     - type: text

--- a/docs/mc/widgets/easing_config.md
+++ b/docs/mc/widgets/easing_config.md
@@ -31,7 +31,7 @@ slide_player entry to show that slide on the *init_done* event which is
 posted by the media controller once it's ready to show slides. (That's
 why we don't need the MPF core engine to run this example.)
 
-``` mpf-mc-config
+``` yaml
 # config_version=5
 displays:
   default:
@@ -122,7 +122,7 @@ And here's the example where we animate the opacity:
 
 ![image](../images/easing_opacity.gif)
 
-``` mpf-mc-config
+``` yaml
 # config_version=5
 displays:
   default:

--- a/docs/mc/widgets/ellipse.md
+++ b/docs/mc/widgets/ellipse.md
@@ -16,7 +16,7 @@ use the [Bezier Curve Widget](bezier.md).
 
 Here's an example:
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 slide_player:
   mc_ready:

--- a/docs/mc/widgets/expire.md
+++ b/docs/mc/widgets/expire.md
@@ -12,7 +12,7 @@ expire a widget:
 
 ## Option 1: In the widget or slide definition
 
-``` mpf-mc-config
+``` yaml
 widgets:
   my_widget:
     type: text
@@ -40,7 +40,7 @@ player.
 
 Here's an example:
 
-``` mpf-mc-config
+``` yaml
 widgets:
   my_widget:
     type: text
@@ -68,7 +68,7 @@ of time, remember you can use the widget player to remove a widget by
 name, which means you can use one event to show the widget and another
 event to remove it. For example:
 
-``` mpf-mc-config
+``` yaml
 widgets:
   my_widget:
     type: text

--- a/docs/mc/widgets/fonts.md
+++ b/docs/mc/widgets/fonts.md
@@ -45,7 +45,7 @@ touching all your slides and widgets. For that reason it makes sense to
 define a [widget_style](styles.md) for all
 your fonts and sizes:
 
-``` mpf-mc-config
+``` yaml
 widget_styles:
   text_small:
     font_size: 15

--- a/docs/mc/widgets/keys.md
+++ b/docs/mc/widgets/keys.md
@@ -28,7 +28,7 @@ are shown below.
 This is an example using priorities of the events, which will affect the
 priority:
 
-``` mpf-mc-config
+``` yaml
 #! widgets:
 #!   widget_1: []
 widget_player:
@@ -62,7 +62,7 @@ logic on the same event (example: event_1{param1} and event_1{param2}.
 This is an example using unique conditional formatting for the same
 event:
 
-``` mpf-mc-config
+``` yaml
 #! widgets:
 #!   widget_1: []
 widget_player:
@@ -94,7 +94,7 @@ need to refer to the key of that widget. This is done by the following
 code, which has calls upon the generic widget and the key when an event
 is posted.
 
-``` mpf-mc-config
+``` yaml
 #! widgets:
 #!   widget_1: []
 widget_player:

--- a/docs/mc/widgets/layers.md
+++ b/docs/mc/widgets/layers.md
@@ -28,7 +28,7 @@ drawn in the order they are in the config.
 For example, here's a slide that has widget3.1, then widget3.2, then
 widget3.3:
 
-``` mpf-mc-config
+``` yaml
 slides:
   3_widgets:
     - type: text
@@ -70,7 +70,7 @@ will be drawn on top of those with lower values.
 
 Here's the same example as before, but with `z:` values added:
 
-``` mpf-mc-config
+``` yaml
 slides:
   3_widgets:
     - type: text

--- a/docs/mc/widgets/line.md
+++ b/docs/mc/widgets/line.md
@@ -12,7 +12,7 @@ that if you want to draw a curved line, you can use the
 
 Here's an example:
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 slide_player:
   mc_ready:

--- a/docs/mc/widgets/points.md
+++ b/docs/mc/widgets/points.md
@@ -10,7 +10,7 @@ slide.
 
 Here's an example:
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 slide_player:
   mc_ready:

--- a/docs/mc/widgets/positioning.md
+++ b/docs/mc/widgets/positioning.md
@@ -291,7 +291,7 @@ So now you've seen all the options for positioning and placement of
 widgets. But how do you actually use them? Simple. Everything discussed
 here are just regular widget settings. So you can use them in slides:
 
-``` mpf-mc-config
+``` yaml
 slides:
   slide1:
     widgets:
@@ -310,7 +310,7 @@ slides:
 
 You can use them in [named widgets](reusable_widgets.md):
 
-``` mpf-mc-config
+``` yaml
 widgets:
   my_cool_widget:
     - type: text
@@ -328,7 +328,7 @@ widgets:
 
 You can use them in the widget player:
 
-``` mpf-mc-config
+``` yaml
 widgets:
   my_widget:
     - type: text
@@ -348,7 +348,7 @@ widget_player:
 
 And you can use them in shows:
 
-``` mpf-mc-config
+``` yaml
 # in your machine config
 widgets:
   my_widget:

--- a/docs/mc/widgets/quad.md
+++ b/docs/mc/widgets/quad.md
@@ -9,7 +9,7 @@ The quad widget is used to draw solid polygons on a slide.
 
 Here's an example:
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 slide_player:
   mc_ready:

--- a/docs/mc/widgets/rectangle.md
+++ b/docs/mc/widgets/rectangle.md
@@ -11,7 +11,7 @@ width are the same.
 
 Here's an example:
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 slide_player:
   mc_ready:

--- a/docs/mc/widgets/reusable_widgets.md
+++ b/docs/mc/widgets/reusable_widgets.md
@@ -22,7 +22,7 @@ You probably know that you can have a `slides:` section of your config
 (either machine-wide or mode-specific configs), and when you define a
 slide, you can specify what widgets are on that slide, like this:
 
-``` mpf-mc-config
+``` yaml
 slides:
   my_slide:
     widgets:
@@ -58,7 +58,7 @@ machine-wide or a mode config file.)
 
 For example:
 
-``` mpf-mc-config
+``` yaml
 widgets:
   laughing_jackal:
     - type: image
@@ -96,7 +96,7 @@ slide, etc.)
 If you just want to add your widget to whichever slide is current on the
 default display, you can use the "express" config, like this:
 
-``` mpf-mc-config
+``` yaml
 #! widgets:
 #!   laughing_jackal: []
 #!   another_widget: []
@@ -124,7 +124,7 @@ If you want to build a slide and include a reusable widget, you can
 reference the widget's name in your slide config by declaring `widget:`
 instead of `type:`.
 
-``` mpf-mc-config
+``` yaml
 widgets:
   jackpot_value_widget:
     - type: text
@@ -152,7 +152,7 @@ If you want to add your widget to a particular slide (versus whatever
 slide happens to be showing at the moment), you can do so by specifying
 that slide name in the `widget_player:`. For example:
 
-``` mpf-mc-config
+``` yaml
 #! widgets:
 #!   laughing_jackal: []
 widget_player:
@@ -171,7 +171,7 @@ Remember you can add as many events and widgets as you want to the
 `widget_player:` section of your config, and you can even mix-and-match
 formats, like this:
 
-``` mpf-mc-config
+``` yaml
 #! widgets:
 #!   laughing_jackal: []
 #!   another_widget: []
@@ -188,7 +188,7 @@ Rather than specifying a particular slide to add your widget to, you can
 target a display, and the widget will be added "on top" of whatever
 slide is currently being shown:
 
-``` mpf-mc-config
+``` yaml
 #! widgets:
 #!   laughing_jackal: []
 #! displays:
@@ -221,7 +221,7 @@ For example, if you use a widget for the tilt warning like in the
 previous example, you'd probably want that widget to be removed after a
 few seconds, which you could do like this:
 
-``` mpf-mc-config
+``` yaml
 #! widgets:
 #!   tilt_warning: []
 widget_player:
@@ -251,7 +251,7 @@ You can also use the widget player to remove named widgets from a slide
 that had been previous added. To do this, just add an `action: remove`
 setting to the widget player, like this:
 
-``` mpf-mc-config
+``` yaml
 #! widgets:
 #!   laughing_jackal: []
 widget_player:
@@ -272,7 +272,7 @@ widget. But you can actually define multiple widgets in a named widget
 (essentially meaning that your named widget is really a named group of
 widgets. For example:
 
-``` mpf-mc-config
+``` yaml
 widgets:
   widget3:
     - type: text
@@ -315,7 +315,7 @@ You can also add multiple named widgets from a single event. This is
 nice if you want to add widgets to multiple displays or slides at the
 same time. For example:
 
-``` mpf-mc-config
+``` yaml
 #! widgets:
 #!   widget1: []
 #!   widget2: []
@@ -353,7 +353,7 @@ with the standard
 For example, using the player variable "hero_class" to pick a text
 image (but could be an image widget as well):
 
-``` mpf-mc-config
+``` yaml
 widgets:
   hero_portrait_rogue:
     - type: text
@@ -395,7 +395,7 @@ include. In the following example from a game with different multiballs,
 the event `mball_lock_lit` might post with either "angel"
 or "demon" as the `mball_name` parameter.
 
-``` mpf-mc-config
+``` yaml
 slide_player:
   mball_lock_lit: mball_lock_slide
 slides:

--- a/docs/mc/widgets/segment_display_emulator/how_to.md
+++ b/docs/mc/widgets/segment_display_emulator/how_to.md
@@ -15,7 +15,7 @@ only available if you're using MPF-MC for your media controller.
 Add the segment display to your list of displays in your machine-wide
 config file:
 
-``` mpf-mc-config
+``` yaml
 displays:
   window:
     width: 600
@@ -39,7 +39,7 @@ You can make the width and height anything you want. In this case we're
 just configuring it to be 600x200 with a window title of "Mission
 Pinball Framework".
 
-``` mpf-mc-config
+``` yaml
 window:
   width: 600
   height: 200
@@ -65,7 +65,7 @@ to show. In this case, we've decided to name that slide
 "window_slide_1". (Of course you can call this slide whatever you
 want.)
 
-``` mpf-mc-config
+``` yaml
 slides:
   window_slide_1:
 ##! test
@@ -81,7 +81,7 @@ The first widget will be a
 [glow effect](../display/effects.md) which is a widget which renders a emulation of a segment
 display:
 
-``` mpf-mc-config
+``` yaml
 #! displays:
 #!   window:
 #!     width: 600
@@ -129,7 +129,7 @@ Now we have a nice slide with the virtual segment display on it, but if
 you run MPF, you still won't see it because we didn't tell MPF to show
 that slide in the window. So that's what we're doing here:
 
-``` mpf-mc-config
+``` yaml
 #! displays:
 #!   window:
 #!     width: 600
@@ -192,7 +192,7 @@ machine wide config and add an entry for each segment display emulator
 widget (in this example we created a single widget so we will only need
 one entry).
 
-``` mpf-config
+``` yaml
 segment_displays:
   display1:
     number: 1
@@ -213,7 +213,7 @@ Now we need to let MPF know to send changes to the segment displays to
 the virtual segment display emulator in MPF-MC. This is accomplished
 using the [virtual_segment_display_connector:](../../../config/virtual_segment_display_connector.md) plugin.
 
-``` mpf-config
+``` yaml
 virtual_segment_display_connector:
   segment_displays: display1
 ```
@@ -230,7 +230,7 @@ display. To do this, we use the
 [Segment Display player](../../../config_players/segment_display_player.md)
 (see also [segment_display_player:](../../../config/segment_display_player.md)).
 
-``` mpf-config
+``` yaml
 segment_display_player:
   update_segment_display_hello:
     display1:

--- a/docs/mc/widgets/segment_display_emulator/index.md
+++ b/docs/mc/widgets/segment_display_emulator/index.md
@@ -10,7 +10,7 @@ displays on a [slide](../../slides/index.md).
 
 Here's an example:
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 slide_player:
   mc_ready:

--- a/docs/mc/widgets/triangle.md
+++ b/docs/mc/widgets/triangle.md
@@ -10,7 +10,7 @@ The triangle widget is used to draw triangles on a
 
 Here's an example:
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 slide_player:
   mc_ready:

--- a/docs/mc/widgets/video.md
+++ b/docs/mc/widgets/video.md
@@ -150,7 +150,7 @@ action will be applied to the video.
 
 Consider the example below:
 
-``` mpf-mc-config
+``` yaml
 slides:
   my_slide:
     - type: video

--- a/docs/mechs/autofire_coils.md
+++ b/docs/mechs/autofire_coils.md
@@ -226,7 +226,7 @@ board but run Windows or macOS you have to change the `ports`. If you
 run a completely different hardware you have to adapt the `hardware`
 section.
 
-``` mpf-config
+``` yaml
 #config_version=5
 
 hardware:

--- a/docs/mechs/coils/dual_wound_coils.md
+++ b/docs/mechs/coils/dual_wound_coils.md
@@ -91,7 +91,7 @@ the strength of coils.
 
 This is an example for dual-wound coils which are configured separately:
 
-``` mpf-config
+``` yaml
 coils:
   c_your_coil_main:
     number: 00   # depends on your platform and hardware

--- a/docs/mechs/coils/hold_power.md
+++ b/docs/mechs/coils/hold_power.md
@@ -35,7 +35,7 @@ power (off), and 1.0 being 100% power.
 
 Consider the following example:
 
-``` mpf-config
+``` yaml
 coils:
   some_coil:
     number:

--- a/docs/mechs/coils/index.md
+++ b/docs/mechs/coils/index.md
@@ -114,7 +114,7 @@ Video about electronics basics:
 
 This is an example for a single-wound coil:
 
-``` mpf-config
+``` yaml
 coils:
   c_your_coil:
     number: 00   # depends on your platform and hardware
@@ -123,7 +123,7 @@ coils:
 
 This is an example for dual-wound coils which are configured separately:
 
-``` mpf-config
+``` yaml
 coils:
   c_your_coil_main:
     number: 00   # depends on your platform and hardware

--- a/docs/mechs/coils/pulse_power.md
+++ b/docs/mechs/coils/pulse_power.md
@@ -60,7 +60,7 @@ a very safe default starting point.)
 
 For example, for coils used in dual-wound flippers:
 
-``` mpf-config
+``` yaml
 coils:
   c_flipper_left_main:
     number: 00
@@ -78,7 +78,7 @@ coils:
 
 Or for single-wound flipper coils:
 
-``` mpf-config
+``` yaml
 coils:
   c_flipper_left:
     number: 0

--- a/docs/mechs/coils/recycle.md
+++ b/docs/mechs/coils/recycle.md
@@ -23,7 +23,7 @@ How this recycle is implemented differs between platforms. MPF exposes a
 very basic interface to enable or disable `recycle` per coil. Usually,
 you want to keep it enabled. This is an example:
 
-``` mpf-config
+``` yaml
 coils:
   c_coil_with_recycle:
     number:

--- a/docs/mechs/diverters/dual_coil_diverter.md
+++ b/docs/mechs/diverters/dual_coil_diverter.md
@@ -19,7 +19,7 @@ active position for as long as you need.
 
 First we need to define the coils in our hardware section:
 
-``` mpf-config
+``` yaml
 coils:
   c_diverter_upper_right_main:
     number: 25
@@ -32,7 +32,7 @@ coils:
 
 Next we'll define the dual wound coil for the diverter to use:
 
-``` mpf-config
+``` yaml
 #! coils:
 #!   c_diverter_upper_right_main:
 #!     number: 25
@@ -49,7 +49,7 @@ dual_wound_coils:
 
 Then we define the Diverter itself:
 
-``` mpf-config
+``` yaml
 #! coils:
 #!   c_diverter_upper_right_main:
 #!     number: 25

--- a/docs/mechs/diverters/servo_as_diverter.md
+++ b/docs/mechs/diverters/servo_as_diverter.md
@@ -15,7 +15,7 @@ events. Specifically, we are using
 [diverter_(name)_deactivating](../../events/diverter_diverter_deactivating.md)
 and [diverter_(name)_activating](../../events/diverter_diverter_activating.md). This is an example:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_ball1:
 #!     number:

--- a/docs/mechs/diverters/stepper_as_diverter.md
+++ b/docs/mechs/diverters/stepper_as_diverter.md
@@ -15,7 +15,7 @@ events. Specifically, we are using
 [diverter_(name)_deactivating](../../events/diverter_diverter_deactivating.md)
 and [diverter_(name)_activating](../../events/diverter_diverter_activating.md). This is an example:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_ball1:
 #!     number:

--- a/docs/mechs/diverters/up_down_ramps.md
+++ b/docs/mechs/diverters/up_down_ramps.md
@@ -37,7 +37,7 @@ Some part numbers:
 
 Up-Down ramps are configured like a normal diverter:
 
-``` mpf-config
+``` yaml
 #! coils:
 #!   c_ramp1_up:
 #!     number:

--- a/docs/mechs/flippers/disabled_flippers.md
+++ b/docs/mechs/flippers/disabled_flippers.md
@@ -7,7 +7,7 @@ title: How to temporarily disable flippers
 
 [Help us to write it](../../about/help.md)
 
-``` mpf-config
+``` yaml
 switches:
   s_left_flipper:
     number: 1

--- a/docs/mechs/flippers/dual_wound.md
+++ b/docs/mechs/flippers/dual_wound.md
@@ -53,7 +53,7 @@ flipper buttons.
 
 Here's an example `config.yaml` with two switches added:
 
-``` mpf-config
+``` yaml
 switches:
   s_left_flipper:
     number: 1
@@ -87,7 +87,7 @@ config. These will be added to a section called `coils:`. Since we're
 using dual-wound coils, there will actually be two coil entries for each
 coil---one for the power (main) winding, and one for the hold winding.
 
-``` mpf-config
+``` yaml
 coils:
   c_flipper_left_main:
     number: 0
@@ -132,7 +132,7 @@ flipper that you defined in Steps 1 and 2.
 Here's what you would create based on the switches and coils we've
 defined so far:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_left_flipper:
 #!     number: 1
@@ -178,7 +178,7 @@ following entry to each of your flippers in your config file:
 So now the `flippers:` section of your config file should look like
 this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_left_flipper:
 #!     number: 1

--- a/docs/mechs/flippers/enabling_secondary_flippers.md
+++ b/docs/mechs/flippers/enabling_secondary_flippers.md
@@ -14,7 +14,7 @@ defined just like normal lower flipper.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_flipper_left:
 #!     number:

--- a/docs/mechs/flippers/eos_switches.md
+++ b/docs/mechs/flippers/eos_switches.md
@@ -163,7 +163,7 @@ it.
 
 This is how you can enable it in MPF:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_flipper_single:
 #!     number: 1

--- a/docs/mechs/flippers/single_wound.md
+++ b/docs/mechs/flippers/single_wound.md
@@ -30,7 +30,7 @@ flipper buttons.
 
 Here's an example `config.yaml` with two switches added:
 
-``` mpf-config
+``` yaml
 switches:
   s_left_flipper:
     number: 1
@@ -62,7 +62,7 @@ things you want the player to be able to skip.
 Next you need to add entries for your flipper coils to your machine-wide
 config. These will be added to a section called `coils:`.
 
-``` mpf-config
+``` yaml
 coils:
   c_flipper_left:
     number: 0
@@ -113,7 +113,7 @@ flipper that you defined in Steps 1 and 2.
 Here's what you would create based on the switches and coils we've
 defined so far:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_left_flipper:
 #!     number: 1
@@ -155,7 +155,7 @@ following entry to each of your flippers in your config file:
 So now the `flippers:` section of your config file should look like
 this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_left_flipper:
 #!     number: 1
@@ -211,7 +211,7 @@ and the [hold power](../coils/hold_power.md) for the coils you're using for your
 Here's the complete machine config file (or sections of the machine
 config file) we created in this How To guide:
 
-``` mpf-config
+``` yaml
 #config_version=5
 switches:
   s_left_flipper:

--- a/docs/mechs/flippers/weak_flippers.md
+++ b/docs/mechs/flippers/weak_flippers.md
@@ -11,7 +11,7 @@ implemented in two ways. Either by reducing `pulse_power` or by reducing
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_left_flipper:
     number: 1

--- a/docs/mechs/kickbacks.md
+++ b/docs/mechs/kickbacks.md
@@ -20,7 +20,7 @@ compensate for missed kickbacks.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_kickback:
     number: 5

--- a/docs/mechs/lights/coils_as_lights.md
+++ b/docs/mechs/lights/coils_as_lights.md
@@ -19,7 +19,7 @@ lights but it will be different from normal lights (and light shows).
 Alternatively, you can map the coils to a light (recommended). To map a
 coil as light you can use the following config:
 
-``` mpf-config
+``` yaml
 coils:
   your_light_coil:
     number: 42                 # number depends on your platform

--- a/docs/mechs/lights/flashers.md
+++ b/docs/mechs/lights/flashers.md
@@ -46,7 +46,7 @@ Starting with MPF 0.50 flashers and lights have been unified. Depending
 on your platform flashers might be [lights:](../../config/lights.md) or [coils:](../../config/coils.md). In most
 cases they are configured as [coil](../../config/coils.md):
 
-``` mpf-config
+``` yaml
 coils:
   flasher_coil_4:
     number: 4
@@ -55,7 +55,7 @@ coils:
 
 Then add them as [light](../../config/lights.md):
 
-``` mpf-config
+``` yaml
 #! coils:
 #!   flasher_coil_4:
 #!     number: 4
@@ -68,7 +68,7 @@ lights:
 
 Now you can use them in [flasher_player:](../../config/flasher_player.md) (or also in [light_player:](../../config/light_player.md) if you want to enable the flasher permanently).
 
-``` mpf-config
+``` yaml
 flasher_player:
   flash:
     flasher_01: 100ms

--- a/docs/mechs/lights/gis.md
+++ b/docs/mechs/lights/gis.md
@@ -56,7 +56,7 @@ and then you can enable, disable, and dim the dimmable ones as you wish.
 
 This is an example for a [light](../../config/lights.md) with `subtype: gi`:
 
-``` mpf-config
+``` yaml
 lights:
   gi_string_left:
     number: 3    # number depends on your platform
@@ -69,7 +69,7 @@ the platform documentation.
 
 This is an example for a [light](../../config/lights.md) in Spike:
 
-``` mpf-config
+``` yaml
 lights:
   gi_string_left:
     number: 3    # number depends on your platform
@@ -82,7 +82,7 @@ configure them as [coils](../../config/coils.md).
 Then add them as [light](../../config/lights.md)
 with `platform: drivers`:
 
-``` mpf-config
+``` yaml
 coils:
   gi_string_left:
     number: A1-B1-3    # number depends on your platform

--- a/docs/mechs/lights/index.md
+++ b/docs/mechs/lights/index.md
@@ -27,14 +27,14 @@ There are multiple types of lights (read those for specific details):
 
 This is an example of for a light:
 
-``` mpf-config
+``` yaml
 lights:
   my_led:
     number: 7   # the exact number format depends on your platform
 ```
 
 For WS2812 LEDs use `type grb` (WS2811 does not need this)
-``` mpf-config
+``` yaml
 lights:
   my_ws2812_led:
     number: 23  # the exact number format depends on your platform
@@ -42,7 +42,7 @@ lights:
 ```
 
 You can also map individual color channels:
-``` mpf-config
+``` yaml
 lights:
   rgb_led:
     type: rgb
@@ -58,7 +58,7 @@ lights:
 ```
 
 Starting with MPF 0.54 there is a new syntax to chain lights:
-``` mpf-config
+``` yaml
 lights:
   led_0:
     start_channel: 0-0    # the exact number format depends on your platform
@@ -75,7 +75,7 @@ lights:
 ```
 
 If your light is connected to a driver use this example:
-``` mpf-config
+``` yaml
 coils:
   light_connected_to_a_driver:
     number: 42          # number depends on your platform
@@ -89,7 +89,7 @@ lights:
 ## Fully working Example 1 - Basics
 Let’s bring above informaton together and learn by example. Though the following example is a fully working minimal set for the Cobra controller, it is as well helpful to understand the concpet more if you use a different set of hardware. For this example to work physically, the Cobra board needs to have 5V power supply and a Neopixel strip connected to NEO0. No need for a high voltage power supply like you need for coils. The example has been built for a WS2811 strip, but can be used as well for a WS2812 strips and others. This `config.yaml` is the only configuration file you need in your project. The config file is fully valid for the Cobra board connected to a Linux PC running MPF. If you have a Cobra board but run Windows or macOS you have to change the `ports`. If you run a completely different hardware you have to adapt the `hardware` section.
 
-``` mpf-config
+``` yaml
 #config_version=5
 
 hardware:               # change in case you don't use OPP
@@ -202,7 +202,7 @@ paramater is that you are able to define a full serial LED light strip
 with a few lines of config. See as well the corresponding config file
 section [light_stripes:](../../config/light_stripes.md)
 
-``` mpf-config
+``` yaml
 #config_version=5
 
 hardware:

--- a/docs/mechs/lights/leds.md
+++ b/docs/mechs/lights/leds.md
@@ -76,7 +76,7 @@ Video about wiring of lights:
 
 You can define serial LEDS in MPF as [lights:](../../config/lights.md):
 
-``` mpf-config
+``` yaml
 lights:
   my_ws2811:
     number: 0         # first LED in chain (with three channels)
@@ -96,7 +96,7 @@ interal LEDs). The second will map to LED four to six and so on.
 The config above is equivalent to the following (again numbers may be
 different per platform):
 
-``` mpf-config
+``` yaml
 lights:
   my_ws2811:
     channels:
@@ -120,7 +120,7 @@ RGBW LEDs are special in most serial LED controllers since the
 controller assumes that every LED has exactly three channels. Therefore,
 you have to assign the channels directly:
 
-``` mpf-config
+``` yaml
 lights:
   my_rgbw_serial_led:
     channels:
@@ -148,7 +148,7 @@ any non-three-channel LEDs) as a separate chain.
 
 Starting with MPF 0.54 there is a new syntax to chain lights:
 
-``` mpf-config
+``` yaml
 lights:
   led_0:
     start_channel: 0-0    # the exact number format depends on your platform
@@ -174,7 +174,7 @@ channel for example. MPF cannot guess your hardware layout in most
 platforms. Therefore your have to explicitly tell MPF your channel
 layout:
 
-``` mpf-config
+``` yaml
 lights:
   my_red_only_insert:
     channels:
@@ -197,7 +197,7 @@ lights:
 You can also have multiple channels per color (if you do not want to
 make them different lights):
 
-``` mpf-config
+``` yaml
 lights:
   multi_white_channels:
     channels:
@@ -210,7 +210,7 @@ lights:
 With parallel LED you can also use `start_channel` to define the color
 (starting from MPF 0.54):
 
-``` mpf-config
+``` yaml
 lights:
   my_red_only_insert:
     start_channel: 0    # the exact number format depends on your platform

--- a/docs/mechs/lights/matrix_lights.md
+++ b/docs/mechs/lights/matrix_lights.md
@@ -36,7 +36,7 @@ Details differ by platform but the syntax for the number of such a light
 is usually `column:row` or `column:row` (see
 your platform for details). The config looks like this:
 
-``` mpf-config
+``` yaml
 lights:
   my_matrix_light:
     number: 2:10      # or 2/10

--- a/docs/mechs/lights/ws2812.md
+++ b/docs/mechs/lights/ws2812.md
@@ -22,7 +22,7 @@ Overview video about serial LEDs:
 MPF tries to make this right for you and your can configure those LEDs
 as follows:
 
-``` mpf-config
+``` yaml
 lights:
   my_ws2811:
     number: 0         # first LED in chain (with three channels) - exact number format depends on your platform
@@ -35,7 +35,7 @@ lights:
 There are also RGBW LEDs which are compatible which usually use RGBW as
 order. They can be used like this:
 
-``` mpf-config
+``` yaml
 lights:
   my_rgbw_serial_led:
     channels:
@@ -51,7 +51,7 @@ lights:
 
 Starting with MPF 0.54 there is a new syntax to chain LEDs:
 
-``` mpf-config
+``` yaml
 lights:
   led_0:
     start_channel: 0-0    # the exact number format depends on your platform

--- a/docs/mechs/loops.md
+++ b/docs/mechs/loops.md
@@ -17,7 +17,7 @@ hit in order you can use
 
 [TODO: Add a picture of an orbit](../about/help.md)
 
-``` mpf-config
+``` yaml
 switches:
   s_ramp_entry:
     number: 1
@@ -36,7 +36,7 @@ to indicate that the ball made it. You can use
 this example you would use the events `s_ramp_entry_active` and
 `ramp_hit` to play the sounds:
 
-``` mpf-config
+``` yaml
 sound_player:
   s_ramp_entry_active: indicate_ramp
   s_ramp_success: indicate_ramp_success

--- a/docs/mechs/magnets/index.md
+++ b/docs/mechs/magnets/index.md
@@ -70,7 +70,7 @@ FETs with flyback diode and a logic buffer for further protection.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 coils:
   magnet_coil:
     number:

--- a/docs/mechs/magnets/stern_magnet_pcb.md
+++ b/docs/mechs/magnets/stern_magnet_pcb.md
@@ -92,7 +92,7 @@ change. Caution: if the board is in a hold mode and MPF crashes the
 board will remain in the hold mode until power is lost or MPF instructs
 it to enter the OFF-state.
 
-``` mpf-config
+``` yaml
 digital_outputs:
   magnet_strobe:
     number: 1    # number depends on your platform

--- a/docs/mechs/motors.md
+++ b/docs/mechs/motors.md
@@ -22,7 +22,7 @@ Related Config File Sections:
 In this example we configure a motorized drop target bank which can move
 up and down with two position switches.
 
-``` mpf-config
+``` yaml
 switches:
   s_position_up:
     number:
@@ -56,7 +56,7 @@ be commanded using the events `go_up` and
 
 The following is an example to drive the slimer in Stern Ghostbusters:
 
-``` mpf-config
+``` yaml
 switches:
   s_slimer_home:
     number: 8-1

--- a/docs/mechs/playfields/ball_tracking.md
+++ b/docs/mechs/playfields/ball_tracking.md
@@ -29,7 +29,7 @@ every switch which is hit by a ball that's active on the playfield.
 You do this in the `switches:` section of your machine config, like
 this:
 
-``` mpf-config
+``` yaml
 switches:
   s_trough1:
     number:

--- a/docs/mechs/plungers/auto_manual.md
+++ b/docs/mechs/plungers/auto_manual.md
@@ -50,7 +50,7 @@ only.
 So add one (or both, if you have a launch button) to your machine config
 if you haven't done so already:
 
-``` mpf-config
+``` yaml
 switches:
   s_plunger_lane:
     number: 2-6
@@ -73,7 +73,7 @@ Next, create an entry in your `coils:` section of your machine config
 file for your plunger lane's eject coil. Again, the name doesn't
 matter. We'll call this *c_plunger* and enter it like this:
 
-``` mpf-config
+``` yaml
 coils:
   c_plunger:
     number: 2-1
@@ -103,7 +103,7 @@ entries for the ball switch and eject coil.
 Here's an example. Note that in this case, we've left out the other
 ball devices (such as your trough and/or drain):
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -142,7 +142,7 @@ ball from this device.
 To do that, add `mechanical_eject: true` to your plunger device, like
 this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -189,7 +189,7 @@ means an event called *s_launch_button_active* will be posted as soon as
 that switch is hit. In that case, you'd configure your plunger like
 this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -214,7 +214,7 @@ Pretty straightforward.
 If you want to launch the ball into play when the player *releases* the
 launch button, then just use that switch's inactive event:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -294,7 +294,7 @@ Here are some examples of these settings in action.
 First, for a typical coil-fired plunger lane / catapult that ejects the
 ball directly to the playfield: (This is probably 99% of all cases)
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -315,7 +315,7 @@ Next, for a coil-fired plunger that has a switch at the exit of the
 plunger lane that is only hit if the ball has made it out of the plunger
 and cannot be hit by a random ball on the playfield:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -339,7 +339,7 @@ ball_devices:
 Next, if your plunger lane ejects into another ball device (a cannon, in
 this case):
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -371,7 +371,7 @@ Once you have your plunger device set up, you need to go back to your
 trough or ball drain device and add the new plunger to your trough's
 `eject_targets:`, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -421,7 +421,7 @@ device is used to add a new ball into play.
 To do that, add your new plunger ball device as `default_source_device`
 in the default `playfield`, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -458,7 +458,7 @@ does not include the switches and coils for the trough.
 This config is what probably 99% of machines with coil-fired plungers
 will use:
 
-``` mpf-config
+``` yaml
 switches:
   s_plunger_lane:
     number: 2-6

--- a/docs/mechs/plungers/coil_fired.md
+++ b/docs/mechs/plungers/coil_fired.md
@@ -39,7 +39,7 @@ ball.
 
 Here's an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_plunger_lane:
     number: 2-6
@@ -62,7 +62,7 @@ Next, create an entry in your `coils:` section of your machine config
 file for your plunger's eject coil. Again, the name doesn't matter.
 We'll call this *c_plunger* and enter it like this:
 
-``` mpf-config
+``` yaml
 coils:
   c_plunger:
     number: 2-1
@@ -92,7 +92,7 @@ entries for the ball switch and eject coil.
 Here's an example. Note that in this case, we've left out the other
 ball devices (such as your trough and/or drain):
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -152,7 +152,7 @@ means an event called *s_launch_button_active* will be posted as soon as
 that switch is hit. In that case, you'd configure your plunger like
 this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -176,7 +176,7 @@ Pretty straightforward.
 If you want to launch the ball into play when the player *releases* the
 launch button, then just use that switch's inactive event:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -255,7 +255,7 @@ Here are some examples of these settings in action.
 First, for a typical coil-fired plunger lane / catapult that ejects the
 ball directly to the playfield: (This is probably 99% of all cases)
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -275,7 +275,7 @@ Next, for a coil-fired plunger that has a switch at the exit of the
 plunger lane that is only hit if the ball has made it out of the plunger
 and cannot be hit by a random ball on the playfield:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -298,7 +298,7 @@ ball_devices:
 Next, if your plunger lane ejects into another ball device (a cannon, in
 this case):
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -329,7 +329,7 @@ Once you have your plunger device set up, you need to go back to your
 trough or ball drain device and add the new plunger to your trough's
 `eject_targets:`, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -378,7 +378,7 @@ ball into play.
 To do that, add your new plunger ball device as `default_source_device`
 in the default `playfield`, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -416,7 +416,7 @@ does not include the switches and coils for the trough.
 This config is what probably 99% of machines with coil-fired plungers
 will use:
 
-``` mpf-config
+``` yaml
 switches:
   s_plunger_lane:
     number: 2-6

--- a/docs/mechs/plungers/mechanical_no_switch.md
+++ b/docs/mechs/plungers/mechanical_no_switch.md
@@ -61,7 +61,7 @@ device is used to add a new ball into play.
 To do that, add your trough device as `default_source_device` in the
 default `playfield`, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough:
 #!     number: 2-6

--- a/docs/mechs/plungers/mechanical_with_switch.md
+++ b/docs/mechs/plungers/mechanical_with_switch.md
@@ -29,7 +29,7 @@ coil fired option, then follow the [/mechs/playfields/ball_tracking](auto_manual
 The first step is to add your plunger lane switches to the `switches:`
 section of your machine config file. Here's an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_plunger_lane:
     number: 2-6
@@ -55,7 +55,7 @@ entries for the ball switch.
 Here's an example. Note that in this case, we've left out the other
 ball devices (such as your trough and/or drain):
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -88,7 +88,7 @@ been made.
 To do that, add `mechanical_eject: true` to your plunger device, like
 this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -154,7 +154,7 @@ Here are some examples of these settings in action.
 First, for a typical coil-fired plunger lane / catapult that ejects the
 ball directly to the playfield: (This is probably 99% of all cases)
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -170,7 +170,7 @@ Next, for a coil-fired plunger that has a switch at the exit of the
 plunger lane that is only hit if the ball has made it out of the plunger
 and cannot be hit by a random ball on the playfield:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -189,7 +189,7 @@ ball_devices:
 Next, if your plunger lane ejects into another ball device (a cannon, in
 this case):
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -217,7 +217,7 @@ Once you have your plunger device set up, you need to go back to your
 trough or ball drain device and add the new plunger to your trough's
 `eject_targets:`, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -263,7 +263,7 @@ device is used to add a new ball into play.
 To do that, add your new plunger ball device as `default_source_device`
 in the default `playfield`, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger_lane:
 #!     number: 2-6
@@ -295,7 +295,7 @@ does not include the switches and coils for the trough.
 This config is what probably 99% of machines with coil-fired plungers
 will use:
 
-``` mpf-config
+``` yaml
 switches:
   s_plunger_lane:
     number: 2-6

--- a/docs/mechs/pop_bumpers/index.md
+++ b/docs/mechs/pop_bumpers/index.md
@@ -114,7 +114,7 @@ Part numbers:
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_popbumper_left:
     number: 7                 # depends on your platform

--- a/docs/mechs/scoops.md
+++ b/docs/mechs/scoops.md
@@ -44,7 +44,7 @@ since they can count balls and choose to keep or eject it.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_scoop:
     number: 2
@@ -65,7 +65,7 @@ this using a
 [queue_relay_player](../config/queue_relay_player.md) in your mode (you might want to use
 [conditional events](../events/overview/conditional.md) to only trigger it when certain condition match):
 
-``` mpf-config
+``` yaml
 switches:
   s_scoop:
     number: 2

--- a/docs/mechs/score_reels.md
+++ b/docs/mechs/score_reels.md
@@ -17,7 +17,7 @@ detect certain position using switches (usually 0)
 
 This is an example:
 
-``` mpf-config
+``` yaml
 lights:
   light_p1:
     number:

--- a/docs/mechs/servos/index.md
+++ b/docs/mechs/servos/index.md
@@ -19,7 +19,7 @@ will not provide any position feedback to the software side.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 servos:
   servo1:
     servo_min: 0.1

--- a/docs/mechs/servos/servo_sequence.md
+++ b/docs/mechs/servos/servo_sequence.md
@@ -24,7 +24,7 @@ and lights.
 The following example will move the servo six times when `my_toy_hit` is
 posted (three times to open and three times to close):
 
-``` mpf-config
+``` yaml
 servos:
   my_toy:
     positions:

--- a/docs/mechs/shaker.md
+++ b/docs/mechs/shaker.md
@@ -32,7 +32,7 @@ the voltage your PWM should have a duty cycle between 10% and 30%.
 
 This is an example on how to use a shaker using coil_player:
 
-``` mpf-config
+``` yaml
 coils:
   c_shaker:
     number:
@@ -56,7 +56,7 @@ coil_player:
 
 Alternatively, you can use it inside a show:
 
-``` mpf-config
+``` yaml
 coils:
   c_shaker:
     number:

--- a/docs/mechs/slingshots.md
+++ b/docs/mechs/slingshots.md
@@ -34,7 +34,7 @@ Part numbers:
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_sling_left:
     number: 5

--- a/docs/mechs/spinners.md
+++ b/docs/mechs/spinners.md
@@ -25,7 +25,7 @@ Part numbers:
 
 In MPF spinners are configured as follows:
 
-``` mpf-config
+``` yaml
 switches:
   s_my_spinner:
     number: 42    # number depends on your platform
@@ -40,7 +40,7 @@ It is very common to count the rotations of your spinner per player. You
 can either use a player variable or a counter for that. This is an
 example:
 
-``` mpf-config
+``` yaml
 switches:
   s_my_spinner:
     number: 42    # number depends on your platform

--- a/docs/mechs/steppers.md
+++ b/docs/mechs/steppers.md
@@ -61,7 +61,7 @@ details.
 
 ## Example config
 
-``` mpf-config
+``` yaml
 #config_version=5
 switches:
   s_home:

--- a/docs/mechs/switches/index.md
+++ b/docs/mechs/switches/index.md
@@ -65,7 +65,7 @@ bumpers.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   my_switch:
     number)

--- a/docs/mechs/switches/mechanical_switches.md
+++ b/docs/mechs/switches/mechanical_switches.md
@@ -116,7 +116,7 @@ platform documentation for details.
 
 This is an example of switches in MPF:
 
-``` mpf-config
+``` yaml
 switches:
   my_direct_switch:
     number: 23        # number depends on your platform

--- a/docs/mechs/switches/optos.md
+++ b/docs/mechs/switches/optos.md
@@ -197,7 +197,7 @@ Part numbers:
 
 You can configure a normally closed opto like this:
 
-``` mpf-config
+``` yaml
 switches:
   trough1:
     number: 81    # number depends on your platform

--- a/docs/mechs/switches/rollover_switches.md
+++ b/docs/mechs/switches/rollover_switches.md
@@ -24,7 +24,7 @@ Typical part numbers:
 
 This is an example config:
 
-``` mpf-config
+``` yaml
 # this is in your machine-wide config
 switches:
   s_outlane_left:

--- a/docs/mechs/switches/start_tournament_and_launcher_buttons.md
+++ b/docs/mechs/switches/start_tournament_and_launcher_buttons.md
@@ -35,7 +35,7 @@ rated at 6.3V which works fine at either 5V or in a lamp matrix at 12V
 
 To configure your start button you can use this config:
 
-``` mpf-config
+``` yaml
 lights:
   l_start_button:
     number: 3           # number depends on your platform

--- a/docs/mechs/targets/drop_targets/drop_target_bank.md
+++ b/docs/mechs/targets/drop_targets/drop_target_bank.md
@@ -19,7 +19,7 @@ posted when the entire bank is up, down or in a mixed state.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drop_front:
 #!     number:

--- a/docs/mechs/targets/drop_targets/fixing_drop_target_reset_issues.md
+++ b/docs/mechs/targets/drop_targets/fixing_drop_target_reset_issues.md
@@ -23,7 +23,7 @@ Behind the scenes MPF performs
 [some magic for you to prevent stress on your power supply unit](../../../hardware/voltages_and_power/power_management.md). The default should be fine for most machine but if your PSU
 is very weak try this config:
 
-``` mpf-config
+``` yaml
 psus:
   default:
     release_wait_ms: 50    # defaults to 10ms
@@ -52,7 +52,7 @@ much stress.
 The following example will try to reset your drop target bank up to
 three times on ball start:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drop_front:
 #!     number:

--- a/docs/mechs/targets/drop_targets/index.md
+++ b/docs/mechs/targets/drop_targets/index.md
@@ -26,7 +26,7 @@ allows the software to knock the target down.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 switches:
   s_drop_target:
     number:

--- a/docs/mechs/targets/kicking_targets.md
+++ b/docs/mechs/targets/kicking_targets.md
@@ -18,7 +18,7 @@ with a coil for kicking. Used rarely, these targets look like stationary
 targets, but when hit they kick the back in the opposite direction much
 like a [slingshot](../slingshots.md) or [bumper](../pop_bumpers/index.md).
 
-``` mpf-config
+``` yaml
 switches:
   s_kicking_target:
     number: 1

--- a/docs/mechs/targets/stationary_targets.md
+++ b/docs/mechs/targets/stationary_targets.md
@@ -16,7 +16,7 @@ a switch in a pinball machine. This might also be know as a stand-up
 target. It is essentially a switch above the playfield with a scoring
 value associated with it. When the ball hits it the value is scored.
 
-``` mpf-config
+``` yaml
 switches:
   s_target:
     number: 5

--- a/docs/mechs/tilt_bob.md
+++ b/docs/mechs/tilt_bob.md
@@ -21,7 +21,7 @@ the built-in [tilt mode](../game_logic/tilt/index.md) in the list of your modes.
 
 This is an example:
 
-``` mpf-config
+``` yaml
 modes:
   - tilt
 switches:

--- a/docs/mechs/troughs/classic_single_ball.md
+++ b/docs/mechs/troughs/classic_single_ball.md
@@ -32,7 +32,7 @@ the case see [/mechs/plungers/index](classic_single_ball_no_shooter_lane.md).
 The first step is to add the drain and plunger switches to the
 `switches:` section of your machine config file.
 
-``` mpf-config
+``` yaml
 switches:
   s_drain:
     number: 01
@@ -50,7 +50,7 @@ Next, create the entry in your `coils:` section for the drain eject
 coil. Again, the name doesn't matter. We'll call it *c_drain_eject*
 and enter it like this:
 
-``` mpf-config
+``` yaml
 coils:
   c_drain_eject:
     number: 03
@@ -103,7 +103,7 @@ ball device.
 
 Your drain device configuration should look now look like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drain:
 #!     number: 01
@@ -130,7 +130,7 @@ ball_devices:
 
 We also add the plunger as ball_device `bd_plunger_lane`:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drain:
 #!     number: 01
@@ -174,7 +174,7 @@ when you're running with one of the virtual hardware interfaces. To use
 it, simply add the section along with a list of the switches you want to
 start active. For example:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drain:
 #!     number: 01
@@ -183,7 +183,7 @@ virtual_platform_start_active_switches: s_drain
 
 ## Here's the complete config
 
-``` mpf-config
+``` yaml
 #config_version=5
 switches:
   s_drain:

--- a/docs/mechs/troughs/classic_single_ball_no_shooter_lane.md
+++ b/docs/mechs/troughs/classic_single_ball_no_shooter_lane.md
@@ -22,7 +22,7 @@ Here's an example from a Gottlieb Playball (1971 EM):
 The first step is to add the drain switch to the `switches:` section of
 your machine config file.
 
-``` mpf-config
+``` yaml
 switches:
   s_drain:
     number: 01
@@ -39,7 +39,7 @@ Next, create the entry in your `coils:` section for the drain eject
 coil. Again, the name doesn't matter. We'll call it *c_drain_eject*
 and enter it like this:
 
-``` mpf-config
+``` yaml
 coils:
   c_drain_eject:
     number: 03
@@ -85,7 +85,7 @@ ball device.
 
 Your drain device configuration should look now look like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drain:
 #!     number: 01
@@ -113,7 +113,7 @@ ball into play.
 To do that, add your trough device as `default_source_device` in the
 default `playfield`, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drain:
 #!     number: 01
@@ -157,7 +157,7 @@ when you're running with one of the virtual hardware interfaces. To use
 it, simply add the section along with a list of the switches you want to
 start active. For example:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drain:
 #!     number: 01
@@ -166,7 +166,7 @@ virtual_platform_start_active_switches: s_drain
 
 ## Here's the complete config
 
-``` mpf-config
+``` yaml
 #config_version=5
 switches:
   s_drain:

--- a/docs/mechs/troughs/modern_mechanical.md
+++ b/docs/mechs/troughs/modern_mechanical.md
@@ -42,7 +42,7 @@ section of your config file. Create an entry in your `switches:` section
 for each switch in your trough, like this: (This example has six
 switches plus the jam switch. Yours may have more or less.)
 
-``` mpf-config
+``` yaml
 switches:
   s_trough1:
     number: 2
@@ -86,7 +86,7 @@ Next, create an entry in your `coils:` section for your trough's eject
 coil. Again, the name doesn't matter. We'll call this *c_trough_eject*
 and enter it like this:
 
-``` mpf-config
+``` yaml
 coils:
   c_trough_eject:
     number: 4
@@ -113,7 +113,7 @@ your machine config. (If you don't have that section add it now.)
 Then in your `ball_devices:` section, create an entry called
 `bd_trough:`, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -168,7 +168,7 @@ Indented under `bd_trough:`, create an entry called `ball_switches:` and
 then add a comma-separated list of all the switches in your trough, like
 this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -236,7 +236,7 @@ coil that MPF should fire when it wants to eject a ball from the trough.
 This should be the name of the coil you added in Step 2,
 *c_trough_eject* in our case:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -319,7 +319,7 @@ for now you have to add `trough`, `home`, and `drain` tags to your
 trough. You can specify the tags in any order, and your `tags:` entry
 should look something like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -367,7 +367,7 @@ ball_devices:
 If you have a jam switch, add a setting called `jam_switch:` and add it
 there, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -419,7 +419,7 @@ kick out two balls (the jammed ball and the one below it).
 
 So for our example, we'll set the jam pulse time to 15ms.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -486,7 +486,7 @@ when you're running with one of the virtual hardware interfaces. To use
 it, simply add the section along with a list of the switches you want to
 start active. For example:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -527,7 +527,7 @@ full details since there are lots of different types of plungers.
 
 You add an eject target via the `eject_targets:` section, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -594,7 +594,7 @@ measure how long the maximum time is until a ball cannot possibly return
 to your trough and plunger (with some safty margin). Usually this is
 about `2s - 4s` for a trough and `3s - 5s` for a plunger.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -638,7 +638,7 @@ ball_devices:
 
 ## Here's the complete config
 
-``` mpf-config
+``` yaml
 switches:
   s_trough1:
     number: 2

--- a/docs/mechs/troughs/modern_opto.md
+++ b/docs/mechs/troughs/modern_opto.md
@@ -106,7 +106,7 @@ section of your machine config file. Create an entry in the `switches:`
 section for each switch in your trough, like this: (This example has six
 switches plus the jam switch. Yours may have more or less.)
 
-``` mpf-config
+``` yaml
 switches:
   s_trough1:
     number: 2
@@ -158,7 +158,7 @@ Next, create an entry in your `coils:` section for your trough's eject
 coil. Again, the name doesn't matter. We'll call this *c_trough_eject*
 and enter it like this:
 
-``` mpf-config
+``` yaml
 coils:
   c_trough_eject:
     number: 04
@@ -185,7 +185,7 @@ your machine config. (If you don't have that section add it now.)
 Then in your `ball_devices:` section, create an entry called
 `bd_trough:`, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -240,7 +240,7 @@ Indented under `bd_trough:`, create an entry called `ball_switches:` and
 then add a comma-separated list of all the switches in your trough, like
 this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -308,7 +308,7 @@ coil that MPF should fire when it wants to eject a ball from the trough.
 This should be the name of the coil you added in Step 2,
 *c_trough_eject* in our case:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -391,7 +391,7 @@ for now you have to add `trough`, `home`, and `drain` tags to your
 trough. You can specify the tags in any order, and your `tags:` entry
 should look something like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -439,7 +439,7 @@ ball_devices:
 If you have a jam switch, add a setting called `jam_switch:` and add it
 there, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -491,7 +491,7 @@ kick out two balls (the jammed ball and the one below it).
 
 So for our example, we'll set the jam pulse time to 15ms.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -558,7 +558,7 @@ when you're running with one of the virtual hardware interfaces. To use
 it, simply add the section along with a list of the switches you want to
 start active. For example:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -608,7 +608,7 @@ full details since there are lots of different types of plungers.
 
 You add an eject target via the `eject_targets:` section, like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -682,7 +682,7 @@ measure how long the maximum time is until a ball cannot possibly return
 to your trough and plunger (with some safety margin). Usually this is
 about `2s - 4s` for a trough and `3s - 5s` for a plunger.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -733,7 +733,7 @@ ball_devices:
 
 ## Here's the complete config
 
-``` mpf-config
+``` yaml
 switches:
   s_trough1:
     number: 2

--- a/docs/mechs/troughs/spike_trough.md
+++ b/docs/mechs/troughs/spike_trough.md
@@ -39,7 +39,7 @@ If you got a Stern Spike trough but are not using
 can use our
 [SPI Bit Bang platform](../../hardware/spi_bit_bang.md) to read the switches of your trough:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: your_platform, spi_bit_bang      # add your platform first here
 spi_bit_bang:

--- a/docs/mechs/troughs/two_coil_multiple_switches.md
+++ b/docs/mechs/troughs/two_coil_multiple_switches.md
@@ -42,7 +42,7 @@ your config file. Create an entry in your `switches:` section for the
 drain switch as well as each switch in your trough, like this: (This
 example has three switches in the trough. Yours may have more or less.)
 
-``` mpf-config
+``` yaml
 switches:
   s_drain:
     number: 1
@@ -72,7 +72,7 @@ coil and the trough release coil. Again, the names don't matter. We'll
 call them *c_drain_eject* and *c_trough_release* and enter them like
 this:
 
-``` mpf-config
+``` yaml
 coils:
   c_drain_eject:
     number: 3
@@ -104,7 +104,7 @@ platforms).
 
 In other words, a trough release time of 1s would look like this:
 
-``` mpf-config
+``` yaml
 coils:
   c_trough_release:
     number: 4
@@ -147,7 +147,7 @@ ball device.
 
 Your drain device configuration should look now look like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drain:
 #!     number: 1
@@ -208,7 +208,7 @@ The configuration is pretty straightforward:
 
 Your trough device configuration should look now look like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drain:
 #!     number: 1
@@ -260,7 +260,7 @@ when you're running with one of the virtual hardware interfaces. To use
 it, simply add the section along with a list of the switches you want to
 start active. For example:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 2
@@ -273,7 +273,7 @@ virtual_platform_start_active_switches: s_trough1, s_trough2, s_trough3
 
 ## Here's the complete config
 
-``` mpf-config
+``` yaml
 #config_version=5
 switches:
   s_drain:

--- a/docs/mechs/troughs/two_coil_one_switch.md
+++ b/docs/mechs/troughs/two_coil_one_switch.md
@@ -41,7 +41,7 @@ your config file. Create an entry in your `switches:` section for the
 drain switch as well as each switch in your trough, like this: (This
 example has three switches in the trough. Yours may have more or less.)
 
-``` mpf-config
+``` yaml
 switches:
   s_drain:
     number: 1
@@ -66,7 +66,7 @@ coil and the trough release coil. Again, the names don't matter. We'll
 call them *c_drain_eject* and *c_trough_release* and enter them like
 this:
 
-``` mpf-config
+``` yaml
 coils:
   c_drain_eject:
     number: 3
@@ -96,7 +96,7 @@ versus pulsed, so in that case, you also need to add
 
 In other words, a trough with long release time would look like this:
 
-``` mpf-config
+``` yaml
 coils:
   c_trough_release:
     number: 4
@@ -141,7 +141,7 @@ ball device.
 
 Your drain device configuration should look now look like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drain:
 #!     number: 1
@@ -204,7 +204,7 @@ The configuration is pretty straightforward:
 
 Your trough device configuration should look now look like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drain:
 #!     number: 01
@@ -243,7 +243,7 @@ ball_devices:
 If you need to enable `c_trough_release` for 1s (more than a few ms) it
 would look like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_drain:
 #!     number: 01
@@ -304,7 +304,7 @@ when MPF starts up.
 
 Here's an example from the machine config:
 
-``` mpf-config
+``` yaml
 machine:
   balls_installed: 4
 ```
@@ -330,7 +330,7 @@ when you're running with one of the virtual hardware interfaces. To use
 it, simply add the section along with a list of the switches you want to
 start active. For example:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough_enter:
 #!     number: 2
@@ -339,7 +339,7 @@ virtual_platform_start_active_switches: s_trough_enter
 
 ## Here's the complete config
 
-``` mpf-config
+``` yaml
 switches:
   s_drain:
     number: 01

--- a/docs/running/ports.md
+++ b/docs/running/ports.md
@@ -40,7 +40,7 @@ the MC reads to know what port it should listen on.
 
 Valid port numbers are anything between 1024 and 65535.
 
-``` mpf-config
+``` yaml
 # config_version=5
 
 bcp:

--- a/docs/shows/config_shows.md
+++ b/docs/shows/config_shows.md
@@ -16,7 +16,7 @@ of a standalone show file on disk. Basically you add a `shows:` section
 to a config, create sub-sections based on show name, and then add normal
 show items to the config. For example:
 
-``` mpf-config
+``` yaml
 shows:
   flash_red:
     - time: 0

--- a/docs/shows/file_shows.md
+++ b/docs/shows/file_shows.md
@@ -26,7 +26,7 @@ Here is a sample show file. This file might be called something like
 `flash_red.yaml` and would be located in your machine's `/shows`
 folder:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 #show_version=5
 - time: 0

--- a/docs/shows/format.md
+++ b/docs/shows/format.md
@@ -17,7 +17,7 @@ Then after another second, the show is over. (Most likely you'd
 configure a show like this to *loop*, meaning this should could be used
 to flash *led1* on and off.)
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: 0
   lights:
@@ -42,7 +42,7 @@ could say that the example show above has three steps:
 
 Step 1:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: 0
   lights:
@@ -51,7 +51,7 @@ Step 1:
 
 Step 2:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: +1
   lights:
@@ -60,7 +60,7 @@ Step 2:
 
 Step 3:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: +1
 ```
@@ -121,7 +121,7 @@ Sometimes it's more convenient to specify the timing of a step in a
 show relative to the step before it. To do that, enter the *time* value
 with a + in front of it, like this:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: +1
 ```
@@ -134,7 +134,7 @@ You can mix-and-match incremental and absolute times in the same show,
 and you can also combine the plus sign for relative times with seconds
 or millisecond values. For example:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: 0   # plays right away, at 0 seconds
   # ...
@@ -160,7 +160,7 @@ useful in different situations.
 
 For example, the following to shows are identical:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: 0
   lights:
@@ -171,7 +171,7 @@ For example, the following to shows are identical:
 - time: +1
 ```
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - duration: 1
   lights:
@@ -199,7 +199,7 @@ what about your last step in the show? How long should it run for? If
 you just use time-based steps, you'd still want to specify a
 "duration" for the final step, like this:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: 0
   lights:
@@ -221,7 +221,7 @@ you want to run and then hold something in their final state. For
 example, maybe you want a show that runs once (no loop) and flashes a
 light which then stays on. You could do that like this:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: 0
   lights:

--- a/docs/shows/shows_in_shows.md
+++ b/docs/shows/shows_in_shows.md
@@ -11,7 +11,7 @@ Luckily, a show can use any [Config Players](../config_players/index.md) and the
 
 This is an example of an attract mode:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - duration: 3s
   shows:

--- a/docs/shows/tokens.md
+++ b/docs/shows/tokens.md
@@ -17,7 +17,7 @@ different situations with different lights, slides, sounds, etc.
 To understand how tokens work, let's first look at a show that does not
 include any tokens, like this:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: 0
   lights:
@@ -34,7 +34,7 @@ loop to flash *led_01* between red and off.
 If you called this show *flash_red*, you could play it via the
 *show_player:* section of your config, like this:
 
-``` mpf-config
+``` yaml
 show_player:
   some_event: flash_red
 ```
@@ -52,7 +52,7 @@ combination you'd ever want. :(
 This is where tokens come in. Consider a slightly modified version of
 the show above using a token instead of a hard-coded LED name:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: 0
   lights:
@@ -73,7 +73,7 @@ So in the second show here, when you run the show, you could tell it
 "replace the "leds" token with the value "led_02", which would make
 a show like this:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: 0
   lights:
@@ -91,7 +91,7 @@ For example, here's how you'd do it via the *show_player:*. (In this
 example, we also add `loops: -1` which will cause the show to loop
 (repeat) indefinitely.
 
-``` mpf-config
+``` yaml
 show_player:
   some_event:
     flash_red:
@@ -105,7 +105,7 @@ run the above show multiple times (at the same time), passing different
 tokens to each one, meaning you could use the same show to flash lots of
 lights at once:
 
-``` mpf-config
+``` yaml
 show_player:
   some_event:
     flash_red:
@@ -124,7 +124,7 @@ show_player:
 You can also use tags to insert multiple values into a single token. For
 example, consider the following section from your machine config:
 
-``` mpf-config
+``` yaml
 lights:
   led_01:
     number: 00
@@ -138,7 +138,7 @@ You can see that both *led_01* and *led_02* have the *tag1* tag applied.
 So if you play the show above (with the *leds* token), you can actually
 pass the tag name to the token instead:
 
-``` mpf-config
+``` yaml
 show_player:
   some_event:
     flash_red:
@@ -149,7 +149,7 @@ show_player:
 
 This would result in a show that was equivalent to:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: 0
   lights:
@@ -171,7 +171,7 @@ names it was passed.
 
 For example, this is a perfectly valid show:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: 0
   lights:
@@ -184,7 +184,7 @@ For example, this is a perfectly valid show:
 In this case, you'd just pass a value for the *corndog* token when you
 play the show:
 
-``` mpf-config
+``` yaml
 show_player:
   some_event:
     flash_red:
@@ -202,7 +202,7 @@ the show starts.
 
 You can also pass multiple tokens. Consider the following show:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 - time: 0
   lights:
@@ -216,7 +216,7 @@ Notice there are three tokens in this show: *led*, *color1*, and
 *color2*. You might call this show *color_cycle*, which you could then
 play like this:
 
-``` mpf-config
+``` yaml
 show_player:
   some_event:
     color_cycle:
@@ -239,7 +239,7 @@ INFO : EventManager : Event: ======'player_turn_started'====== Args={'player': <
 ```
 The event `player_turn_started` has for example the argument `number` for the number of the player whose turn has started.
 
-``` mpf-config
+``` yaml
 show_player:
   player_turn_started:
     player_num: #The name of the show to be started upon this event
@@ -252,7 +252,7 @@ The number of the player whose turn started is being displayed in the show where
 ### Variable values
 You can use as well variable values to be used in a token. For example if you want to access a player variable you can access it with `current_player.<variable>`
 
-``` mpf-config
+``` yaml
 show_player:
   player_turn_started:
     ball_num: #The name of the show to be started upon this event
@@ -267,7 +267,7 @@ You can as well access game variables, machine variables or settings. Just use t
 ### Formatting of variable values
 mpf is being build with Python, thus you find in some config files things which are Python specific. An example is how to tell mpf how to format the variable value. In some config files you might find something like this
 
-``` mpf-config
+``` yaml
 show_player:
   player_turn_started:
     ball_num: #The name of the show to be started upon this event

--- a/docs/start/config_files.md
+++ b/docs/start/config_files.md
@@ -36,14 +36,14 @@ When you create your machine code in MPF, you'll actually create a
 folder which will contain your config files. A super-simple snippet
 might look like this:
 
-``` mpf-config
+``` yaml
 game:
   balls_per_game: 3
 ```
 
 Want a 5-ball game instead? Simple! Just change it:
 
-``` mpf-config
+``` yaml
 game:
   balls_per_game: 5
 ```

--- a/docs/tools/hardware.md
+++ b/docs/tools/hardware.md
@@ -33,7 +33,7 @@ MPF will benchmark latency and jitter of inputs, outputs and rules for
 your hardware setup (i.e. your controller with your OS and hardware).
 This needs to be configured:
 
-``` mpf-config
+``` yaml
 switches:
   s_test1:
     number:

--- a/docs/tools/showcreator.md
+++ b/docs/tools/showcreator.md
@@ -38,7 +38,7 @@ which the next element in the list is played. Here is an example of a
 light show with three lights which sequentially turn blue over one
 second:
 
-``` mpf-config
+``` yaml
 ##! show: my_show
 #show_version=5
 - duration: .25

--- a/docs/troubleshooting/debugging_memory_leaks.md
+++ b/docs/troubleshooting/debugging_memory_leaks.md
@@ -14,7 +14,7 @@ dump start MPF and MPF-MC without the production flag and post the
 `debug_dump_stats` events. For example, you can add a keyboard key `d`
 to do that:
 
-``` mpf-config
+``` yaml
 keyboard:
   d:
     event: debug_dump_stats

--- a/docs/troubleshooting/general_debugging.md
+++ b/docs/troubleshooting/general_debugging.md
@@ -76,7 +76,7 @@ a `debug` option. If in doubt check the
 instance if you suspect an issue with a switch add `debug: true` to
 it's config:
 
-``` mpf-config
+``` yaml
 switches:
   my_switch:
     number: 42
@@ -88,7 +88,7 @@ not affect performance much.
 
 Most platforms support the same. For instance with a P-Roc:
 
-``` mpf-config
+``` yaml
 p_roc:
   debug: true
 ```

--- a/docs/tutorial/10_run_a_game.md
+++ b/docs/tutorial/10_run_a_game.md
@@ -23,7 +23,7 @@ what's actually going on. For now just make this change.) In your
 config file, add a `ball_started:` entry with the following information.
 Your complete `slide_player:` section should now look like this:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   welcome_slide:
 #!     widgets:
@@ -60,7 +60,7 @@ your virtual machine starts up. Additionally, we add keyboard bindings
 for ball switches to the numbers `1` to `5` and the plunger switch to
 `p`.
 
-``` mpf-mc-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number:
@@ -117,7 +117,7 @@ flipper sections of your config file. So now your `` `flippers: ``
 section should look like this: (It might not be 100% identical since you
 might have single-wound flipper coils and/or EOS switches.)
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_left_flipper:
 #!     number: 0

--- a/docs/tutorial/12_add_ball_devices.md
+++ b/docs/tutorial/12_add_ball_devices.md
@@ -40,7 +40,7 @@ when it boots because these additional devices do not have "home"
 listed as one of their tags.) Here's the `ball_devices:` section from a
 *Demolition Man* config file:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 1

--- a/docs/tutorial/13_add_autofires.md
+++ b/docs/tutorial/13_add_autofires.md
@@ -20,7 +20,7 @@ has two standard slingshots, and upper slingshot near the pop bumpers,
 and two pop bumpers (which we happen to refer to as "jets" in this
 config):
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_left_slingshot:
 #!     number: 1

--- a/docs/tutorial/14_add_a_mode.md
+++ b/docs/tutorial/14_add_a_mode.md
@@ -93,7 +93,7 @@ entry `start_events: ball_starting`. On the following line, also indent
 four spaces and type `priority: 100`. Your `base.yaml` file should now
 look like this:
 
-``` mpf-config
+``` yaml
 ##! mode: my_mode
 #config_version=5
 mode:
@@ -195,7 +195,7 @@ To do this, go back to your base mode's config file
 `slide_player:`. Then add the following subsections so your complete
 `base.yaml` looks like this:
 
-``` mpf-mc-config
+``` yaml
 ##! mode: base
 #config_version=5
 mode:
@@ -284,7 +284,7 @@ can go into your machine-wide `config.yaml` and remove the slide_player:
 entry for ball_started:. So now the slide_player: in your machine-wide
 `config.yaml` should just look like this:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   welcome_slide:
 #!     widgets:

--- a/docs/tutorial/15_scoring.md
+++ b/docs/tutorial/15_scoring.md
@@ -51,7 +51,7 @@ up.) To give the player points when a switch is hit, add sub-entries to
 the `variable_player:` section of your config file, with some switch
 name followed by "_active", like this:
 
-``` mpf-config
+``` yaml
 ##! mode: base
 variable_player:
   s_right_inlane_active:
@@ -109,7 +109,7 @@ the `variable_player:` section--even player variables that you make up.
 
 For example, try changing your scoring section to this:
 
-``` mpf-config
+``` yaml
 # we will initially set the value to 0 when the machine starts up
 player_vars:
   potato:
@@ -152,7 +152,7 @@ when the base mode starts. (So we're going to be editing
 `<your_machine>/modes/config/base.yaml` again. Add the potato text
 entry, like this:
 
-``` mpf-mc-config
+``` yaml
 #! player_vars:
 #!   potato:
 #!     initial_value: 0

--- a/docs/tutorial/16_attract_mode_show.md
+++ b/docs/tutorial/16_attract_mode_show.md
@@ -61,7 +61,7 @@ folder since it keeps everything from one mode together.
 Here's a complete sample `attract_display_loop.yaml` file you can use
 as a starting point:
 
-``` mpf-mc-config
+``` yaml
 #show_version=5
 ##! show: attract_display_loop
 
@@ -202,7 +202,7 @@ running. To do this, go back to the config file for the attract mode (
 `<your_machine>/modes/attract/config/attract.yaml`) and add the
 following:
 
-``` mpf-mc-config
+``` yaml
 #config_version=5
 ##! show: attract_display_loop
 #! - duration: .1
@@ -242,7 +242,7 @@ the attract_started slide from the `slides:` section, and the
 
 OLD machine-wide config (partial):
 
-``` mpf-mc-config
+``` yaml
 # old
 slides:
   welcome_slide:
@@ -268,7 +268,7 @@ slide_player:
 
 NEW machine-wide config:
 
-``` mpf-mc-config
+``` yaml
 slides:
   welcome_slide:
     widgets:

--- a/docs/tutorial/17_add_lights_leds.md
+++ b/docs/tutorial/17_add_lights_leds.md
@@ -78,7 +78,7 @@ to names that actually exist for you. If you have matrix lights, add
 entries to your `attract_light_show.yaml` file so that it looks
 something like like this:
 
-``` mpf-config
+``` yaml
 ##! show: attract_light_show
 #show_version=5
 - duration: 1
@@ -111,7 +111,7 @@ different colors for each light at each step. For example, if you just
 wanted to have a show that cycled three RGB LEDs through the colors of
 the rainbow, you could create a show like this:
 
-``` mpf-config
+``` yaml
 ##! show: attract_light_show
 #show_version=5
 - duration: 1
@@ -174,7 +174,7 @@ will exit and print a warning about the duplicate so you can fix it.)
 MPF offers a way around this though, in that you can add a `.1` to the
 end of the event name, like this:
 
-``` mpf-config
+``` yaml
 ##! mode: test_mode
 #config_version=5
 show_player:
@@ -252,7 +252,7 @@ it. The YAML processor doesn't know what to do?
 To fix this, we need to make a slight change to our YAML file, like
 this:
 
-``` mpf-config
+``` yaml
 ##! mode: test_mode
 #config_version=5
 show_player:
@@ -269,7 +269,7 @@ setting under there.
 If you wanted to, you could consolidate the duplicate
 `mode_attract_started` entries like so:
 
-``` mpf-config
+``` yaml
 ##! mode: test_mode
 #config_version=5
 show_player:

--- a/docs/tutorial/18_shots.md
+++ b/docs/tutorial/18_shots.md
@@ -38,7 +38,7 @@ time.
 Let's start by creating our first shot in the base mode's config file
 (base.yaml).
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_right_inlane:
 #!     number: 1
@@ -60,7 +60,7 @@ Next, find the `variable_player:` section that you added in Step 15, and
 change the first entry from `s_right_inlane_active:` to
 `my_first_shot_hit`, like this:
 
-``` mpf-config
+``` yaml
 ##! mode: base
 variable_player:
   my_first_shot_hit:  # this was s_right_inlane_active
@@ -153,7 +153,7 @@ To do this, go back to the mode config where you defined the shot
 
 If you have LEDs in your machine, change it to this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_right_inlane:
 #!     number: 1
@@ -167,7 +167,7 @@ shots:
 
 If you have a lamp matrix, change it to this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_right_inlane:
 #!     number: 1
@@ -207,7 +207,7 @@ To do this, we'll add a section to the mode's config file (base.yaml)
 called `shot_profiles:`. Create that section now, and define a shot
 profile called "my_first_profile" with the following settings:
 
-``` mpf-config
+``` yaml
 ##! mode: base
 shot_profiles:
   my_first_profile:
@@ -265,7 +265,7 @@ a show is separate from playing the show.
 So next we need to tell our shot that it should use the new profile we
 just created by adding a `profile:` setting.
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_right_inlane:
 #!     number: 1
@@ -350,7 +350,7 @@ points when they hit that shot depending on what state the shot's in.
 
 Here's the existing variable_player section from the base mode config:
 
-``` mpf-config
+``` yaml
 ##! mode: base
 variable_player:
   my_first_shot_hit:
@@ -368,7 +368,7 @@ event which does not include details of what state the shot is in.
 
 Now let's change the variable_player section to this:
 
-``` mpf-config
+``` yaml
 ##! mode: base
 variable_player:
   my_first_shot_my_first_profile_unlit_hit:
@@ -419,7 +419,7 @@ mode configuration file for that mode.
 Open up the `mode2.yaml` file and add the following lines. (We'll
 explain them step-by-step next.)
 
-``` mpf-mc-config
+``` yaml
 ##! mode: mode2
 #config_version=5
 # mode2 config file
@@ -499,7 +499,7 @@ So what's happening here?
 First, notice that in the `mode2.yaml` file, we configured the following
 variable_player entry:
 
-``` mpf-config
+``` yaml
 ##! mode: mode2
 variable_player:
   my_first_shot_hit:
@@ -543,7 +543,7 @@ To illustrate this, open up your `mode2.yaml` file and:
 2.  Add the `shots:` section from below
 3.  Add the `shot_profiles:` section from below
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_right_inlane:
 #!     number: 1
@@ -593,7 +593,7 @@ what's going on.
 First, notice that we added a `shots:` section and then added
 "my_first_shot" to it, like this:
 
-``` mpf-config
+``` yaml
 ##! mode: mode2
 #! shot_profiles:
 #!   mode2:
@@ -623,7 +623,7 @@ when that mode is active.)
 
 Next, take a look at the `shot_profiles:` section:
 
-``` mpf-config
+``` yaml
 ##! mode: mode2
 shot_profiles:
   mode2:

--- a/docs/tutorial/3_get_flipping.md
+++ b/docs/tutorial/3_get_flipping.md
@@ -31,7 +31,7 @@ line, type four spaces (these must be spaces, not a tab), and write
 
 So now your `config.yaml` file should look like this:
 
-``` mpf-config
+``` yaml
 #config_version=6
 
 switches:
@@ -133,7 +133,7 @@ hardware numbering works on each of the various hardware platforms MPF
 supports, so check that out now and enter your real numbers, not the
 made-up ones we use below.
 
-``` mpf-config
+``` yaml
 switches:
   s_left_flipper:
     number: 0  # this can be blank if you don't have physical hw yet
@@ -160,7 +160,7 @@ Here's an example of how you'd enter your coils for a machine with two
 dual-wound coils. If you have single-wound coils, or you have more than
 two flippers, refer to the [Flippers](../mechs/flippers/index.md) documentation for examples of how to configure them.
 
-``` mpf-config
+``` yaml
 coils:
   c_flipper_left_main:
     number: 0  # again, these numbers will probably be different for you
@@ -210,7 +210,7 @@ flipper. Since the flippers belong to a playfield we also create this
 now. Here's what you would create based on the switches and coils
 we've defined so far:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_left_flipper:
 #!     number: 0
@@ -403,7 +403,7 @@ booting up, rather than them waiting for a ball to start.) So now the
 have single-wound coils, then you won't have the `hold_coil:` entries
 here.)
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_left_flipper:
 #!     number: 0
@@ -470,7 +470,7 @@ list above.
 
 FAST Pinball with FAST IO driver boards:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: fast
   driverboards: fast
@@ -485,7 +485,7 @@ switches:
 
 P-ROC installed in an existing WPC machine:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: p_roc
   driverboards: wpc
@@ -497,7 +497,7 @@ switches:
 
 P3-ROC with P-ROC driver & switch boards:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: p3_roc
   driverboards: pdb
@@ -510,7 +510,7 @@ switches:
 In case you are using
 [the Virtual Pinball (VPX) Platform](../hardware/virtual/virtual_pinball_vpx.md) the config file will look like:
 
-``` mpf-config
+``` yaml
 hardware:
   platform: virtual_pinball
 
@@ -562,7 +562,7 @@ affect your coil and switch numbers). But here's the general idea.
 (This is the exact file we use with a FAST WPC controller plugged into
 an existing *Demolition Man* machine.)
 
-``` mpf-config
+``` yaml
 #config_version=6
 
 hardware:

--- a/docs/tutorial/4_adjust_flipper_power.md
+++ b/docs/tutorial/4_adjust_flipper_power.md
@@ -59,7 +59,7 @@ config, not the `flippers:` section.) So let's try changing your
 flipper coils from the default of 10ms to 20ms. Change your config file
 so it looks like this:
 
-``` mpf-config
+``` yaml
 coils:
   c_flipper_left_main:
     number: 00

--- a/docs/tutorial/5_add_a_display.md
+++ b/docs/tutorial/5_add_a_display.md
@@ -73,7 +73,7 @@ height and width, both defined in terms of the number of pixels. So for
 now, create a single display called "window" set to 800x600 pixels. To
 do this, add the following to your `config.yaml` file:
 
-``` mpf-mc-config
+``` yaml
 displays:
   window:
     width: 800
@@ -161,7 +161,7 @@ In MPF, all slides have names. You can define slides in the `slides:`
 section of the config. So let's create a slide called
 "welcome_slide", like this:
 
-``` mpf-mc-config
+``` yaml
 slides:
   welcome_slide:
 ##! test
@@ -171,7 +171,7 @@ slides:
 Now let's add a `widgets:` section under that slide, then under that,
 we'll start creating some widgets.
 
-``` mpf-mc-config
+``` yaml
 slides:
   welcome_slide:
     widgets:
@@ -184,7 +184,7 @@ common for slides to be made up of lots of widgets). For now let's add
 a text widget that reads "PINBALL!". Do this by adding the following
 to your config:
 
-``` mpf-mc-config
+``` yaml
 slides:
   welcome_slide:
     widgets:
@@ -235,7 +235,7 @@ slide_player watches for certain events to occur, and when they do, it
 
 To see this in action, add the following section to your machine config:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   welcome_slide:
 #!     widgets:
@@ -281,7 +281,7 @@ config file. Since this is a text widget, we can look at the
 For example, let's change the font size and the color, by adding
 `font_size:` and `color:` lines:
 
-``` mpf-mc-config
+``` yaml
 slides:
   welcome_slide:
     widgets:
@@ -314,7 +314,7 @@ slide and that there are lots of different kinds of widgets. Let's add
 a second widget to your welcome slide. This one will be a rectangle
 which appears behind the word "PINBALL!".
 
-``` mpf-mc-config
+``` yaml
 slides:
   welcome_slide:
     widgets:
@@ -368,7 +368,7 @@ event.
 So in your `slides:` section, add another slide called
 `attract_started`, like this:
 
-``` mpf-mc-config
+``` yaml
 slides:
   welcome_slide:
     widgets:
@@ -415,7 +415,7 @@ these as triggers for your slides via the `slide_player:`.
 Anyway, add the `mode_attract_started` to your `slide_player:` like
 this:
 
-``` mpf-mc-config
+``` yaml
 #! slides:
 #!   welcome_slide:
 #!     widgets:

--- a/docs/tutorial/6_keyboard.md
+++ b/docs/tutorial/6_keyboard.md
@@ -30,7 +30,7 @@ want to map them to. (Switches, in this case.)
 Here's an example where we map the left flipper button to the `Z` key
 and the right flipper button to the `?` key:
 
-``` mpf-config
+``` yaml
 keyboard:
   z:
     switch: s_left_flipper

--- a/docs/tutorial/7_trough.md
+++ b/docs/tutorial/7_trough.md
@@ -64,7 +64,7 @@ from filling up with too much gunk.
 For example, if you have a modern style trough with a jam switch, you'd
 add the debug setting like this:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_trough1:
 #!     number: 1

--- a/docs/tutorial/8_plunger.md
+++ b/docs/tutorial/8_plunger.md
@@ -52,7 +52,7 @@ add this to the second device (the one that feeds the plunger).
 
 Tell the playfield to use the plunger for new balls:
 
-``` mpf-config
+``` yaml
 #! switches:
 #!   s_plunger:
 #!     number: 10

--- a/docs/tutorial/9_start_button.md
+++ b/docs/tutorial/9_start_button.md
@@ -15,7 +15,7 @@ First, add the switch for your start button to the `switches:` section
 of your config file. Again this should be easy by now. In this tutorial
 we'll just call this button `s_start` and add it like this:
 
-``` mpf-config
+``` yaml
 switches:
   s_start:
     number: 11
@@ -36,7 +36,7 @@ might not, etc.) So we use a "start" tag behind the scenes to make
 whatever switch you want act as the start button. So now your start
 switch in your `switches:` section should look like this:
 
-``` mpf-config
+``` yaml
 switches:
   s_start:
     number: 11
@@ -56,7 +56,7 @@ hardware. For your start button keyboard key, how about using the `S`
 key? To do so, add an entry like this to the `keyboard:` section of your
 config file:
 
-``` mpf-config
+``` yaml
 keyboard:
   s:
     switch: s_start
@@ -80,7 +80,7 @@ playfield switches with `playfield_active`, so we're just getting
 starting on this now. To do this, create a new entry in your `switches:`
 section for one of your playfield switches, for example:
 
-``` mpf-config
+``` yaml
 switches:
   s_right_inlane:
     number: 12
@@ -93,7 +93,7 @@ purpose tags for [switches](../config/switches.md).
 While you're at it, create a keyboard key mapping for this switch in
 the `keyboard:` section of your config, like this:
 
-``` mpf-config
+``` yaml
 keyboard:
   q:
     switch: s_right_inlane

--- a/includes/troubleshooting_lights.md
+++ b/includes/troubleshooting_lights.md
@@ -3,7 +3,7 @@
 If you got a lot of lights you might run into bus contention issues. You
 can reduce the light update rate in MPF:
 
-``` mpf-config
+``` yaml
 mpf:
   default_light_hw_update_hz: 30   # defaults to 50
 ```


### PR DESCRIPTION
There were over 1k code blocks changed, so it's possible some of them weren't supposed to be yaml-formatted. I could not find evidence that the mpf-config and mpf-mc-config hints to ``` were generating any difference in the output HTML vs. no hint at all. YAML makes a nightmare dom of highlighting every token, but that's probably just how that kind of thing works, huh. I tried copy-paste and found that I could still copy code blocks without any extra garbage creeping in from this formatting.

But please, if anyone hates this or it is in too many places, let me know - I'm happy to put some or all of it back :)