### PR TITLE
Changed widget style workings

### DIFF
--- a/docs/config/widget_styles.md
+++ b/docs/config/widget_styles.md
@@ -10,7 +10,7 @@ title: "widget_styles:"
 | Valid in | |
 |-----|:----:|
 |[machine](instructions/machine_config.md) config files |**YES** :white_check_mark:|
-|[mode](instructions/mode_config.md) config files|**YES** :white_check_mark:|
+|[mode](instructions/mode_config.md) config files|**NO** :no_entry_sign:|
 
 The `widget_styles:` section of your config is where you configure
 styles for your widgets.


### PR DESCRIPTION
I don't know whether this is a bug, or it's intended to be this way, but mode config doesn't allow widget_styles currently:

What I can see, is that MPF-MC only checks in the machine configuration, but not in mode configs.

Here's log of what I'm talking about:
2025-04-11 10:36:03,953 : root : Exception while processing RegisteredHandler(callback=<bound method McConfigPlayer.play_from_trigger of McConfigPlayer.slides>, priority=1, kwargs={}, key=UUID('79f2fbec-8162-4b70-9e19-93e493fb347b'), condition=None, blocking_facility=None) for event slides_play. <Text Widget text=> has an invalid style name: 'player_display' Traceback (most recent call last):
  File "/home/admin/mpfvenv/lib/python3.11/site-packages/mpfmc/uix/widget.py", line 379, in _apply_style
    styles = [self.mc.machine_config['widget_styles'][s] for s in self.config['style']]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/mpfvenv/lib/python3.11/site-packages/mpfmc/uix/widget.py", line 379, in <listcomp>
    styles = [self.mc.machine_config['widget_styles'][s] for s in self.config['style']]
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
KeyError: 'player_display'

If needed further info, I'm more than happy to oblige, just hit me up :)

Tested with MPF & MPF-MC 0.57 and Kivy 2.2.1

If this is a bug, please deny the documentation change :)