### PR TITLE
More code formatting

### DIFF
--- a/docs/code/BCP_Protocol/index.md
+++ b/docs/code/BCP_Protocol/index.md
@@ -51,19 +51,19 @@ In all commands referenced below, the `\n` terminator is implicit. Some characte
 
 When a connection is initially established, the pinball controller transmits the following command:
 
-```
+``` console
 hello?version=1.0
 ```
 
 …where 1.0 is the version of the Backbox protocol it wants to speak. The media controller may reply with one of two responses:
 
-```
+``` console
 hello?version=1.0
 ```
 
 …indicating that it can speak the protocol version named, and reporting the version it speaks, or
 
-```
+``` console
 error?message=unknown protocol version
 ```
 

--- a/docs/code/BCP_Protocol/mode_list.md
+++ b/docs/code/BCP_Protocol/mode_list.md
@@ -11,7 +11,7 @@ Pin controller
 Type: JSON Array
 
 Example (Formatted for legibility; the parameter does not contain line-breaks):
-```
+``` json
 {
     "running_modes": [
         [

--- a/docs/code/BCP_Protocol/switch.md
+++ b/docs/code/BCP_Protocol/switch.md
@@ -1,13 +1,13 @@
 # switch (BCP command)
 Indicates that the other side should process the changed state of a switch. When sent from the media controller to the pin controller, this is typically used to implement a virtual keyboard interface via the media controller (where the player can activate pinball machine switches via keyboard keys for testing). For example, for the media controller to tell the pin controller that the player just pushed the start button, the command would be:
 
-```
+``` console
 switch?name=start&state=1
 ```
 
 followed very quickly by
 
-```
+``` console
 switch?name=start&state=0
 ```
 
@@ -17,7 +17,8 @@ When sent from the pin controller to the media controller, this is used to send 
 Pin controller or media controller
 
 ## Parameters
-## name
+
+### name
 Type: `string`
 
 This is the name of the switch.

--- a/docs/code/Writing_Tests/RunUnitTests.md
+++ b/docs/code/Writing_Tests/RunUnitTests.md
@@ -3,7 +3,7 @@
 
 Once MPF is installed, you can run some automated tests to make sure that everything is working. To do this, open a command prompt, and then type the following command and then press <enter>:
 
-```
+``` console
 python3 -m unittest discover mpf/tests
 ```
 
@@ -13,7 +13,7 @@ When you do this, you should see a bunch of dots on the screen (one for each tes
 
 The important thing is that when the tests are done, you should have a message like this:
 
-```
+``` console
 Ran 587 tests in 27.121s
 
 OK
@@ -27,7 +27,7 @@ These tests are the actual tests that the developers of MPF use to test MPF itse
 
 Remember though that MPF is actually two separate parts, the MPF game engine and the MPF media controller. The command you run just tested the game engine, so now let’s test the media controller. To do this, run the following command (basically the same thing as last time but with an “mc” added to the end, like this):
 
-```
+``` console
 python3 -m unittest discover mpfmc/tests
 ```
 

--- a/docs/code/Writing_Tests/WritingCustomTestsForYourMachine.md
+++ b/docs/code/Writing_Tests/WritingCustomTestsForYourMachine.md
@@ -51,7 +51,7 @@ These test methods will also load the machine config files (just like if the com
 
 Anyway, in our test method, we have the only actual line that does anything:
 
-```
+``` python
 self.assertModeRunning('attract')
 ```
 
@@ -82,7 +82,7 @@ That warning about the deprecation can be ignored (if you even have it.. you mig
 
 When you’re writing unit tests, you’ll end up dealing with failed tests a lot! So let’s purposefully change the test so it fails. In this case, change the line which asserts a mode called “attract” is running to look for a mode called “foo” instead, like this:
 
-```
+``` python
 self.assertModeRunning('foo')
 ```
 

--- a/docs/code/Writing_Tests/WritingCustomTestsForYourMachine.md
+++ b/docs/code/Writing_Tests/WritingCustomTestsForYourMachine.md
@@ -63,7 +63,7 @@ You can run your tests via the command prompt from your machine folder. (In othe
 
 The exact command to run is `python -m unittest`. This should produce output similar to the following:
 
-```
+``` console
 C:\pinball\your_machine>python -m unittest
 C:\Python34\lib\imp.py:32: PendingDeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
   PendingDeprecationWarning)
@@ -88,7 +88,7 @@ self.assertModeRunning('foo')
 
 Save the file and rerun the tests and you should see results like this:
 
-```
+``` console
 C:\pinball\your_machine>python -m unittest
 C:\Python34\lib\imp.py:32: PendingDeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
   PendingDeprecationWarning)

--- a/docs/code/api_reference/misc_components/Players.md
+++ b/docs/code/api_reference/misc_components/Players.md
@@ -17,7 +17,7 @@ This Player class is responsible for tracking player variables which is a dictio
 
 First, player variables can be accessed as attributes of the player object directly. For example, to set a player variable foo for the current player, you could use:
 
-```
+``` python
 self.machine.player.foo = 0
 ```
 
@@ -25,7 +25,7 @@ If that variable didn’t exist, it will be automatically created.
 
 You can get the value of player variables by accessing them directly. For example:
 
-```
+``` python
 print(self.machine.player.foo)  # prints 0
 ```
 
@@ -44,7 +44,7 @@ For the change parameter, it will attempt to subtract the old value from the new
 
 For examples, the following three lines:
 
-```
+``` python
 self.machine.player.score = 0
 self.machine.player.score += 500
 self.machine.player.score = 1200

--- a/docs/code/api_reference/misc_components/RGBAColor.md
+++ b/docs/code/api_reference/misc_components/RGBAColor.md
@@ -34,6 +34,9 @@ Parameters:
 
 Returns: An RGBColor object that is a blend between the start and end
 
+`red`
+
+Return the red component of the RGB color representation.
 
 `blue`
 
@@ -54,7 +57,7 @@ Convert a HEX color representation to an RGB color representation.
 Parameters:
 
 * **hex_string** – The 3- or 6-char hexadecimal string representing the color value.
-* **default** – The default value to return if _hex is invalid.
+* **default** – The default value to return if \_hex is invalid.
 
 Returns: RGB representation of the input HEX value as a 3-item tuple
 with each item being an integer 0-255.
@@ -76,9 +79,6 @@ If the name is not found, the default value is returned. :param name: A standard
 Generate a uniformly random RGB value.
 Returns:	A tuple of three integers with values between 0 and 255 inclusive
 
-`red`
-
-Return the red component of the RGB color representation.
 
 `rgb`
 

--- a/docs/code/api_reference/misc_components/RGBAColor.md
+++ b/docs/code/api_reference/misc_components/RGBAColor.md
@@ -88,7 +88,7 @@ Return an RGB representation of the color.
 
 Convert an RGB color representation to a HEX color representation.
 
-```
+``` python
 (r, g, b) :: r -> [0, 255]
 g -> [0, 255] b -> [0, 255]
 ```

--- a/docs/code/api_reference/misc_components/RGBColor.md
+++ b/docs/code/api_reference/misc_components/RGBColor.md
@@ -80,19 +80,15 @@ If the name is not found, the default value is returned. :param name: A standard
 Generate a uniformly random RGB value.
 Returns:	A tuple of three integers with values between 0 and 255 inclusive
 
-`red
+`rgb`
 
-Return the red component of the RGB color representation.
-
-`rgb
-`
 Return an RGB representation of the color.
 
 `static rgb_to_hex(rgb: Tuple[int, int, int]) → str`
 
 Convert an RGB color representation to a HEX color representation.
 
-```
+``` python
 (r, g, b) :: r -> [0, 255]
 g -> [0, 255] b -> [0, 255]
 ```

--- a/docs/code/api_reference/misc_components/RGBColor.md
+++ b/docs/code/api_reference/misc_components/RGBColor.md
@@ -32,8 +32,12 @@ Parameters:
 * **end_color** – The end color
 * **fraction** – The fraction between 0 and 1 that is used to set the blend point between the two colors.
 
-Returns: An RGBColor object that is a blend between the start and end
+Returns: An RGBColor object that is a blend between the start and end.
 
+
+`red`
+
+Return the red component of the RGB color representation.
 
 `blue`
 
@@ -54,7 +58,7 @@ Convert a HEX color representation to an RGB color representation.
 Parameters:
 
 * **hex_string** – The 3- or 6-char hexadecimal string representing the color value.
-* **default** – The default value to return if _hex is invalid.
+* **default** – The default value to return if \_hex is invalid.
 
 Returns: RGB representation of the input HEX value as a 3-item tuple
 with each item being an integer 0-255.

--- a/docs/code/api_reference/misc_components/UtilityFunctions.md
+++ b/docs/code/api_reference/misc_components/UtilityFunctions.md
@@ -55,22 +55,22 @@ For example, in the traditional python dictionary update() methods, if a diction
 
 Consider the following example:
 
-Original dictionary: config[‘foo’][‘bar’] = 1
+Original dictionary: `config['foo']['bar'] = 1`
 
-New dictionary we’re merging in: config[‘foo’][‘other_bar’] = 2
+New dictionary we’re merging in: `config['foo']['other_bar'] = 2`
 
 Default python dictionary update() method would have the updated dictionary as this:
 
-```
-{‘foo’: {‘other_bar’: 2}}
+``` python
+{'foo': {'other_bar': 2}}
 ```
 
 This happens because the original dictionary which had the single key bar was overwritten by a new dictionary which has a single key other_bar.)
 
 But really we want this:
 
-```
-{‘foo’: {‘bar’: 1, ‘other_bar’: 2}}
+``` python
+{'foo': {'bar': 1, 'other_bar': 2}}
 ```
 
 This code was based on this: https://www.xormedia.com/recursively-merge-dictionaries-in-python/

--- a/docs/code/api_reference/testing_class_api/MpfBcpTestCase.md
+++ b/docs/code/api_reference/testing_class_api/MpfBcpTestCase.md
@@ -474,9 +474,9 @@ Returns:	String name of the platform this test class will use.
 
 If you don’t include this method in your test class, the platform will be set to virtual. If you want to use the smart virtual platform, you would add the following to your test class:
 
-```
+``` python
 def get_platform(self):
-  return 'smart_virtual`
+  return 'smart_virtual'
 ```
 
 `get_use_bcp()
@@ -658,5 +658,3 @@ Tear down test.
 Return the verbosity setting of the currently running unittest program, or 0 if none is running.
 
 Returns: An integer value of the current verbosity setting.
-
-

--- a/docs/code/api_reference/testing_class_api/MpfBcpTestCase.md
+++ b/docs/code/api_reference/testing_class_api/MpfBcpTestCase.md
@@ -27,7 +27,7 @@ This method will cause anything scheduled during the time to run, including thin
 
 Advancing the clock will happen in multiple small steps if things are scheduled to happen during this advance. For example, you can advance the clock 10 seconds like this:
 
-```
+``` python
 self.advance_time_and_run(10)
 ```
 
@@ -63,13 +63,13 @@ Parameters:
 
 An unordered sequence comparison asserting that the same elements, regardless of order. If the same element occurs more than once, it verifies that the elements occur the same number of times.
 
-```
+``` python
 self.assertEqual(Counter(list(first)),
   Counter(list(second)))
 ```
 
 Example:
-```
+``` python
 [0, 1, 1] and [1, 0, 1] compare equal.
 [0, 0, 1] and [0, 1] compare unequal.
 ```
@@ -97,7 +97,7 @@ Note that the event must be mocked via self.mock_event() first in order to use t
 
 For example:
 
-```
+``` python
 self.mock_event('my_event')
 self.assertEventNotCalled('my_event')  # This will pass
 
@@ -121,7 +121,7 @@ Parameters:
 
 For example:
 
-```
+``` python
 self.mock_event('jackpot')
 
 self.post_event('jackpot', count=1, first_time=True)
@@ -226,7 +226,7 @@ This method must be used as a context manager, and will yield a recording object
 
 Example:
 
-```
+``` python
 with self.assertLogs('foo', level='INFO') as cm:
   logging.getLogger('foo').info('first message')
   logging.getLogger('foo.bar').error('second message')
@@ -300,15 +300,16 @@ Fail unless an exception of class expected_exception is raised by the callable w
 
 If called with the callable and arguments omitted, will return a context object used like this:
 
-```
+``` python
 with self.assertRaises(SomeException):
   do_something()
 ```
+
 An optional keyword argument ‘msg’ can be provided when assertRaises is used as a context object.
 
 The context manager keeps a reference to the exception as the ‘exception’ attribute. This allows you to inspect the exception after the assertion:
 
-```
+``` python
 with self.assertRaises(SomeException) as cm:
   do_something()
 the_exception = cm.exception
@@ -380,7 +381,7 @@ Fail unless a warning of class warnClass is triggered by the callable when invok
 
 If called with the callable and arguments omitted, will return a context object used like this:
 
-```
+``` python
 with self.assertWarns(SomeWarning):
   do_something()
 ```
@@ -389,7 +390,7 @@ An optional keyword argument ‘msg’ can be provided when assertWarns is used 
 
 The context manager keeps a reference to the first matching warning as the ‘warning’ attribute; similarly, the ‘filename’ and ‘lineno’ attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
 
-```
+``` python
 with self.assertWarns(SomeWarning) as cm:
   do_something()
 the_warning = cm.warning
@@ -429,7 +430,7 @@ Returns:	A string name of the machine config file to use, complete with the .yam
 
 For example:
 
-```
+``` python
 def get_config_file(self):
   return 'my_config.yaml'
 ```
@@ -442,10 +443,10 @@ Returns: True or False
 
 The default is False. To load plugins in your test class, add the following:
 
-```
+``` python
 def get_enable_plugins(self):
   return True
-`
+```
 
 `get_machine_path()`
 
@@ -456,7 +457,7 @@ Returns:	A string name of the machine path to use
 
 For example:
 
-```
+``` python
 def get_machine_path(self):
   return 'tests/machine_files/my_test/'
 ```
@@ -487,7 +488,7 @@ Returns: True or False
 
 The default is False. To use BCP in your test class, add the following:
 
-```
+``` python
 def get_use_bcp(self):
   return True
 ```
@@ -547,7 +548,7 @@ Mocking an event will not “break” it. In other words, any other registered h
 
 For example:
 
-```
+``` python
 self.mock_event('my_event')
 self.assertEventNotCalled('my_event')  # This will be True
 self.post_event('my_event')
@@ -565,13 +566,13 @@ Parameters:
 
 For example, to post an event called “shot1_hit”:
 
-```
+``` python
 self.post_event('shot1_hit')
 ```
 
 To post an event called “tilt” and then advance the time 1.5 seconds:
 
-```
+``` python
 self.post_event('tilt', 1.5)
 ```
 
@@ -586,7 +587,7 @@ Parameters:
 
 For example, to post an event called “jackpot” with the parameters count=1 and first_time=True, you would use:
 
-```
+``` python
 self.post_event('jackpot', count=1, first_time=True)
 ```
 

--- a/docs/code/api_reference/testing_class_api/MpfFakeGameTestCase.md
+++ b/docs/code/api_reference/testing_class_api/MpfFakeGameTestCase.md
@@ -23,7 +23,7 @@ This method hits and releases a switch called s_start and then verifies that the
 
 You can call this method multiple times to add multiple players. For example, to start a game and then add 2 additional players (for 3 players total), you would use:
 
-```
+``` python
 self.start_game()
 self.add_player()
 self.add_player()
@@ -70,7 +70,7 @@ Raises: Assertion error if there is no game in progress or if – the current ba
 
 The following code will check to make sure the game is on Ball 1:
 
-```
+``` python
 self.assertBallNumber(1)
 ```
 
@@ -107,10 +107,11 @@ self.assertEqual(Counter(list(first)),
 Counter(list(second)))
 
 Example:
-```
+``` python
 [0, 1, 1] and [1, 0, 1] compare equal.
 [0, 0, 1] and [0, 1] compare unequal.
 ```
+
 `assertDictContainsSubset(subset, dictionary, msg=None)`
 
 Checks whether dictionary is a superset of subset.
@@ -134,7 +135,7 @@ Note that the event must be mocked via self.mock_event() first in order to use t
 
 For example:
 
-```
+``` python
 self.mock_event('my_event')
 self.assertEventNotCalled('my_event')  # This will pass
 
@@ -158,7 +159,7 @@ Parameters:
 
 For example:
 
-```
+``` python
 self.mock_event('jackpot')
 
 self.post_event('jackpot', count=1, first_time=True)
@@ -187,7 +188,7 @@ Assert a game is not running.
 
 Example:
 
-```
+``` python
 self.assertGameIsNotRunning()
 ```
 
@@ -197,7 +198,7 @@ Assert a game is running.
 
 Example:
 
-```
+``` python
 self.assertGameIsRunning()
 ```
 
@@ -356,7 +357,7 @@ Parameters:
 
 For example, to assert that the to players are in the game:
 
-```
+``` python
 self.assertPlayerCount(2)
 ```
 
@@ -379,7 +380,7 @@ Fail unless an exception of class expected_exception is raised by the callable w
 
 If called with the callable and arguments omitted, will return a context object used like this:
 
-```
+``` python
 with self.assertRaises(SomeException):
 do_something()
 ```
@@ -388,7 +389,7 @@ An optional keyword argument ‘msg’ can be provided when assertRaises is used
 
 The context manager keeps a reference to the exception as the ‘exception’ attribute. This allows you to inspect the exception after the assertion:
 
-```
+``` python
 with self.assertRaises(SomeException) as cm:
 do_something()
 the_exception = cm.exception
@@ -460,7 +461,7 @@ Fail unless a warning of class warnClass is triggered by the callable when invok
 
 If called with the callable and arguments omitted, will return a context object used like this:
 
-```
+``` python
 with self.assertWarns(SomeWarning):
 do_something()
 ```
@@ -469,7 +470,7 @@ An optional keyword argument ‘msg’ can be provided when assertWarns is used 
 
 The context manager keeps a reference to the first matching warning as the ‘warning’ attribute; similarly, the ‘filename’ and ‘lineno’ attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
 
-```
+``` python
 with self.assertWarns(SomeWarning) as cm:
 do_something()
 the_warning = cm.warning
@@ -525,7 +526,7 @@ Returns:	A string name of the machine config file to use, complete with the .yam
 
 For example:
 
-```
+``` python
 def get_config_file(self):
 return 'my_config.yaml'
 ```
@@ -538,7 +539,7 @@ Returns: True or False
 
 The default is False. To load plugins in your test class, add the following:
 
-```
+``` python
 def get_enable_plugins(self):
 return True
 ```
@@ -552,7 +553,7 @@ Returns:	A string name of the machine path to use
 
 For example:
 
-```
+``` python
 def get_machine_path(self):
 return 'tests/machine_files/my_test/'
 ```
@@ -583,7 +584,7 @@ Returns: True or False
 
 The default is False. To use BCP in your test class, add the following:
 
-```
+``` python
 def get_use_bcp(self):
 return True
 ```
@@ -640,7 +641,7 @@ Mocking an event will not “break” it. In other words, any other registered h
 
 For example:
 
-```
+``` python
 self.mock_event('my_event')
 self.assertEventNotCalled('my_event')  # This will be True
 self.post_event('my_event')
@@ -675,7 +676,7 @@ Parameters:
 
 For example, to post an event called “jackpot” with the parameters count=1 and first_time=True, you would use:
 
-```
+``` python
 self.post_event('jackpot', count=1, first_time=True)
 ```
 
@@ -718,7 +719,7 @@ This is needed for tests where you don’t have any ball devices and other situa
 
 Example:
 
-```
+``` python
 self.set_num_balls_known(3)
 ```
 
@@ -754,7 +755,7 @@ This method asserts that a game is running, then call’s the game mode’s end_
 
 Example:
 
-```
+``` python
 self.stop_game()
 ```
 

--- a/docs/code/api_reference/testing_class_api/MpfFakeGameTestCase.md
+++ b/docs/code/api_reference/testing_class_api/MpfFakeGameTestCase.md
@@ -283,12 +283,11 @@ This method must be used as a context manager, and will yield a recording object
 
 Example:
 
-```
+``` python
 with self.assertLogs('foo', level='INFO') as cm:
 logging.getLogger('foo').info('first message')
 logging.getLogger('foo.bar').error('second message')
-self.assertEqual(cm.output, ['INFO:foo:first message',
- 'ERROR:foo.bar:second message'])
+self.assertEqual(cm.output, ['INFO:foo:first message', 'ERROR:foo.bar:second message'])
 ```
 
 `assertMachineVarEqual(value, machine_var)`
@@ -571,9 +570,9 @@ Returns:	String name of the platform this test class will use.
 
 If you don’t include this method in your test class, the platform will be set to virtual. If you want to use the smart virtual platform, you would add the following to your test class:
 
-```
+``` python
 def get_platform(self):
-return 'smart_virtual`
+return 'smart_virtual'
 ```
 
 `get_use_bcp()`

--- a/docs/code/api_reference/testing_class_api/MpfGameTestCase.md
+++ b/docs/code/api_reference/testing_class_api/MpfGameTestCase.md
@@ -21,7 +21,7 @@ This method hits and releases a switch called s_start and then verifies that the
 
 You can call this method multiple times to add multiple players. For example, to start a game and then add 2 additional players (for 3 players total), you would use:
 
-```
+``` python
 self.start_game()
 self.add_player()
 self.add_player()
@@ -112,7 +112,7 @@ Counter(list(second)))
 
 Example:
 
-```
+``` python
 [0, 1, 1] and [1, 0, 1] compare equal.
 [0, 0, 1] and [0, 1] compare unequal.
 ```
@@ -140,7 +140,7 @@ Note that the event must be mocked via self.mock_event() first in order to use t
 
 For example:
 
-```
+``` python
 self.mock_event('my_event')
 self.assertEventNotCalled('my_event')  # This will pass
 
@@ -164,7 +164,7 @@ Parameters:
 
 For example:
 
-```
+``` python
 self.mock_event('jackpot')
 
 self.post_event('jackpot', count=1, first_time=True)
@@ -193,7 +193,7 @@ Assert a game is not running.
 
 Example:
 
-```
+``` python
 self.assertGameIsNotRunning()
 ```
 
@@ -203,7 +203,7 @@ Assert a game is running.
 
 Example:
 
-```
+``` python
 self.assertGameIsRunning()
 ```
 
@@ -289,12 +289,11 @@ This method must be used as a context manager, and will yield a recording object
 
 Example:
 
-```
+``` python
 with self.assertLogs('foo', level='INFO') as cm:
 logging.getLogger('foo').info('first message')
 logging.getLogger('foo.bar').error('second message')
-self.assertEqual(cm.output, ['INFO:foo:first message',
-'ERROR:foo.bar:second message'])
+self.assertEqual(cm.output, ['INFO:foo:first message', 'ERROR:foo.bar:second message'])
 ```
 
 `assertMachineVarEqual(value, machine_var)`
@@ -387,7 +386,7 @@ Fail unless an exception of class expected_exception is raised by the callable w
 
 If called with the callable and arguments omitted, will return a context object used like this:
 
-```
+``` python
 with self.assertRaises(SomeException):
 do_something()
 ```
@@ -396,7 +395,7 @@ An optional keyword argument ‘msg’ can be provided when assertRaises is used
 
 The context manager keeps a reference to the exception as the ‘exception’ attribute. This allows you to inspect the exception after the assertion:
 
-```
+``` python
 with self.assertRaises(SomeException) as cm:
 do_something()
 the_exception = cm.exception
@@ -468,7 +467,7 @@ Fail unless a warning of class warnClass is triggered by the callable when invok
 
 If called with the callable and arguments omitted, will return a context object used like this:
 
-```
+``` python
 with self.assertWarns(SomeWarning):
 do_something()
 ```
@@ -477,7 +476,7 @@ An optional keyword argument ‘msg’ can be provided when assertWarns is used 
 
 The context manager keeps a reference to the first matching warning as the ‘warning’ attribute; similarly, the ‘filename’ and ‘lineno’ attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
 
-```
+``` python
 with self.assertWarns(SomeWarning) as cm:
 do_something()
 the_warning = cm.warning
@@ -533,7 +532,7 @@ Returns:	A string name of the machine config file to use, complete with the .yam
 
 For example:
 
-```
+``` python
 def get_config_file(self):
 return 'my_config.yaml'
 ```
@@ -558,7 +557,7 @@ Returns:	A string name of the machine path to use
 
 For example:
 
-```
+``` python
 def get_machine_path(self):
 return 'tests/machine_files/my_test/'
 ```
@@ -642,7 +641,7 @@ Mocking an event will not “break” it. In other words, any other registered h
 
 For example:
 
-```
+``` python
 self.mock_event('my_event')
 self.assertEventNotCalled('my_event')  # This will be True
 self.post_event('my_event')
@@ -718,7 +717,7 @@ This is needed for tests where you don’t have any ball devices and other situa
 
 Example:
 
-```
+``` python
 self.set_num_balls_known(3)
 ```
 
@@ -740,7 +739,7 @@ This method checks to make sure a game is not running, then hits and releases th
 
 For example:
 
-```
+``` python
 self.start_game()
 ```
 
@@ -760,7 +759,7 @@ This method asserts that a game is running, then call’s the game mode’s end_
 
 Example:
 
-```
+``` python
 self.stop_game()
 ```
 

--- a/docs/code/api_reference/testing_class_api/MpfMachineTestCase.md
+++ b/docs/code/api_reference/testing_class_api/MpfMachineTestCase.md
@@ -58,14 +58,14 @@ Parameters:
 
 An unordered sequence comparison asserting that the same elements, regardless of order. If the same element occurs more than once, it verifies that the elements occur the same number of times.
 
-```
+``` python
 self.assertEqual(Counter(list(first)),
 Counter(list(second)))
 ```
 
 Example:
 
-```
+``` python
 [0, 1, 1] and [1, 0, 1] compare equal.
 [0, 0, 1] and [0, 1] compare unequal.
 ```
@@ -93,7 +93,7 @@ Note that the event must be mocked via self.mock_event() first in order to use t
 
 For example:
 
-```
+``` python
 self.mock_event('my_event')
 self.assertEventNotCalled('my_event')  # This will pass
 
@@ -117,7 +117,7 @@ Parameters:
 
 For example:
 
-```
+``` python
 self.mock_event('jackpot')
 
 self.post_event('jackpot', count=1, first_time=True)
@@ -222,7 +222,7 @@ This method must be used as a context manager, and will yield a recording object
 
 Example:
 
-```
+``` python
 with self.assertLogs('foo', level='INFO') as cm:
 logging.getLogger('foo').info('first message')
 logging.getLogger('foo.bar').error('second message')
@@ -296,7 +296,7 @@ Fail unless an exception of class expected_exception is raised by the callable w
 
 If called with the callable and arguments omitted, will return a context object used like this:
 
-```
+``` python
 with self.assertRaises(SomeException):
   do_something()
 ```
@@ -305,7 +305,7 @@ An optional keyword argument ‘msg’ can be provided when assertRaises is used
 
 The context manager keeps a reference to the exception as the ‘exception’ attribute. This allows you to inspect the exception after the assertion:
 
-```
+``` python
 with self.assertRaises(SomeException) as cm:
   do_something()
 the_exception = cm.exception
@@ -377,7 +377,7 @@ Fail unless a warning of class warnClass is triggered by the callable when invok
 
 If called with the callable and arguments omitted, will return a context object used like this:
 
-```
+``` python
 with self.assertWarns(SomeWarning):
   do_something()
 ```
@@ -386,7 +386,7 @@ An optional keyword argument ‘msg’ can be provided when assertWarns is used 
 
 The context manager keeps a reference to the first matching warning as the ‘warning’ attribute; similarly, the ‘filename’ and ‘lineno’ attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
 
-```
+``` python
 with self.assertWarns(SomeWarning) as cm:
   do_something()
 the_warning = cm.warning
@@ -426,9 +426,9 @@ Returns:	A string name of the machine config file to use, complete with the .yam
 
 For example:
 
-```
+``` python
 def get_config_file(self):
-return 'my_config.yaml'
+  return 'my_config.yaml'
 ```
 
 `get_enable_plugins()`
@@ -439,9 +439,9 @@ Returns: True or False
 
 The default is False. To load plugins in your test class, add the following:
 
-```
+``` python
 def get_enable_plugins(self):
-return True
+  return True
 ```
 
 `get_machine_path()`
@@ -453,9 +453,9 @@ Returns:	A string name of the machine path to use
 
 For example:
 
-```
+``` python
 def get_machine_path(self):
-return 'tests/machine_files/my_test/'
+  return 'tests/machine_files/my_test/'
 ```
 
 Note that this path is relative to the MPF package root
@@ -471,9 +471,9 @@ Returns:	String name of the platform this test class will use.
 
 If you don’t include this method in your test class, the platform will be set to virtual. If you want to use the smart virtual platform, you would add the following to your test class:
 
-```
+``` python
 def get_platform(self):
-  return 'smart_virtual`
+  return 'smart_virtual'
 ```
 
 `get_use_bcp()`
@@ -542,7 +542,7 @@ Mocking an event will not “break” it. In other words, any other registered h
 
 For example:
 
-```
+``` python
 self.mock_event('my_event')
 self.assertEventNotCalled('my_event')  # This will be True
 self.post_event('my_event')
@@ -618,7 +618,7 @@ This is needed for tests where you don’t have any ball devices and other situa
 
 Example:
 
-```
+``` python
 self.set_num_balls_known(3)
 ```
 

--- a/docs/code/api_reference/testing_class_api/MpfTestCase.md
+++ b/docs/code/api_reference/testing_class_api/MpfTestCase.md
@@ -1,7 +1,9 @@
 
 # MpfTestCase
 
-`class mpf.tests.MpfTestCase.MpfTestCase(methodName='runTest')`
+``` python
+class mpf.tests.MpfTestCase.MpfTestCase(methodName='runTest')
+```
 
 Bases: unittest.case.TestCase
 
@@ -24,7 +26,7 @@ This method will cause anything scheduled during the time to run, including thin
 
 Advancing the clock will happen in multiple small steps if things are scheduled to happen during this advance. For example, you can advance the clock 10 seconds like this:
 
-```
+``` python
 self.advance_time_and_run(10)
 ```
 
@@ -60,14 +62,14 @@ Parameters:
 
 An unordered sequence comparison asserting that the same elements, regardless of order. If the same element occurs more than once, it verifies that the elements occur the same number of times.
 
-```
+``` python
 self.assertEqual(Counter(list(first)),
   Counter(list(second)))
 ```
 
 Example:
 
-```
+``` python
 [0, 1, 1] and [1, 0, 1] compare equal.
 [0, 0, 1] and [0, 1] compare unequal.
 ```
@@ -95,7 +97,7 @@ Note that the event must be mocked via self.mock_event() first in order to use t
 
 For example:
 
-```
+``` python
 self.mock_event('my_event')
 self.assertEventNotCalled('my_event')  # This will pass
 
@@ -119,7 +121,7 @@ Parameters:
 
 For example:
 
-```
+``` python
 self.mock_event('jackpot')
 
 self.post_event('jackpot', count=1, first_time=True)
@@ -224,7 +226,7 @@ This method must be used as a context manager, and will yield a recording object
 
 Example:
 
-```
+``` python
 with self.assertLogs('foo', level='INFO') as cm:
   logging.getLogger('foo').info('first message')
   logging.getLogger('foo.bar').error('second message')
@@ -298,7 +300,7 @@ Fail unless an exception of class expected_exception is raised by the callable w
 
 If called with the callable and arguments omitted, will return a context object used like this:
 
-```
+``` python
 with self.assertRaises(SomeException):
   do_something()
 ```
@@ -307,7 +309,7 @@ An optional keyword argument ‘msg’ can be provided when assertRaises is used
 
 The context manager keeps a reference to the exception as the ‘exception’ attribute. This allows you to inspect the exception after the assertion:
 
-```
+``` python
 with self.assertRaises(SomeException) as cm:
   do_something()
 the_exception = cm.exception
@@ -379,7 +381,7 @@ Fail unless a warning of class warnClass is triggered by the callable when invok
 
 If called with the callable and arguments omitted, will return a context object used like this:
 
-```
+``` python
 with self.assertWarns(SomeWarning):
   do_something()
 ```
@@ -388,7 +390,7 @@ An optional keyword argument ‘msg’ can be provided when assertWarns is used 
 
 The context manager keeps a reference to the first matching warning as the ‘warning’ attribute; similarly, the ‘filename’ and ‘lineno’ attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
 
-```
+``` python
 with self.assertWarns(SomeWarning) as cm:
   do_something()
 the_warning = cm.warning
@@ -428,7 +430,7 @@ Returns:	A string name of the machine config file to use, complete with the .yam
 
 For example:
 
-```
+``` python
 def get_config_file(self):
   return 'my_config.yaml'
 ```
@@ -441,7 +443,7 @@ Returns: True or False
 
 The default is False. To load plugins in your test class, add the following:
 
-```
+``` python
 def get_enable_plugins(self):
   return True
 ```
@@ -455,7 +457,7 @@ Returns:	A string name of the machine path to use
 
 For example:
 
-```
+``` python
 def get_machine_path(self):
   return 'tests/machine_files/my_test/'
 ```
@@ -484,7 +486,7 @@ Returns: True or False
 
 The default is False. To use BCP in your test class, add the following:
 
-```
+``` python
 def get_use_bcp(self):
   return True
 ```
@@ -544,7 +546,7 @@ Mocking an event will not “break” it. In other words, any other registered h
 
 For example:
 
-```
+``` python
 self.mock_event('my_event')
 self.assertEventNotCalled('my_event')  # This will be True
 self.post_event('my_event')
@@ -579,7 +581,7 @@ Parameters:
 
 For example, to post an event called “jackpot” with the parameters count=1 and first_time=True, you would use:
 
-```
+``` python
 self.post_event('jackpot', count=1, first_time=True)
 ```
 
@@ -622,7 +624,7 @@ This is needed for tests where you don’t have any ball devices and other situa
 
 Example:
 
-```
+``` python
 self.set_num_balls_known(3)
 ```
 

--- a/docs/code/introduction/machine_code.md
+++ b/docs/code/introduction/machine_code.md
@@ -24,7 +24,7 @@ All your classes will be referenced as `custom_code.file_name.ClassName`.
 
 Next, edit the class file you created. At a bare minimum, you’ll need this:
 
-```
+``` python
 from mpf.core.custom_code import CustomCode
 
 class Claw(CustomCode):
@@ -41,7 +41,7 @@ Next, edit your machine config file and add a `custom_code:` section, then under
 
 For Demo Man, that looks like this:
 
-```
+``` yaml
 custom_code:
   - custom_code.claw.Claw
 ```
@@ -55,7 +55,7 @@ At this point you should be able to run your game, though nothing should happen 
 Take a look at the final Demo Man claw class to see what we did there. Since custom code classes have access to self.machine and they load when MPF loads, you can do anything you want in them.
 
 
-```
+``` python
 from mpf.core.custom_code import CustomCode
 
 

--- a/docs/code/introduction/mode_code.md
+++ b/docs/code/introduction/mode_code.md
@@ -33,7 +33,7 @@ For example, if you wanted to create custom code for your base mode, it might lo
 
 Next, open the new mode code Python file you just created and add the bare minimum, which would look like this:
 
-```
+``` python
 from mpf.core.mode import Mode
 
 class Base(Mode):
@@ -93,7 +93,7 @@ Also, modes have additional convenience attributes you can use within your mode 
 Here’s an example of some mode code in use. This example is just a bunch of random things, but again, since you’re writing code here, the sky’s the limit! Seriously you could do all your game logic in mode code and not use the MPF configs at all if you wanted to.
 
 
-```
+``` python
 from mpf.core.mode import Mode
 
 

--- a/docs/code/introduction/mode_code.md
+++ b/docs/code/introduction/mode_code.md
@@ -17,7 +17,7 @@ First, go into the mode folder where you want to create your custom code, and ad
 
 For example, if you wanted to create custom code for your base mode, it might look like this:
 
-```
+``` diagram
 <mpf-game-folder>
 ├── config
 └── modes
@@ -50,7 +50,7 @@ Once you create your custom mode code, you need to tell MPF that this mode uses 
 
 To do this, add a `code:` entry into the mode config file for the mode where you’re adding custom code. So in this case, that would be in the `/modes/base/config/base.yaml` file, like this:
 
-```
+``` yaml
 mode:
   start_events: ball_starting
   priority: 100
@@ -69,7 +69,7 @@ You can look at the Mode base class (the link from GitHub from earlier) to see w
 
 * **mode_init:** Called once when MPF is starting up
 
-* **mode_start:** Called every time the mode starts, just after the mode_<name>_started event is posted.
+* **mode_start:** Called every time the mode starts, just after the mode_(name)\_started event is posted.
 
 * **add_mode_event_handler:** This is the same as the main add_event_handler() method from the Event Manager, except since it’s mode-specific it will also automatically remove any event handlers that you registered when the mode stops. (If you want to register event handlers that are always watching for events even when the mode is not running, you can use the regular `self.machine.mode.add_handler()` method.
 

--- a/docs/code/introduction/setup.md
+++ b/docs/code/introduction/setup.md
@@ -23,13 +23,13 @@ If you’re on Windows or Mac, the easiest way to get a git client installed is 
 
 Clone the mpf repository and its submodules :
 
-```
+``` console
 git clone --recursive https://github.com/missionpinball/mpf.git
 ```
 
 Same thing for the mpf-mc repository :
 
-```
+``` console
 git clone --recursive https://github.com/missionpinball/mpf-mc.git
 ```
 
@@ -45,13 +45,13 @@ Using virtualenv lets you keep all the other Python packages MPF needs (pyserial
 
 Create a new virtualenv called “mpf-venv” (or whatever you want to name it) like this:
 
-```
+``` console
 virtualenv -p python3 mpf-venv
 ```
 
 Then enter the newly-created virtualenv:
 
-```
+``` console
 source mpf-venv/bin/activate
 ```
 
@@ -62,7 +62,7 @@ On Macs, you will need to uninstall and reinstall kivy in the the virtual envirm
 
 Each time you’ll work with your MPF development version you’ll have to switch to this environment.
 
-```
+``` console
 source mpf-venv/bin/activate
 ```
 
@@ -70,16 +70,16 @@ Note: in this environment, thanks to the “-p python3” option of virtualenv, 
 
 Next you’ll install MPF and MPF-MC. This is pretty much like a regular install, except that you’ll also use the -e command line option which means these packages will be installed in “editable” mode.
 
-```
 Install mpf and mpf-mc like this:
 
+``` console
 pip install -e mpf
 pip install -e mpf-mc
 ```
 
 You should now be done, and you can verify that everyething is installed properly via:
 
-```
+``` console
 mpf --version
 ```
 

--- a/docs/code/introduction/variables_in_code.md
+++ b/docs/code/introduction/variables_in_code.md
@@ -8,7 +8,7 @@ Inside a (game) mode you can access the current player using `self.player`. Alte
 
 You can use player variables like this:
 
-```
+``` python
 player = self.machine.game.player    # do not persist the player because it may change
                                      # alternatively use self.player in modes
 
@@ -28,7 +28,7 @@ player["my_variable"] = 17
 
 You can use machine variables by calling into the MPF machine.
 
-```
+``` python
 # read machine variable
 self.machine.log.info(self.machine.variables.get_machine_var("my_variable"))
 

--- a/docs/config/bonus.md
+++ b/docs/config/bonus.md
@@ -112,7 +112,7 @@ one begins.
 Here's how an example might look based on the aliens, modes, and combos
 example just mentioned:
 
-```
+``` yaml
 bonus_entries:
   - event: alien_bonus
     score: 25000

--- a/docs/config/neoseg_displays.md
+++ b/docs/config/neoseg_displays.md
@@ -27,7 +27,7 @@ Single value, type: [lights:](lights.md).
 Defaults to empty. Used to specify the light you have, though neoseg displays come in different
 colors each segment is considered a single color segment, use color white in any case.
 
-```
+``` yaml
 light_template:
       type: w
       subtype: led

--- a/docs/config/playlists.md
+++ b/docs/config/playlists.md
@@ -78,13 +78,13 @@ empty.
 If you want to use a sound that has spaces in its name, the name of the
 sound must be in quotes: :
 
-```
+``` yaml
 playlists:
     mode_music:
         sounds:
             * song_01
             * song_02
-            * "song 03" \# example of a sound with a space in its name using quotes
+            * "song 03" # example of a sound with a space in its name using quotes
             * song_04
 ```
 

--- a/docs/config/speedometers.md
+++ b/docs/config/speedometers.md
@@ -9,7 +9,7 @@ title: "speedometers:"
 
 New in MPF 0.56.1.
 
-```
+``` yaml
 speedometers:
     __valid_in__: machine, mode
     __type__: device

--- a/docs/gmc/reference/mpf-text-input.md
+++ b/docs/gmc/reference/mpf-text-input.md
@@ -104,6 +104,6 @@ When the END key on the on-screen keyboard is selected, GMC will post an event *
 
 This event will include an argument `text` with the text string entered by the user.
 
-```
+``` console
 ==='text_input_high_score_complete'=== Args={'text': 'MY NAME'}
 ```

--- a/docs/hardware/opp/cobrapin/cobrapin_serial_segment_displays.md
+++ b/docs/hardware/opp/cobrapin/cobrapin_serial_segment_displays.md
@@ -197,6 +197,7 @@ light_settings:
     NeoSeg_green:
       whitepoint: [.5, .5, .5]
 ```
+
 ## Complete Example Config for Show Definition
 
 Below you find a complete example config file to display scored points. It is not using all possible hardware options like the example above, but it includes the display of a show on the LED segments. To keep this example simple the `neoseg_displays` object is mapped 1:1 to a `segment_displays` object.
@@ -244,4 +245,5 @@ shows:
         text: (txt)
 
 ```
+
 To learn more about show tokens and how to use dynamic values take a look [here](../../../shows/tokens.md).

--- a/docs/hardware/opp/oppcombo/index.md
+++ b/docs/hardware/opp/oppcombo/index.md
@@ -74,7 +74,7 @@ and use a PC with [gen2test.py](https://gitlab.com/mrechte/open-pinball-project/
 
 In the above example one would do:
 
-```
+``` console
 ./gen2test.py --serial 0
 ./gen2test.py --config opp16o16icfg.py
 ./gen2test.py --save

--- a/docs/install/0.80.md
+++ b/docs/install/0.80.md
@@ -23,13 +23,13 @@ In your bonus.yaml config section, change each entry from `event: bonus_item_nam
 With this change, given a bonus entry named "completed_ramps" that was hit 3 times for a score of 3000:
 
 **MPF 0.57 Event:**
-```
-    completed_ramps{hits=3, score=3000}
+``` console
+completed_ramps{hits=3, score=3000}
 ```
 
 **MPF 0.80 Event:**
-```
-    bonus_entry{entry="completed_ramps", hits=3, score=3000}
+``` console
+bonus_entry{entry="completed_ramps", hits=3, score=3000}
 ```
 
 
@@ -40,13 +40,13 @@ Carousel events have changed to use a consolidated *item_highlighted* event inst
 Given a carousel mode "missionselect" and an item "garrus":
 
 **MPF 0.57 Event:**
-```
-    missionselect_garrus_highlighted{direction="forwards"}
+``` console
+missionselect_garrus_highlighted{direction="forwards"}
 ```
 
 **MPF 0.80 Event:**
-```
-    item_highlighted{carousel="missionselect", item="garrus", direction="forwards"}
+``` console
+item_highlighted{carousel="missionselect", item="garrus", direction="forwards"}
 ```
 
 The new *item_highlighted* event is incorporated into GMC, but if you have other custom event handlers for carousel item selection those will need to be updated.

--- a/docs/install/linux/index.md
+++ b/docs/install/linux/index.md
@@ -111,6 +111,7 @@ Now you should be ready to use mpf, for a first test run
 ``` doscon
 mpf --version
 ```
+
 You should see a version number printed, as time of writing it is 0.56.2. Maybe you see some higher
 number. If you get a message that the command `mpf` is not being found or known you might have to add the location of the
 command to your `PATH` variable. Most likely (it depends on the shell type you use) you need to add to your `.profile` or `.bashrc` file an entry like
@@ -149,7 +150,7 @@ with Multimorphic P-ROC/P3-ROC boards with Python 3.8.
 
 Example Error:
 
-```
+``` console
 Failed to initialize MPF
 Traceback (most recent call last):
 File “/usr/local/lib/python3.8/dist-packages/mpf/platforms/p_roc_common.py”, line 31, in <module>
@@ -166,14 +167,14 @@ Try Changing `Edit install-proc:`
 
 From:
 
-```
+``` console
 cd pypinproc
 sudo python3 setup.py install
 ```
 
 To:
 
-```
+``` console
 cd pypinproc
 python3 setup.py install --user
 ```

--- a/docs/install/linux/raspberry.md
+++ b/docs/install/linux/raspberry.md
@@ -138,6 +138,7 @@ Note: If you're connected via SSH, you'll need to specify which display should b
 # set default display for windowed apps
 export DISPLAY=:0
 ```
+
 To test MPF with the demo-man game, follow these steps:
 
 ``` shell

--- a/docs/install/virtual-machine/basic-guide.md
+++ b/docs/install/virtual-machine/basic-guide.md
@@ -85,10 +85,12 @@ To fix this:
     * ``` console
         usermod -aG sudo [your-user]
         ```
+
 4.  Exit the root user shell
     * ``` console
         exit
         ```
+
 5.  Verify your username was granted sudo access
     * ``` console
         sudo echo
@@ -164,6 +166,7 @@ virtual machine.
                ether 0a:00:27:00:00:00
                inet 192.168.56.1 netmask 0xffffff00 broadcast 192.168.56.255
         ```
+
 4.  In the *guest* OS (Debian), verify the VirtualBox virtual network
     adapter is connected
     * The following is for my installation. Your command and output may look different
@@ -227,6 +230,7 @@ pip3 install pip setuptools --upgrade
         cd mpf-debian-installer/
         chmod +x install && sudo ./install
         ```
+
 2.  Setup the mpf directory and clone examples
     * ``` console
         cd ~
@@ -234,6 +238,7 @@ pip3 install pip setuptools --upgrade
         cd mpf
         git clone https://github.com/missionpinball/mpf-examples
         ```
+
 3.  Run the Demo Man example. In the VBox Desktop, open terminal and execute:
     * ``` console
         cd ~/mpf/mpf-examples/demo_man
@@ -266,10 +271,12 @@ The full installation guide for setting up MPF-Monitor [can be found here](../..
     * ``` console
         sudo apt-get install python3-pyqt6
         ```
+
 2.  Install mpf-monitor:
     * ``` console
         pip install mpf-monitor
         ```
+
 3.  Start mpf (with mc) and mpf monitor (in separate terminal tabs):
     * ``` console
         mpf both -X
@@ -278,6 +285,7 @@ The full installation guide for setting up MPF-Monitor [can be found here](../..
     * ``` console
         mpf monitor
         ```
+
 4.  Adjust the size of switches and lights by adding the following to
     the first line of your `monitor.yaml` file:
     * ``` yaml

--- a/docs/mechs/ball_devices/troubleshooting.md
+++ b/docs/mechs/ball_devices/troubleshooting.md
@@ -45,8 +45,8 @@ doesn't match how many balls you actually have, that could be:
     ball in the trough, the switch entry in your log should show that
     the switch is active (*State:1*), like this:
 
-```
-    2014-10-27 20:05:29,891 : SwitchController : <<<<< switch: trough1, State:1 >>>>>
+``` console
+2014-10-27 20:05:29,891 : SwitchController : <<<<< switch: trough1, State:1 >>>>>
 ```
 
 If you see State:1 immediately followed by another entry with State:0,

--- a/docs/mechs/lights/index.md
+++ b/docs/mechs/lights/index.md
@@ -237,6 +237,7 @@ keyboard:
  3:
     event: single_led_green
 ```
+
 Pay attention to the event `single_led_green` to understand how to address a single light in your light strip.
 
 

--- a/docs/shows/tokens.md
+++ b/docs/shows/tokens.md
@@ -234,9 +234,10 @@ In the above explainations the token values, e.g. led_02 were objects you have d
 
 Let's assume the following event is posted
 
-```
+``` console
 INFO : EventManager : Event: ======'player_turn_started'====== Args={'player': <Player 1>, 'number': 1}
 ```
+
 The event `player_turn_started` has for example the argument `number` for the number of the player whose turn has started.
 
 ``` yaml
@@ -259,6 +260,7 @@ show_player:
       show_tokens:
         txt: (current_player.ball)
 ```
+
 In this example the ball number of the player is being used in your show once the player's turn has started. In case you want to access a variable of a specific player (which is not necessarily the current player) you can use `players[<player_number>].<variable>` where `player_number` is the player starting with 0, e.g. the second player needs the value 1 in this example.
 
 

--- a/docs/tutorial/8_plunger.md
+++ b/docs/tutorial/8_plunger.md
@@ -156,8 +156,8 @@ devices doesn't match how many balls you actually have, that could be:
     your log should show that the switch is active (*State:1*), like
     this:
 
-```
-    2014-10-27 20:05:29,891 : SwitchController : <<<<< switch: trough1, State:1 >>>>>
+``` console
+2014-10-27 20:05:29,891 : SwitchController : <<<<< switch: trough1, State:1 >>>>>
 ```
 
 If you see `State:1` immediately followed by another entry with `State:0`,


### PR DESCRIPTION
I was able to use sublime regex search with the pattern:
` ```\n[^\n] `
to find all of the blocks that did not have highlighting declared