### PR TITLE
add duck_default option to gmc.cfg docs

### DIFF
--- a/docs/gmc/reference/gmc-cfg.md
+++ b/docs/gmc/reference/gmc-cfg.md
@@ -184,6 +184,12 @@ Single value, type `bool`. Default `false`
 
 One audio bus is allowed to be set as default, and any sound playback trigger that does not include a value for `bus:` will play on this bus.
 
+### `duck_default`
+
+Single value, type `bool`. Default `false`
+
+One audio bus is allowed to be set as the default ducking target. Any sound playback trigger using ducking settings that has not specified a value for `bus:` in the ducking settings will duck the audio on this bus.
+
 ### `simultaneous_sounds`
 
 Single value, type `int`. Default `None`


### PR DESCRIPTION
I was reading GMC code and I noticed this cfg option, which I hadn't seen in the documentation.

I'm not 100% certain that the option is working though -- I see it get stored in sound_player.gd:12
```
var default_duck_bus: GMCBus
```
and I see that used in `get_ducking_bus` on line 59, but I can't tell if `get_ducking_bus` is used anywhere.

If that's okay and this is working, we can merge this PR