### PR TITLE
fix names that looked like paths in various links

### DIFF
--- a/docs/config/achievements.md
+++ b/docs/config/achievements.md
@@ -85,7 +85,7 @@ achievements:
 More examples:
 
 * [Recipe: The Addams Family Mansion Awards](../cookbook/TAF_mansion_awards.md)
-* [/game_logic/achievements/index](../examples/index.md)
+* [Example MPF projects you can learn from](../examples/index.md)
 
 ## Shows
 
@@ -104,7 +104,7 @@ You can configure achievements to post certain events when they change
 state.
 
 Note that all achievements will by default post events in the form
-[achievement_(name)_[state_(state)](../events/achievement_achievement_state_state.md) when they change state. The events listed below as
+[achievement_(name)\_[state_(state)](../events/achievement_achievement_state_state.md) when they change state. The events listed below as
 `events_when_xxx`, if defined, will replace the default event.
 
 ## Control Events

--- a/docs/config/ball_devices.md
+++ b/docs/config/ball_devices.md
@@ -224,7 +224,7 @@ attempts.
 Unknown type. See description below.
 
 MPF might delay the eject by `eject_coil_max_wait_ms` to ensure
-consistent pulses. See [/mechs/ball_devices/index](psus.md) for details.
+consistent pulses. See [psus:](psus.md) for details.
 
 ### eject_coil_reorder_pulse:
 

--- a/docs/config/coil_overwrites.md
+++ b/docs/config/coil_overwrites.md
@@ -15,8 +15,8 @@ title: "coil_overwrites:"
 Some devices offer one or multiple `coil_overwrites:` settings where you
 can overwrite coil settings.
 
-Most commonly this is used in [/config/autofire_coils](flippers.md)
-and [/config/autofire_coils](autofire_coils.md).
+Most commonly this is used in [flippers:](flippers.md)
+and [autofire_coils:](autofire_coils.md).
 
 ## Optional settings
 
@@ -28,7 +28,7 @@ your config. (If you don't include them, the default will be used).
 Single value, type: float(0,1).
 
 Overwrite the `hold_power` of the coil for this device. See
-`default_hold_power` in [/config/autofire_coils](coils.md) for
+`default_hold_power` in [coils:](coils.md) for
 details.
 
 ### pulse_ms:
@@ -37,14 +37,14 @@ Single value, type: `time string (ms)`
 ([Instructions for entering time strings](instructions/time_strings.md)).
 
 Overwrite the `pulse_ms` of the coil for this device. See
-`default_pulse_ms` in [/config/autofire_coils](coils.md) for details.
+`default_pulse_ms` in [coils:](coils.md) for details.
 
 ### pulse_power:
 
 Single value, type: float(0,1).
 
 Overwrite the `pulse_power` of the coil for this device. See
-`default_pulse_power` in [/config/autofire_coils](coils.md) for
+`default_pulse_power` in [coils:](coils.md) for
 details.
 
 ### recycle:
@@ -52,7 +52,7 @@ details.
 Single value, type: `boolean` (Yes/No or True/False).
 
 Overwrite the `recycle` setting of the coil for this device. See
-`recycle` in [/config/autofire_coils](coils.md) for details.
+`recycle` in [coils:](coils.md) for details.
 
 ## Related How To guides
 

--- a/docs/config/custom_code.md
+++ b/docs/config/custom_code.md
@@ -14,9 +14,9 @@ title: "custom_code:"
 
 The `custom_code:` section of your config is a list where you register
 your custom code classes. You can find an example here:
-[/examples/custom_code/index](../examples/index.md).
+[How to add machine-wide custom code](../code/introduction/machine_code.md).
 
 ## Related How To guides
 
-* [MPF developer
-    documentation](http://developer.missionpinball.org/en/dev/code/machine_code.html).
+* [Adding custom code to your game](../code/index.md).
+* [MPF developer documentation](http://developer.missionpinball.org/en/dev/code/machine_code.html).

--- a/docs/config/dmds.md
+++ b/docs/config/dmds.md
@@ -16,7 +16,7 @@ The `dmds:` section of your config is where you configure the settings
 for physical DMDs (dot matrix displays). You only need this section if
 you have a physical monochrome DMD connected to a 14-pin header on a
 hardware controller. If you have an RGB DMD, configure that in the
-[/displays/dmd](rgb_dmds.md) section.
+[rgb_dmds:](rgb_dmds.md) section.
 
 If you want to show a virtual DMD in an on-screen window, you configure
 that as a display widget with a dot filter. That does not involve this
@@ -79,8 +79,7 @@ Single value, type: `number` (will be converted to floating point).
 Default: `1.0`
 
 Sets the gamma of the DMD. See
-[/displays/dmd](instructions/gamma_correction.md) for
-details.
+[Gamma correction in MPF](instructions/gamma_correction.md) for details.
 
 Note that the default setting of `1.0` means that no gamma correction is
 used. Some physical DMDs do their own internal gamma correction, so this

--- a/docs/config/drop_target_banks.md
+++ b/docs/config/drop_target_banks.md
@@ -122,8 +122,7 @@ Single value, type: `time string (ms)`
 ([Instructions for entering time strings](instructions/time_strings.md)). Default: `100ms`
 
 Max time allowed to delay the pulse of the reset coil. This is used to
-prevent excess power usage. See [/mechs/targets/drop_targets/drop_target_bank](psus.md) for
-details.
+prevent excess power usage. See [psus:](psus.md) for details.
 
 ### reset_coils:
 

--- a/docs/config/drop_targets.md
+++ b/docs/config/drop_targets.md
@@ -163,8 +163,7 @@ Single value, type: `time string (ms)`
 ([Instructions for entering time strings](instructions/time_strings.md)). Default: `100ms`
 
 Max time allowed to delay the pulse of the knockdown coil. This is used
-to prevent excess power usage. See [/mechs/targets/drop_targets/index](psus.md)
-for details.
+to prevent excess power usage. See [psus:](psus.md) for details.
 
 ### knockdown_events:
 
@@ -213,8 +212,7 @@ Single value, type: `time string (ms)`
 ([Instructions for entering time strings](instructions/time_strings.md)). Default: `100ms`
 
 Max time allowed to delay the pulse of the reset coil. This is used to
-prevent excess power usage. See [/mechs/targets/drop_targets/index](psus.md) for
-details.
+prevent excess power usage. See [psus:](psus.md) for details.
 
 ### reset_events:
 

--- a/docs/config/fast.md
+++ b/docs/config/fast.md
@@ -118,8 +118,7 @@ Log level for the console log for this platform.
 
 Single value, type: `boolean` (`true`/`false`). Default: `false`
 
-See the
-[/hardware/fast/index](documentation on the debug setting](config/instructions/debug) for details.
+See the [documentation on the debug setting](instructions/debug.md) for details.
 
 ### dmd_buffer:
 

--- a/docs/config/flippers.md
+++ b/docs/config/flippers.md
@@ -204,7 +204,7 @@ Single value, type:
 Defaults to empty.
 
 Overwrites settings on the hold_coil. See
-[/mechs/flippers/index](coil_overwrites.md) for details.
+[coil_overwrites:](coil_overwrites.md) for details.
 
 ### include_in_ball_search:
 
@@ -231,7 +231,7 @@ Single value, type:
 Defaults to empty.
 
 Overwrites settings on the main_coil. See
-[/mechs/flippers/index](coil_overwrites.md) for details.
+[coil_overwrites:](coil_overwrites.md) for details.
 
 ### playfield:
 
@@ -304,7 +304,7 @@ One or more sub-entries. Each in the format of `string` : `string`
 
 One or more sub-entries, each in the format of `string` : `string`
 Overwrites settings on the activation_switch. See
-[/mechs/flippers/index](switch_overwrites.md) for details.
+[switch_overwrites:](switch_overwrites.md) for details.
 
 ### use_eos:
 

--- a/docs/config/pololu_tic.md
+++ b/docs/config/pololu_tic.md
@@ -15,8 +15,7 @@ title: "pololu_tic:"
 The `pololu_tic:` section of your config is where you configure your
 [Pololu Tic Stepper Controller](../hardware/pololu_tic.md).
 
-See [/hardware/pololu_tic/index](tic_stepper_settings.md) for
-`platform_settings` in your steppers.
+See [tic_stepper_settings:](tic_stepper_settings.md) for `platform_settings` in your steppers.
 
 ## Optional settings
 

--- a/docs/config/rgb_dmds.md
+++ b/docs/config/rgb_dmds.md
@@ -15,7 +15,7 @@ title: "rgb_dmds:"
 The `rgb_dmds:` section of your machine config is where you configure
 the settings for physical RGB DMDs (dot matrix displays). You only need
 this section if you have a RGB DMD connected via USB. If you have a mono
-DMD, configure that in the [/displays/rgb_dmd](dmds.md) section.
+DMD, configure that in the [dmds:](dmds.md) section.
 
 If you want to show a virtual RGB DMD in an on-screen window, you
 configure that as a display widget with a dot filter. You don't need to
@@ -82,9 +82,7 @@ get behind.
 Single value, type: `number` (will be converted to floating point).
 Default: `2.2`
 
-Sets the gamma of the DMD. See
-[/displays/rgb_dmd](instructions/gamma_correction.md) for
-details.
+Sets the gamma of the DMD. See [Gamma correction in MPF](instructions/gamma_correction.md) for details.
 
 Note that the default setting of `2.2` will probably be ok, though if
 your RGB DMD does its own internal gamma correction, you'll want to set

--- a/docs/config/segment_display_player.md
+++ b/docs/config/segment_display_player.md
@@ -19,7 +19,7 @@ title: "segment_display_player:"
 
 The `segment_display_player:` section of your config is a
 [Config Players](../config_players/index.md) which controls
-[/hardware/segment_display_platforms](segment_displays.md). See
+[segment_displays:](segment_displays.md). See
 [Alpha-Numeric / Segment Displays](../mc/displays/alpha_numeric.md) for
 details.
 

--- a/docs/config/shows.md
+++ b/docs/config/shows.md
@@ -13,7 +13,7 @@ title: "shows:"
 |[mode](instructions/mode_config.md) config files|**YES** :white_check_mark:|
 
 The `shows:` section of your config is where you define shows in your
-config. See [/tutorial/16_attract_mode_show](../shows/config_shows.md) for
+config. See [Creating shows in config files](../shows/config_shows.md) for
 details. Furthermore, you can also
 [define shows in separate files](../shows/file_shows.md).
 

--- a/docs/config/state_machine_states.md
+++ b/docs/config/state_machine_states.md
@@ -51,7 +51,7 @@ Single value, type: [show_config:](show_config.md).
 
 A show which is played when the state machine is in this state. This is
 kind of an entry action as you could use `events_when_started` and a
-[/game_logic/logic_blocks/state_machines](show_player.md) to achieve the same. It is
+[show_player:](show_player.md) to achieve the same. It is
 meant as a helper because it is common to play one show per step.
 
 ## Related How To guides

--- a/docs/events/extra_ball_group_extra_ball_group_lit_awarded.md
+++ b/docs/events/extra_ball_group_extra_ball_group_lit_awarded.md
@@ -14,7 +14,7 @@ posted when a player's turn starts if they have a lit extra ball from
 their previous turn. Therefore this event is a good event to use for
 your award slides and shows when a player lights the extra ball, because
 you don't want to use
-[/config/extra_ball_groups](extra_ball_group_extra_ball_group_lit.md)
+[extra_ball_group_extra_ball_group_lit](extra_ball_group_extra_ball_group_lit.md)
 because that is also posted when the player's turn starts and you
 don't want the award show to play again when they're starting their
 turn.

--- a/docs/game_design/game_end_modes.md
+++ b/docs/game_design/game_end_modes.md
@@ -44,7 +44,7 @@ queue_relay_player:
 
 ## Ending the Game by Long-Pressing Start
 
-See [/game_logic/match_mode/index](../cookbook/long_presssing_start_to_end_game.md).
+See [Ending the Current Game by Long-pressing Start](../cookbook/long_presssing_start_to_end_game.md).
 
 ## High Score Mode
 

--- a/docs/game_logic/ball_search/index.md
+++ b/docs/game_logic/ball_search/index.md
@@ -17,7 +17,7 @@ Related Config File Sections:
     Ball search is off by default in MPF because it might hurt users not
     expecting it. In a prototype game it might trigger quite frequently and
     coils can seriously injure humans. To turn it on follow
-    [/events/flipper_cradle_release](configuring_ball_search.md).
+    [How to configure Ball Search](configuring_ball_search.md).
 
 MPF contains ball search functionality which is used to try to dislodge
 a stuck ball if MPF thinks there's a ball loose on the playfield but it

--- a/docs/game_logic/bonus/index.md
+++ b/docs/game_logic/bonus/index.md
@@ -15,7 +15,7 @@ aren't covered by the built-in mode.
 
 Related How To guides:
 
-* [/events/bonus_subtotal](configuring_bonus.md)
+* [How to configure End of Ball Bonus](configuring_bonus.md)
 * [How to design a game in MPF using Modes](../../game_design/index.md)
 
 ## Overview of Bonus Mode

--- a/docs/game_logic/multiballs/index.md
+++ b/docs/game_logic/multiballs/index.md
@@ -23,7 +23,7 @@ automatically re-launched back into play.
 MPF also supports stacking of multiple multiballs at the same time.
 
 Balls can be locked for multiball with the related
-[/events/multiball_multiball_ended](multiball_locks.md) config section.
+[Multiball Locks](multiball_locks.md) config section.
 
 Video about ball locks and multiballs:
 

--- a/docs/hardware/opp/leds.md
+++ b/docs/hardware/opp/leds.md
@@ -44,7 +44,7 @@ have to use channels.
 OPP numbers use the format: `serial_chain`-`card_num`-`index`
 
 `chain_serial` is only relevant if you got multiple chains connected via
-USB. See [/mechs/lights/ws2812](connecting.md) for details about
+USB. See [Connecting OPP to your computer](connecting.md) for details about
 chains. If you only got one chain you can omit this part and your format
 becomes `card_num`-`index`.
 

--- a/docs/logs/CFE-Virtual_Platform-1.md
+++ b/docs/logs/CFE-Virtual_Platform-1.md
@@ -4,7 +4,7 @@ title: "CFE-Virtual_Platform-1: Switch used in virtual_platform_start_active_swi
 
 # CFE-Virtual_Platform-1: Switch used in virtual_platform_start_active_switches was not found in switches section
 
-See [/troubleshooting/index](CFE-Smart_Virtual_Platform-1.md) which
+See [CFE-Smart_Virtual_Platform-1](CFE-Smart_Virtual_Platform-1.md) which
 is exactly the same error.
 
 ## Need more help troubleshooting?

--- a/docs/logs/CFE-show-1.md
+++ b/docs/logs/CFE-show-1.md
@@ -49,7 +49,7 @@ shows:
         led1: off
 ```
 
-See [/shows/index](../shows/config_shows.md) for details.
+See [Creating shows in config files](../shows/config_shows.md) for details.
 
 ## Common Pitfalls
 

--- a/docs/logs/RE-MPF-MC_BCP_Server-1.md
+++ b/docs/logs/RE-MPF-MC_BCP_Server-1.md
@@ -4,7 +4,7 @@ title: "RE-MPF-MC_BCP_Server-1: Failed to bind BCP Socket to localhost on port 5
 
 # RE-MPF-MC_BCP_Server-1: Failed to bind BCP Socket to localhost on port 5050
 
-See [/troubleshooting/index](RE-MPF_BCP_Server-1.md) which is exactly
+See [RE-MPF_BCP_Server-1](RE-MPF_BCP_Server-1.md) which is exactly
 the same error.
 
 ## Need more help troubleshooting?

--- a/docs/mc/slides/creating_slides.md
+++ b/docs/mc/slides/creating_slides.md
@@ -101,7 +101,7 @@ help you keep everything more organized.
 The [slide_player:](../../config/slide_player.md) section of a
 machine-wide or mode config is where you tell MPF to show (or "play")
 a specific slide when some event occurs. Full documentation for the
-slide_player is in the [/config/slide_player](showing_slides.md)
+slide_player is in the [How to Show a Slide on a Display](showing_slides.md)
 section of the documentation.
 
 You can define slides in the slide_player like this:

--- a/docs/mechs/coils/dual_wound_coils.md
+++ b/docs/mechs/coils/dual_wound_coils.md
@@ -108,5 +108,5 @@ devices such as [flippers:](../../config/flippers.md).
 
 ## Related How To guides
 
-* [/mechs/flippers/dual_wound](dual_vs_single_wound.md)
+* [Dual-Wound versus Single-Wound coils](dual_vs_single_wound.md)
 * [How to configure dual-wound flippers](../flippers/dual_wound.md)

--- a/docs/mechs/diverters/index.md
+++ b/docs/mechs/diverters/index.md
@@ -193,8 +193,8 @@ For
 
 ## Related How To guides
 
-* [/events/diverter_diverter_deactivating](dual_coil_diverter.md)
-* [/events/diverter_diverter_deactivating](up_down_ramps.md)
+* [Dual Coil Diverter](dual_coil_diverter.md)
+* [Up-Down Ramps](up_down_ramps.md)
 
 ## Related Events
 

--- a/docs/mechs/flippers/dual_wound.md
+++ b/docs/mechs/flippers/dual_wound.md
@@ -35,7 +35,7 @@ take a look at the coil that your flipper uses. If it has three wires
 this guide is for you.
 
 If it has two wires (or two tabs), then read the
-[/mechs/coils/dual_vs_single_wound](single_wound.md) guide.
+[How to configure single-wound flippers](single_wound.md) guide.
 
 Read more about "dual wound" versus "single wound" coils in the
 [Dual-Wound versus Single-Wound coils](../coils/dual_vs_single_wound.md) guide.

--- a/docs/mechs/flippers/single_wound.md
+++ b/docs/mechs/flippers/single_wound.md
@@ -14,7 +14,7 @@ wires (or two tabs to connect two wires), then it's a single-wound coil
 and this guide is for you.
 
 If it has three wires (or three tabs), then read the
-[/hardware/numbers](dual_wound.md) guide.
+[How to configure dual-wound flippers](dual_wound.md) guide.
 
 Read more about "dual wound" versus "single wound" coils in the
 [Dual-Wound versus Single-Wound coils](../coils/dual_vs_single_wound.md) guide.

--- a/docs/mechs/lights/leds.md
+++ b/docs/mechs/lights/leds.md
@@ -45,8 +45,8 @@ Overview video about serial LEDs:
 
 ### Hardware
 
-There are two common types of serial LEDs: WS281x and LPD880x. (See
-[/tutorial/17_add_lights_leds](ws2812.md) for more details about
+There are two common types of serial LEDs: WS281x and LPD880x. (See:
+[WS2811 and WS2812 LEDs in Pinball](ws2812.md) for more details about
 WS2811/WS2812 in pinball.) Those LEDs are chained which means that the
 controller only connects to the first LED. The first LED will connect to
 the second. The second to the third and so on.

--- a/docs/mechs/magnets/index.md
+++ b/docs/mechs/magnets/index.md
@@ -106,15 +106,15 @@ For
 
 ## Related How To guides
 
-[/events/magnet_magnet_flinged_ball](stern_magnet_pcb.md)
+[How to use the Stern Magnet Processor Board](stern_magnet_pcb.md)
 
 ## Related Events
 
-* [magnet_(name)_grabbing_ball](../../events/magnet_magnet_grabbing_ball.md)
-* [magnet_(name)_grabbed_ball](../../events/magnet_magnet_grabbed_ball.md)
-* [magnet_(name)_releasing_ball](../../events/magnet_magnet_releasing_ball.md)
-* [magnet_(name)_released_ball](../../events/magnet_magnet_released_ball.md)
-* [magnet_(name)_flinging_ball](../../events/magnet_magnet_flinging_ball.md)
-* [magnet_(name)_flinged_ball](../../events/magnet_magnet_flinged_ball.md)
+* [magnet_(name)\_grabbing_ball](../../events/magnet_magnet_grabbing_ball.md)
+* [magnet_(name)\_grabbed_ball](../../events/magnet_magnet_grabbed_ball.md)
+* [magnet_(name)\_releasing_ball](../../events/magnet_magnet_releasing_ball.md)
+* [magnet_(name)\_released_ball](../../events/magnet_magnet_released_ball.md)
+* [magnet_(name)\_flinging_ball](../../events/magnet_magnet_flinging_ball.md)
+* [magnet_(name)\_flinged_ball](../../events/magnet_magnet_flinged_ball.md)
 
 * [How to use the Stern Magnet Processor Board](stern_magnet_pcb.md)

--- a/docs/mechs/plungers/auto_manual.md
+++ b/docs/mechs/plungers/auto_manual.md
@@ -23,9 +23,9 @@ Here's an example of this:
 ![image](../images/auto_launcher_bottom.jpg)
 
 If you have a purely mechanical plunger with no autolaunch option,
-follow the [/mechs/playfields/ball_tracking](mechanical_with_switch.md) guide
+follow the [Mechanical (spring) plungers](mechanical_with_switch.md) guide
 instead. If you have a standard coil-fired plunger or launch device with
-no mechanical spring plunger, follow the [/mechs/playfields/ball_tracking](coil_fired.md) guide instead.
+no mechanical spring plunger, follow the [Coil-fired plungers / ball launchers](coil_fired.md) guide instead.
 
 !!! note
 

--- a/docs/mechs/plungers/coil_fired.md
+++ b/docs/mechs/plungers/coil_fired.md
@@ -26,7 +26,7 @@ attached to the arm to launch the ball into play:
 Note that if you have a coil-fired ball launcher that's combined with a
 spring plunger (giving the option for manual spring launches or
 machine-controlled auto launches, stop here and follow the
-[/mechs/playfields/ball_tracking](auto_manual.md) guide instead.
+[Combo (mechanical + coil-fired) plungers](auto_manual.md) guide instead.
 
 ## 1. Add the switches
 

--- a/docs/mechs/plungers/mechanical_no_switch.md
+++ b/docs/mechs/plungers/mechanical_no_switch.md
@@ -37,7 +37,7 @@ tell MPF that there's a ball in the plunger waiting to be plunged.
 
 However, this How To guide is for plunger lanes with no ball switch. (If
 your plunger lane has a ball switch, then follow the
-[/game_logic/ball_saves/index](mechanical_with_switch.md) guide instead.)
+[Mechanical (spring) plungers](mechanical_with_switch.md) guide instead.)
 
 In machines where the plunger lane does not have a ball switch, that
 means that MPF has no idea whether a ball is in the plunger lane.

--- a/docs/mechs/plungers/mechanical_with_switch.md
+++ b/docs/mechs/plungers/mechanical_with_switch.md
@@ -19,10 +19,10 @@ which is activated by a ball waiting to be plunged, like this:
 ![image](../images/plunger_with_switch.jpg)
 
 If you have a mechanical spring plunger but you do NOT have a switch
-there, then follow the [/mechs/playfields/ball_tracking](mechanical_no_switch.md) guide instead.
+there, then follow the [Plunger lanes with no ball switch](mechanical_no_switch.md) guide instead.
 
 If you have a mechanical spring plunger that also has an "auto launch"
-coil fired option, then follow the [/mechs/playfields/ball_tracking](auto_manual.md) guide instead.
+coil fired option, then follow the [Combo (mechanical + coil-fired) plungers](auto_manual.md) guide instead.
 
 ## 1. Add the switch
 

--- a/docs/mechs/switches/optos.md
+++ b/docs/mechs/switches/optos.md
@@ -86,7 +86,7 @@ Common parts:
 
 Have a look at our [PCB section of
 hardware.missionpinball.org](https://hardware.missionpinball.org/pcbs.html)
-for DIY designs. Have a look at [/config/switches](breakout_boards.md) for details about breakout boards.
+for DIY designs. Have a look at [Breakout Boards](breakout_boards.md) for details about breakout boards.
 
 ### Current Limiting Resistor
 
@@ -109,7 +109,7 @@ Common parts:
 
 Have a look at our [PCB section of
 hardware.missionpinball.org](https://hardware.missionpinball.org/pcbs.html)
-for DIY designs. Have a look at [/config/switches](breakout_boards.md) for details about breakout boards.
+for DIY designs. Have a look at [Breakout Boards](breakout_boards.md) for details about breakout boards.
 
 ## Common Parts in Pinball Machines
 

--- a/docs/mechs/switches/start_tournament_and_launcher_buttons.md
+++ b/docs/mechs/switches/start_tournament_and_launcher_buttons.md
@@ -53,5 +53,5 @@ You might want to integrate the button into your attract light show.
 Related How To guides:
 
 * [Tutorial step 9. Add the start button](../../tutorial/9_start_button.md)
-* [/mechs/lights/matrix_lights](mechanical_switches.md)
+* [Mechanical Switches](mechanical_switches.md)
 * [Matrix Lights (Bulbs)](../lights/matrix_lights.md)

--- a/docs/mechs/troughs/classic_single_ball.md
+++ b/docs/mechs/troughs/classic_single_ball.md
@@ -25,7 +25,7 @@ side view)
 ![image](../images/classic_single_ball.png)
 
 We assume that your machine has a shooter lane switch. If that is not
-the case see [/mechs/plungers/index](classic_single_ball_no_shooter_lane.md).
+the case see [Classic Single Ball - No shooter lane](classic_single_ball_no_shooter_lane.md).
 
 ## 1. Add the drain and plunger switch
 

--- a/docs/mechs/troughs/classic_single_ball_no_shooter_lane.md
+++ b/docs/mechs/troughs/classic_single_ball_no_shooter_lane.md
@@ -1,6 +1,5 @@
 ---
-title: How to configure a classic single-ball trough without shooter
-  lane
+title: How to configure a classic single-ball trough without shooter lane
 ---
 
 Related Config File Sections:

--- a/docs/mechs/troughs/modern_opto.md
+++ b/docs/mechs/troughs/modern_opto.md
@@ -83,7 +83,7 @@ other positions are typically covered by normal switches. Transmitter
 contains current limiting circuit and you can connect it directly to 5V.
 The receiver needs to be powered and also inverts the optos. There is
 typically no need to set `NC` on using those boards. You can follow the
-[/mechs/plungers/index](modern_mechanical.md) guide to configure
+[Modern Mechanical](modern_mechanical.md) guide to configure
 your trough.
 
 ### Spike Trough Opto Boards:

--- a/includes/config_error_footer.md
+++ b/includes/config_error_footer.md
@@ -1,15 +1,15 @@
 ## Need more help troubleshooting?
 
-Have a look at our [/troubleshooting/index](/troubleshooting) section. It might give you some hints for certain classes of
+Have a look at our [troubleshooting](/troubleshooting.md) section. It might give you some hints for certain classes of
 problems.
 
 ## What if this did not fix your problem?
 
 Please tell us about your error in the [community forum](../community/index.md) and we might
 be able to update this page afterwards. Or even better:
-[You help us to update it afterwards](/about/help_docs).
+[You help us to update it afterwards](/about/help_docs.md).
 
 ## Is something missing here? Do you have a helpful hint for others experiencing this error?
 
 Please
-[create a Pull Request and add it](/about/help_docs). Alternatively, please tell us in the [community forum](../community/index.md).
+[create a Pull Request and add it](/about/help_docs.md). Alternatively, please tell us in the [community forum](../community/index.md).


### PR DESCRIPTION
Did another big sweep of link name errors

I'm pretty sure that config_error_footer.md is unused