### PR TITLE
Shot profile links and code blocks everywhere

### DIFF
--- a/docs/config/achievement_groups.md
+++ b/docs/config/achievement_groups.md
@@ -289,7 +289,7 @@ practical use, you'd just configure the show tokens in one place.
 
 ### show_when_enabled:
 
-Single value, type: string name of a [shows:](../shows/index.md) device. Defaults to empty.
+Single value, type: `string` name of a [shows:](../shows/index.md) device. Defaults to empty.
 
 Name of the show that will be started when this achievement group has
 been enabled. Also, any tokens configured in the `show_tokens:` section

--- a/docs/config/achievements.md
+++ b/docs/config/achievements.md
@@ -275,42 +275,42 @@ documentation.)
 
 ### show_when_completed:
 
-Single value, type: string name of a [shows:](../shows/index.md) device. Defaults to empty.
+Single value, type: `string` name of a [shows:](../shows/index.md) device. Defaults to empty.
 
 Name of the show that will be started when this achievement has been
 completed.
 
 ### show_when_disabled:
 
-Single value, type: string name of a [shows:](../shows/index.md) device. Defaults to empty.
+Single value, type: `string` name of a [shows:](../shows/index.md) device. Defaults to empty.
 
 Name of the show that will be started when this achievement has been
 disabled.
 
 ### show_when_enabled:
 
-Single value, type: string name of a [shows:](../shows/index.md) device. Defaults to empty.
+Single value, type: `string` name of a [shows:](../shows/index.md) device. Defaults to empty.
 
 Name of the show that will be started when this achievement has been
 enabled.
 
 ### show_when_selected:
 
-Single value, type: string name of a [shows:](../shows/index.md) device. Defaults to empty.
+Single value, type: `string` name of a [shows:](../shows/index.md) device. Defaults to empty.
 
 Name of the show that will be started when this achievement has been
 selected.
 
 ### show_when_started:
 
-Single value, type: string name of a [shows:](../shows/index.md) device. Defaults to empty.
+Single value, type: `string` name of a [shows:](../shows/index.md) device. Defaults to empty.
 
 Name of the show that will be started when this achievement has been
 started.
 
 ### show_when_stopped:
 
-Single value, type: string name of a [shows:](../shows/index.md) device. Defaults to empty.
+Single value, type: `string` name of a [shows:](../shows/index.md) device. Defaults to empty.
 
 Name of the show that will be started when this achievement has been
 stopped.

--- a/docs/config/autofire_coils.md
+++ b/docs/config/autofire_coils.md
@@ -66,7 +66,7 @@ your config:
 
 ### coil:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 The name of the coil you want to fire. (Actually, perhaps we should
 phrase it as the name of the coil you want to change the state on,
@@ -75,7 +75,7 @@ stop firing based on a switch change.)
 
 ### switch:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -157,7 +157,7 @@ controller hardware.
 
 ### playfield:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [playfields:](playfields.md) device. Default:
 `playfield`
 

--- a/docs/config/ball_devices.md
+++ b/docs/config/ball_devices.md
@@ -49,7 +49,7 @@ many balls that device can hold. Default will be set to the number of
 
 ### ball_missing_target:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [playfields:](playfields.md) device. Default:
 `playfield`
 
@@ -108,7 +108,7 @@ activations.)
 
 ### captures_from:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [playfields:](playfields.md) device. Default:
 `playfield`
 
@@ -127,7 +127,7 @@ ball eject if you have `confirm_eject_type: event`.
 
 ### confirm_eject_switch:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -566,7 +566,7 @@ value 3 times and then increase it on the 4th.
 
 ### target_on_unexpected_ball:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [ball_devices:](ball_devices.md) device.
 Defaults to empty.
 

--- a/docs/config/ball_holds.md
+++ b/docs/config/ball_holds.md
@@ -133,7 +133,7 @@ Event(s) which cause this ball hold to reset its held ball count.
 
 ### source_playfield:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [ball_devices:](ball_devices.md) device.
 Default: `playfield`
 

--- a/docs/config/ball_routings.md
+++ b/docs/config/ball_routings.md
@@ -31,7 +31,7 @@ Defaults to empty.
 
 ### target_device:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [ball_devices:](ball_devices.md) device.
 Defaults to empty.
 

--- a/docs/config/ball_saves.md
+++ b/docs/config/ball_saves.md
@@ -143,7 +143,7 @@ drains it will not be saved.
 
 ### source_playfield:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [ball_devices:](ball_devices.md) device.
 Default: `playfield`
 

--- a/docs/config/blinkenlights.md
+++ b/docs/config/blinkenlights.md
@@ -107,7 +107,7 @@ number of colors, then use `color_duration` instead (see above).
 
 ### light:
 
-Single value, type: string name of a [lights:](lights.md) device. Defaults to empty.
+Single value, type: `string` name of a [lights:](lights.md) device. Defaults to empty.
 
 This is the name of the light which this blinkenlight controls.
 

--- a/docs/config/coil_overwrites.md
+++ b/docs/config/coil_overwrites.md
@@ -25,7 +25,7 @@ your config. (If you don't include them, the default will be used).
 
 ### hold_power:
 
-Single value, type: float(0,1).
+Single value, type: `float(0,1)`.
 
 Overwrite the `hold_power` of the coil for this device. See
 `default_hold_power` in [coils:](coils.md) for
@@ -41,7 +41,7 @@ Overwrite the `pulse_ms` of the coil for this device. See
 
 ### pulse_power:
 
-Single value, type: float(0,1).
+Single value, type: `float(0,1)`.
 
 Overwrite the `pulse_power` of the coil for this device. See
 `default_pulse_power` in [coils:](coils.md) for

--- a/docs/config/coils.md
+++ b/docs/config/coils.md
@@ -91,7 +91,7 @@ your log file.
 
 ### default_hold_power:
 
-Single value, type: float(0,1). Defaults to empty.
+Single value, type: `float(0,1)`. Defaults to empty.
 
 This setting lets you control how much power is sent to the coil when
 it's "held" in the on position. This is an float value from 0-1 (i.e.
@@ -123,7 +123,7 @@ weak, but set low for safety purposes.
 
 ### default_pulse_power:
 
-Single value, type: float(0,1). Defaults to empty.
+Single value, type: `float(0,1)`. Defaults to empty.
 
 The power factor which controls how much power is applied during the
 initial pulse phase of the coil's activation. (Note that not all
@@ -176,7 +176,7 @@ Single value, type: `time string (secs)`
 
 ### max_hold_power:
 
-Single value, type: float(0,1). Defaults to empty.
+Single value, type: `float(0,1)`. Defaults to empty.
 
 This controlls the maximum allowed hold power for this this coil. While
 *default_hold_power* sets the default for all enable calls on the coil
@@ -193,7 +193,7 @@ error if any code tries to pulse the coil for more than `max_pulse_ms`.
 
 ### max_pulse_power:
 
-Single value, type: float(0,1). Default: `1.0`
+Single value, type: `float(0,1)`. Default: `1.0`
 
 Set the maxium pulse power. If pulse is called on the coil without any
 parameters *default_pulse_power* is used.
@@ -212,7 +212,7 @@ details.
 
 ### platform_settings:
 
-Single value, type: dict. Defaults to empty.
+Single value, type: `dict`. Defaults to empty.
 
 Dict of platform specific settings. Consult your platform documentation
 for those settings.

--- a/docs/config/coils.md
+++ b/docs/config/coils.md
@@ -219,7 +219,7 @@ for those settings.
 
 ### psu:
 
-Single value, type: string name of a [psus:](psus.md) device. Default: `default`
+Single value, type: `string` name of a [psus:](psus.md) device. Default: `default`
 
 Specify to which [power supply unit](psus.md) this coil is connected. This is used for power management.
 In some cases, MPF can deliberately delay coil pulses to prevent too

--- a/docs/config/credits.md
+++ b/docs/config/credits.md
@@ -168,7 +168,7 @@ config. (If you don't include them, the default will be used).
 
 #### switch:
 
-Single value, type: string name of a `switches:` device. Default: `None`
+Single value, type: `string` name of a `switches:` device. Default: `None`
 
 The name of the switch (from your machine-wide *switches:* section) for
 the credit switch.

--- a/docs/config/digital_outputs.md
+++ b/docs/config/digital_outputs.md
@@ -81,7 +81,7 @@ In case you want to overwrite the default platform (as defined in
 
 ### platform_settings:
 
-Single value, type: dict. Defaults to empty.
+Single value, type: `dict`. Defaults to empty.
 
 Dict of platform specific settings. Consult your platform documentation
 for those settings.

--- a/docs/config/diverters.md
+++ b/docs/config/diverters.md
@@ -126,7 +126,7 @@ Events in this list, when posted, cause this diverter to activate.
 
 ### activation_coil:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 The name of the coil that is used to activate your diverter.
 
@@ -196,7 +196,7 @@ Events in this list, when posted, cause this diverter to deactivate.
 
 ### deactivation_coil:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 The name of the coil that's used to deactivate your diverter. You only
 need to specify this coil if it's a different coil from from
@@ -279,7 +279,7 @@ itself to make sure the balls gets to where it needs to go.
 
 ### playfield:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [playfields:](playfields.md) device. Default:
 `playfield`
 

--- a/docs/config/drop_target_banks.md
+++ b/docs/config/drop_target_banks.md
@@ -112,7 +112,7 @@ Single value, type: `integer`. Defaults to empty.
 
 ### reset_coil:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 The name of the coil that is fired to reset this bank of drop targets.
 

--- a/docs/config/drop_targets.md
+++ b/docs/config/drop_targets.md
@@ -89,7 +89,7 @@ your config:
 
 ### switch:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -151,7 +151,7 @@ could add to the score, start modes, etc. Default is `500ms`.
 
 ### knockdown_coil:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 This is an optional coil that's used to knock down a drop target. Most
 drop targets do not have these. (In the *Judge Dredd* example above,
@@ -182,7 +182,7 @@ Single value, type: `integer`. Defaults to empty.
 
 ### playfield:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [playfields:](playfields.md) device. Default:
 `playfield`
 
@@ -192,7 +192,7 @@ have more than one playfield and you're managing them separately.
 
 ### reset_coil:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 The name of the coil that is pulsed to reset this drop target. The pulse
 time will be whatever you configure as the default pulse time for this

--- a/docs/config/dual_wound_coils.md
+++ b/docs/config/dual_wound_coils.md
@@ -56,14 +56,14 @@ of your config:
 
 ### hold_coil:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 The name of the hold coil winding. This coil must be a valid coil
 defined in your `coils:` section.
 
 ### main_coil:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 The name of the main (power) coil winding. This coil must be a valid
 coil defined in your `coils:` section.
@@ -79,7 +79,7 @@ of your config. (If you don't include them, the default will be used).
 
 ### eos_switch:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 

--- a/docs/config/extra_balls.md
+++ b/docs/config/extra_balls.md
@@ -59,7 +59,7 @@ Whether the device starts enabled or disabled.
 
 ### group:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [extra_ball_groups:](extra_ball_groups.md)
 device. Defaults to empty.
 

--- a/docs/config/flasher_player.md
+++ b/docs/config/flasher_player.md
@@ -42,7 +42,7 @@ color `AAAAAA`.
 
 ### ms:
 
-Single value, type: ms_or_token. Default: `100ms`
+Single value, type: `ms_or_token`. Default: `100ms`
 
 Configures how long should that flasher be enabled.
 

--- a/docs/config/flippers.md
+++ b/docs/config/flippers.md
@@ -104,7 +104,7 @@ config:
 
 ### main_coil:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 The name of the main flipper coil. For flippers that only have
 single-wound coils, this is where you specify that coil. In that case
@@ -119,7 +119,7 @@ config. (If you don't include them, the default will be used).
 
 ### activation_switch:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -177,7 +177,7 @@ hold coil break we do not want to continuously pulse the coil.
 
 ### eos_switch:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -193,7 +193,7 @@ switch name here.
 
 ### hold_coil:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 The name of the hold coil winding for dual-wound flipper coils.
 
@@ -235,7 +235,7 @@ Overwrites settings on the main_coil. See
 
 ### playfield:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [playfields:](playfields.md) device. Default:
 `playfield`
 

--- a/docs/config/hardware_benchmark.md
+++ b/docs/config/hardware_benchmark.md
@@ -23,19 +23,19 @@ of your config:
 
 ### coil1:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 --8<-- "todo.md"
 
 ### coil2:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 --8<-- "todo.md"
 
 ### flipper:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [flippers:](flippers.md) device. Defaults to
 empty.
 
@@ -48,7 +48,7 @@ of your config. (If you don't include them, the default will be used).
 
 ### switch1:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -56,7 +56,7 @@ empty.
 
 ### switch2:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 

--- a/docs/config/hardware_sound_player.md
+++ b/docs/config/hardware_sound_player.md
@@ -55,7 +55,7 @@ be different per sound.
 
 ### platform_options:
 
-Single value, type: dict. Defaults to empty.
+Single value, type: `dict`. Defaults to empty.
 
 --8<-- "todo.md"
 

--- a/docs/config/hardware_sound_player.md
+++ b/docs/config/hardware_sound_player.md
@@ -61,7 +61,7 @@ Single value, type: dict. Defaults to empty.
 
 ### sound_system:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [hardware_sound_systems:](hardware_sound_systems.md) device. Default: `default`
 
 In case you got multiple hardware_sound platforms you can expliticly

--- a/docs/config/hardware_sound_systems.md
+++ b/docs/config/hardware_sound_systems.md
@@ -30,7 +30,7 @@ Overwrite the default platform.
 
 ### platform_settings:
 
-Single value, type: dict. Defaults to empty.
+Single value, type: `dict`. Defaults to empty.
 
 --8<-- "todo.md"
 

--- a/docs/config/keyboard.md
+++ b/docs/config/keyboard.md
@@ -89,7 +89,7 @@ and *direction=1*.
 
 ### switch:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 

--- a/docs/config/kickbacks.md
+++ b/docs/config/kickbacks.md
@@ -44,7 +44,7 @@ config:
 
 ### coil:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 The name of the coil you want to fire. (Actually, perhaps we should
 phrase it as the name of the coil you want to change the state on,
@@ -53,7 +53,7 @@ stop firing based on a switch change.)
 
 ### switch:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -133,7 +133,7 @@ controller hardware.
 
 ### playfield:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [playfields:](playfields.md) device. Default:
 `playfield`
 

--- a/docs/config/light_player.md
+++ b/docs/config/light_player.md
@@ -76,14 +76,14 @@ to underlying shows as if the light has never been used in this show.
 
 ### fade:
 
-Single value, type: ms_or_token. Defaults to empty.
+Single value, type: `ms_or_token`. Defaults to empty.
 
 Time to fade this light in ms. Use this to achieve smooth transitions
 between colors.
 
 ### priority:
 
-Single value, type: int_or_token. Default: `0`
+Single value, type: `int_or_token`. Default: `0`
 
 Relative priority of this entry in the light stack.
 

--- a/docs/config/light_rings.md
+++ b/docs/config/light_rings.md
@@ -86,7 +86,7 @@ of 200 and a count of 5 will create 5 LEDs with the numbers 7-200,
 
 ### previous:
 
-Single value, type: string name of a [lights:](lights.md) device. Defaults to empty.
+Single value, type: `string` name of a [lights:](lights.md) device. Defaults to empty.
 
 --8<-- "todo.md"
 

--- a/docs/config/light_stripes.md
+++ b/docs/config/light_stripes.md
@@ -93,7 +93,7 @@ of 200 and a count of 5 will create 5 LEDs with the numbers 7-200,
 
 ### previous:
 
-Single value, type: string name of a [lights:](lights.md) device. Defaults to empty.
+Single value, type: `string` name of a [lights:](lights.md) device. Defaults to empty.
 
 --8<-- "todo.md"
 

--- a/docs/config/lights.md
+++ b/docs/config/lights.md
@@ -113,7 +113,7 @@ config. (If you don't include them, the default will be used).
 
 ### channels:
 
-Single value, type: dict. Defaults to empty.
+Single value, type: `dict`. Defaults to empty.
 
 Instead of a single `number` address for a light, you can enter channels
 corresponding to the multi-color channels of an RGB or RGBW LED. Each
@@ -219,7 +219,7 @@ lights:
 
 ### platform_settings:
 
-Single value, type: dict. Defaults to empty.
+Single value, type: `dict`. Defaults to empty.
 
 Platform-specific light settings. Consult your platform documentation
 for details.

--- a/docs/config/lights.md
+++ b/docs/config/lights.md
@@ -226,7 +226,7 @@ for details.
 
 ### previous:
 
-Single value, type: string name of a [lights:](lights.md) device. Defaults to empty.
+Single value, type: `string` name of a [lights:](lights.md) device. Defaults to empty.
 
 Instead of specifying the number for each light in a chain you can also
 use the previous setting. To do this only specify the number of the

--- a/docs/config/magnets.md
+++ b/docs/config/magnets.md
@@ -23,7 +23,7 @@ config:
 
 ### magnet_coil:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 Note that is any of the magnet activation times are longer than 255ms
 and the magnet pulse power is 100%, then you will need to add
@@ -84,7 +84,7 @@ magnet will be activated for the `grab_time:`.
 
 ### grab_switch:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -99,7 +99,7 @@ How long the magnet will be energized when attempting to grab a ball.
 
 ### playfield:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [playfields:](playfields.md) device. Default:
 `playfield`
 

--- a/docs/config/motors.md
+++ b/docs/config/motors.md
@@ -216,7 +216,7 @@ Whether the motor should be included in ball search.
 
 ### motor_left_output:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [digital_outputs:](digital_outputs.md)
 device. Defaults to empty.
 
@@ -227,7 +227,7 @@ in one direction or both if it can move in both directions.
 
 ### motor_right_output:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [digital_outputs:](digital_outputs.md)
 device. Defaults to empty.
 

--- a/docs/config/multiball_locks.md
+++ b/docs/config/multiball_locks.md
@@ -201,7 +201,7 @@ the default playfield source device.
 
 ### source_playfield:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [ball_devices:](ball_devices.md) device.
 Default: `playfield`
 

--- a/docs/config/multiballs.md
+++ b/docs/config/multiballs.md
@@ -254,7 +254,7 @@ play.
 
 ### source_playfield:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [ball_devices:](ball_devices.md) device.
 Default: `playfield`
 

--- a/docs/config/neoseg_displays.md
+++ b/docs/config/neoseg_displays.md
@@ -55,7 +55,7 @@ Single value, type: `string`. Defaults to empty.
 
 ### previous:
 
-Single value, type: string name of a [lights:](lights.md) device. Defaults to empty.
+Single value, type: `string` name of a [lights:](lights.md) device. Defaults to empty.
 
 --8<-- "todo.md"
 

--- a/docs/config/playfield_transfers.md
+++ b/docs/config/playfield_transfers.md
@@ -47,7 +47,7 @@ section of your config:
 
 ### captures_from:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [ball_devices:](ball_devices.md) device.
 Defaults to empty.
 
@@ -55,7 +55,7 @@ Source playfield for the transfer.
 
 ### eject_target:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [ball_devices:](ball_devices.md) device.
 Defaults to empty.
 
@@ -69,7 +69,7 @@ used).
 
 ### ball_switch:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 

--- a/docs/config/playfields.md
+++ b/docs/config/playfields.md
@@ -25,7 +25,7 @@ config:
 
 ### default_source_device:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [ball_devices:](ball_devices.md) device.
 Defaults to empty.
 

--- a/docs/config/score_reels.md
+++ b/docs/config/score_reels.md
@@ -22,7 +22,7 @@ your config. (If you don't include them, the default will be used).
 
 ### coil_inc:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 Coil to fire to increment this reel.
 
@@ -54,7 +54,7 @@ How long to wait after a pulse before pulsing the coil again.
 
 ### switch_0:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -62,7 +62,7 @@ Switch which indicates that the reel is showing a 0.
 
 ### switch_1:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -70,7 +70,7 @@ Switch which indicates that the reel is showing a 1.
 
 ### switch_10:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -78,7 +78,7 @@ Switch which indicates that the reel is showing a 10.
 
 ### switch_11:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -86,7 +86,7 @@ Switch which indicates that the reel is showing a 11.
 
 ### switch_12:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -94,7 +94,7 @@ Switch which indicates that the reel is showing a 12.
 
 ### switch_2:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -102,7 +102,7 @@ Switch which indicates that the reel is showing a 2.
 
 ### switch_3:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -110,7 +110,7 @@ Switch which indicates that the reel is showing a 3.
 
 ### switch_4:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -118,7 +118,7 @@ Switch which indicates that the reel is showing a 4.
 
 ### switch_5:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -126,7 +126,7 @@ Switch which indicates that the reel is showing a 5.
 
 ### switch_6:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -134,7 +134,7 @@ Switch which indicates that the reel is showing a 6.
 
 ### switch_7:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -142,7 +142,7 @@ Switch which indicates that the reel is showing a 7.
 
 ### switch_8:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 
@@ -150,7 +150,7 @@ Switch which indicates that the reel is showing a 8.
 
 ### switch_9:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 

--- a/docs/config/segment_display_player.md
+++ b/docs/config/segment_display_player.md
@@ -60,7 +60,7 @@ information on specifying colors in config files.
 
 ### expire:
 
-Single value, type: ms_or_token. Defaults to empty.
+Single value, type: `ms_or_token`. Defaults to empty.
 
 Only used with `action` `add`. Text will be removed after `expire` ms.
 
@@ -101,7 +101,7 @@ used if `replace` is used.
 
 ### priority:
 
-Single value, type: int_or_token. Default: `0`
+Single value, type: `int_or_token`. Default: `0`
 
 Priority of this text. The segment display will maintain a stack and
 show the text on top (highest priority). Only relevant if [segment_displays](segment_displays.md) `update_method` is `stack`, not being

--- a/docs/config/segment_displays.md
+++ b/docs/config/segment_displays.md
@@ -46,7 +46,7 @@ colors than the `size` of your display the other digitis will have `white` as de
 
 ### default_transition_update_hz:
 
-Single value, type: float_or_token. Default: `30`
+Single value, type: `float_or_token`. Default: `30`
 
 The speed (steps per second) at which text transition effects will be
 updated in the display.
@@ -80,7 +80,7 @@ This can be used to overwrite the platform which is defined in the
 
 ### platform_settings:
 
-Single value, type: dict. Defaults to empty.
+Single value, type: `dict`. Defaults to empty.
 
 Platform specific settings. See your
 [segment platform documentation](../hardware/segment_display_platforms.md).

--- a/docs/config/sequence_shots.md
+++ b/docs/config/sequence_shots.md
@@ -154,7 +154,7 @@ A sequence of events which will complete the sequence.
 
 ### playfield:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [playfields:](playfields.md) device. Default:
 `playfield`
 

--- a/docs/config/servos.md
+++ b/docs/config/servos.md
@@ -118,7 +118,7 @@ details.
 
 ### platform_settings:
 
-Single value, type: dict. Defaults to empty.
+Single value, type: `dict`. Defaults to empty.
 
 --8<-- "todo.md"
 

--- a/docs/config/shot_profiles.md
+++ b/docs/config/shot_profiles.md
@@ -14,7 +14,7 @@ title: "shot_profiles:"
 
 The `shot_profiles:` section of your config is where you configure the
 settings for various *shot profiles* that you can then apply to your
-shots.
+[shots](shots.md), using the [*profile*](shots.md#profile) property.
 
 Here's an example:
 
@@ -28,6 +28,9 @@ shot_profiles:
       - name: lit
         show: "on"
 ```
+
+This is actually the same as the default profile that all shots will use unless
+another is explicitly set.
 
 ## \(name\):
 
@@ -268,4 +271,5 @@ The sync_ms value of the show.
 
 ## Related How To guides
 
+* [Shots](../game_logic/shots/index.md)
 * [Shot Profiles](../game_logic/shots/shot_profiles.md)

--- a/docs/config/shots.md
+++ b/docs/config/shots.md
@@ -19,7 +19,7 @@ be hit in order, or an event or series of events.
 Shots are used for things like standup targets, rollover lanes, drop
 targets, ramps, loops, orbits, etc.
 
-Each shot can have a *shot profile* applied to it which defines what
+Each shot can have a [*shot profile*](shot_profile.md) applied to it which defines what
 happens when its hit. For example the shot profile might specify that
 the shot starts unlit, then when it's hit it becomes complete. Or a
 shot profile might specify that it's flashing slowly, and each hit
@@ -225,7 +225,7 @@ the same player.
 
 ### playfield:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [playfields:](playfields.md) device. Default:
 `playfield`
 
@@ -234,7 +234,7 @@ multiple playfields. It is used mostly for ball search.
 
 ### profile:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [shot_profiles:](shot_profiles.md) device.
 Default: `default`
 
@@ -423,3 +423,4 @@ access groups of devices by tag name.
 ## Related How To guides
 
 * [Shots](../game_logic/shots/index.md)
+* [Shot Profiles](../game_logic/shots/shot_profiles.md)

--- a/docs/config/show_player.md
+++ b/docs/config/show_player.md
@@ -205,7 +205,7 @@ on.
 
 ### loops:
 
-Single value, type: int_or_token. Default: `-1`
+Single value, type: `int_or_token`. Default: `-1`
 
 Controls the looping / repeating of the show. The default if you don't
 include this setting is `loops: -1` means that the show will repeat
@@ -250,7 +250,7 @@ advance to its next step.
 
 ### priority:
 
-Single value, type: int_or_token. Default: `0`
+Single value, type: `int_or_token`. Default: `0`
 
 Adjusts the priority of the show that's played.
 
@@ -339,7 +339,7 @@ Note that you can use a
 
 ### sync_ms:
 
-Single value, type: int_or_token. Defaults to empty.
+Single value, type: `int_or_token`. Defaults to empty.
 
 Sets the sync_ms value of this show which will delay the start to a
 certain millisecond multiple to ensure that multiple shows started at

--- a/docs/config/slide_player.md
+++ b/docs/config/slide_player.md
@@ -144,7 +144,7 @@ priorities to control which slides are shown.
 
 ### priority:
 
-Single value, type: int_or_token. Defaults to empty.
+Single value, type: `int_or_token`. Defaults to empty.
 
 An adjustment to the priority of the slide that will be shown.
 

--- a/docs/config/snux.md
+++ b/docs/config/snux.md
@@ -74,7 +74,7 @@ config:
 
 ### diag_led_driver:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 The coil to use to drive the diag LED on the snux board. This is usually
 driver 23 on the Snux board.

--- a/docs/config/sound_player.md
+++ b/docs/config/sound_player.md
@@ -203,7 +203,7 @@ Used to reference this sound entry when stopping/pausing/resuming it.
 
 ### loops:
 
-Single value, type: int_or_token. Defaults to empty.
+Single value, type: `int_or_token`. Defaults to empty.
 
 Please refer to the [sounds:](sounds.md) documentation for details about this setting as it just
 overwrites the setting in your sound.
@@ -226,14 +226,14 @@ overwrites the setting in your sound.
 
 ### pan:
 
-Single value, type: float_or_token. Defaults to empty.
+Single value, type: `float_or_token`. Defaults to empty.
 
 Please refer to the [sounds:](sounds.md) documentation for details about this setting as it just
 overwrites the setting in your sound.
 
 ### priority:
 
-Single value, type: int_or_token. Defaults to empty.
+Single value, type: `int_or_token`. Defaults to empty.
 
 Please refer to the [sounds:](sounds.md) documentation for details about this setting as it just
 overwrites the setting in your sound.

--- a/docs/config/spi_bit_bang.md
+++ b/docs/config/spi_bit_bang.md
@@ -22,7 +22,7 @@ your config:
 
 ### clock_pin:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [digital_outputs:](digital_outputs.md)
 device. Defaults to empty.
 
@@ -30,7 +30,7 @@ This output is used to clock the SPI chip.
 
 ### cs_pin:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [digital_outputs:](digital_outputs.md)
 device. Defaults to empty.
 
@@ -39,7 +39,7 @@ triggers the parallel read of the chip.
 
 ### miso_pin:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 

--- a/docs/config/spinners.md
+++ b/docs/config/spinners.md
@@ -126,7 +126,7 @@ more times.
 
 ### playfield:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [playfields:](playfields.md) device. Default:
 `playfield`
 

--- a/docs/config/steppers.md
+++ b/docs/config/steppers.md
@@ -169,7 +169,7 @@ details.
 
 ### platform_settings:
 
-Single value, type: dict. Defaults to empty.
+Single value, type: `dict`. Defaults to empty.
 
 Platform specific stepper settings for this stepper. Check the
 [documentation of your platform](../hardware/platform.md) for details.

--- a/docs/config/steppers.md
+++ b/docs/config/steppers.md
@@ -119,7 +119,7 @@ determine whether the stepper is at the home position.
 
 ### homing_switch:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 

--- a/docs/config/switches.md
+++ b/docs/config/switches.md
@@ -176,7 +176,7 @@ details.
 
 ### platform_settings:
 
-Single value, type: dict. Defaults to empty.
+Single value, type: `dict`. Defaults to empty.
 
 Dict of platform specific settings. See your
 [platform documentation](../hardware/index.md)

--- a/docs/config/system11.md
+++ b/docs/config/system11.md
@@ -24,7 +24,7 @@ config:
 
 ### ac_relay_driver:
 
-Single value, type: string name of a [coils:](coils.md) device. Defaults to empty.
+Single value, type: `string` name of a [coils:](coils.md) device. Defaults to empty.
 
 The driver to use to drive the AC relay which switches between A and C
 side drivers.
@@ -50,7 +50,7 @@ Delay when switching between A and C side.
 
 ### ac_relay_switch:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [switches:](switches.md) device. Defaults to
 empty.
 

--- a/docs/config/variable_player.md
+++ b/docs/config/variable_player.md
@@ -228,7 +228,7 @@ will default to the current player.
 
 ### string:
 
-Single value, type: template_str. Defaults to empty.
+Single value, type: `template_str`. Defaults to empty.
 
 Here's an example from *Brooks 'n Dunn* where there is a player
 variable (set via a counter) which tracks the player's current album

--- a/docs/gmc/reference/slide_player.md
+++ b/docs/gmc/reference/slide_player.md
@@ -165,7 +165,7 @@ The name of the slide method to call when `action: method` is used. Additional p
 
 ### priority:
 
-Single value, type: int_or_token. Defaults to empty.
+Single value, type: `int_or_token`. Defaults to empty.
 
 An adjustment to the priority of the slide that will be shown.
 

--- a/docs/mc/widgets/image.md
+++ b/docs/mc/widgets/image.md
@@ -38,7 +38,7 @@ Tells MPF that this is an image widget
 
 ### image:
 
-Single value, type: string name of a
+Single value, type: `string` name of a
 [image](../../assets/images.md).
 
 The name of the image asset this widget will show. Details on image


### PR DESCRIPTION
Was touching up the shot profile linking and noticed that there were a lot of property definitions with "type: string" missing backticks around `string`