### PR TITLE
replace special apostrophe and single quote characters with ascii '

### DIFF
--- a/docs/code/BCP_Protocol/ball_end.md
+++ b/docs/code/BCP_Protocol/ball_end.md
@@ -1,7 +1,7 @@
 
 ## ball_end (BCP command)
 
-Indicates the ball has ended. Note that this does not necessarily mean that the next player’s turn will start, as this player may have an extra ball which means they’ll shoot again.
+Indicates the ball has ended. Note that this does not necessarily mean that the next player's turn will start, as this player may have an extra ball which means they'll shoot again.
 
 ## Origin
 Pin controller

--- a/docs/code/BCP_Protocol/goodbye.md
+++ b/docs/code/BCP_Protocol/goodbye.md
@@ -1,6 +1,6 @@
 
 # goodbye (BCP command)
-Lets one side tell the other than it’s shutting down.
+Lets one side tell the other than it's shutting down.
 
 ## Origin
 Pin controller or media controller

--- a/docs/code/BCP_Protocol/index.md
+++ b/docs/code/BCP_Protocol/index.md
@@ -7,11 +7,11 @@ This document describes the Backbox Control Protocol, (or “BCP”), a simple, 
 
     BCP is how the MPF core engine and the MPF media controller communicate.
 
-BCP transmits semantically relevant information and attempts to isolate specific behaviors and identifiers on both sides. i.e., the pin controller is responsible for telling the media controller “start multiball mode”. The pin controller doesn’t care what the media controller does with that information, and the media controller doesn’t care what happened on the pin controller that caused the multiball mode to start.
+BCP transmits semantically relevant information and attempts to isolate specific behaviors and identifiers on both sides. i.e., the pin controller is responsible for telling the media controller “start multiball mode”. The pin controller doesn't care what the media controller does with that information, and the media controller doesn't care what happened on the pin controller that caused the multiball mode to start.
 
 BCP is versioned to prevent conflicts. Future versions of the BCP will be designed to be backward compatible to every degree possible. The reference implementation uses a raw TCP socket for communication. On localhost the latency is usually sub-millisecond and on LANs it is under 10 milliseconds. That means that the effect of messages is generally under 1/100th of a second, which should be considered instantaneous from the perspective of human perception.
 
-It is important to note that this document specifies the details of the protocol itself, not necessarily the behaviors of any specific implementations it connects. Thus, there won’t be details about fonts or sounds or images or videos or shaders here; those are up to specific implementation being driven.
+It is important to note that this document specifies the details of the protocol itself, not necessarily the behaviors of any specific implementations it connects. Thus, there won't be details about fonts or sounds or images or videos or shaders here; those are up to specific implementation being driven.
 
 !!! warning "Infinite Loops Possible"
 

--- a/docs/code/BCP_Protocol/mode_start.md
+++ b/docs/code/BCP_Protocol/mode_start.md
@@ -1,6 +1,6 @@
 
 # mode_start (BCP command)
-A game mode has just started. The mode is passed via the name parameter, and the mode’s priority is passed as an integer via the priority.
+A game mode has just started. The mode is passed via the name parameter, and the mode's priority is passed as an integer via the priority.
 
 ## Origin
 Pin controller

--- a/docs/code/BCP_Protocol/player_turn_start.md
+++ b/docs/code/BCP_Protocol/player_turn_start.md
@@ -1,6 +1,6 @@
 
 # player_turn_start (BCP command)
-A new player’s turn has begun. If a player has an extra ball, this command will not be sent between balls. However, a new ball_start command will be sent when the same player’s additional balls start.
+A new player's turn has begun. If a player has an extra ball, this command will not be sent between balls. However, a new ball_start command will be sent when the same player's additional balls start.
 
 ## Origin
 Pin controller

--- a/docs/code/BCP_Protocol/player_variable.md
+++ b/docs/code/BCP_Protocol/player_variable.md
@@ -1,7 +1,7 @@
 
 # player_variable (BCP command)
 
-This is a generic “catch all” which sends player-specific variables to the media controller any time they change. Since the pin controller will most likely track hundreds of variables per player (with many being internal things that the media controller doesn’t care about), it’s recommended that the pin controller has a way to filter which player variables are sent to the media controller. Also note the parameter player_num indicates which player this variable is for (starting with 1 for the first player). While it’s usually the case that the player_variable command will be sent for the player whose turn it is, that’s not always the case. (For example, when a second player is added during the first player’s ball, the second player’s default variables will be initialized at 0 and a player_variable event for player 2 will be sent even though player 1 is up.
+This is a generic “catch all” which sends player-specific variables to the media controller any time they change. Since the pin controller will most likely track hundreds of variables per player (with many being internal things that the media controller doesn't care about), it's recommended that the pin controller has a way to filter which player variables are sent to the media controller. Also note the parameter player_num indicates which player this variable is for (starting with 1 for the first player). While it's usually the case that the player_variable command will be sent for the player whose turn it is, that's not always the case. (For example, when a second player is added during the first player's ball, the second player's default variables will be initialized at 0 and a player_variable event for player 2 will be sent even though player 1 is up.
 
 ## Origin
 Pin controller
@@ -30,7 +30,7 @@ This is the previous value of the player variable.
 ### change
 Type: Varies depending upon the variable type.
 
-If the player variable just changed, this will be the amount of the change. If it’s not possible to determine a numeric change (for example, if this player variable is a string), then this change value will be set to the boolean True.
+If the player variable just changed, this will be the amount of the change. If it's not possible to determine a numeric change (for example, if this player variable is a string), then this change value will be set to the boolean True.
 
 ## Response
 None

--- a/docs/code/BCP_Protocol/switch.md
+++ b/docs/code/BCP_Protocol/switch.md
@@ -11,7 +11,7 @@ followed very quickly by
 switch?name=start&state=0
 ```
 
-When sent from the pin controller to the media controller, this is used to send switch inputs to things like video modes, high score name entry, and service menu navigation. Note that the pin controller should not send the state of every switch change at all times, as the media controller doesn’t need it and that would add lots of unnecessary commands. Instead the pin controller should only send switches based on some mode of operation that needs them. (For example, when the video mode starts, the pin controller would start sending the switch states of the flipper buttons, and when the video mode ends, it would stop.)
+When sent from the pin controller to the media controller, this is used to send switch inputs to things like video modes, high score name entry, and service menu navigation. Note that the pin controller should not send the state of every switch change at all times, as the media controller doesn't need it and that would add lots of unnecessary commands. Instead the pin controller should only send switches based on some mode of operation that needs them. (For example, when the video mode starts, the pin controller would start sending the switch states of the flipper buttons, and when the video mode ends, it would stop.)
 
 ## Origin
 Pin controller or media controller

--- a/docs/code/Writing_Tests/RunUnitTests.md
+++ b/docs/code/Writing_Tests/RunUnitTests.md
@@ -7,9 +7,9 @@ Once MPF is installed, you can run some automated tests to make sure that everyt
 python3 -m unittest discover mpf/tests
 ```
 
-When you do this, you should see a bunch of dots on the screen (one for each test that’s run), and then when it’s done, you should see a message showing how many tests were run and that they were successful. The whole process should take less a minute or so.
+When you do this, you should see a bunch of dots on the screen (one for each test that's run), and then when it's done, you should see a message showing how many tests were run and that they were successful. The whole process should take less a minute or so.
 
-(If you see any messages about some tests taking more than 0.5s, that’s ok.)
+(If you see any messages about some tests taking more than 0.5s, that's ok.)
 
 The important thing is that when the tests are done, you should have a message like this:
 
@@ -21,11 +21,11 @@ OK
 C:\>
 ```
 
-Note that the number of tests is changing all the time, so it probably won’t be exactly 587. And also the time they took to run will be different depending on how fast your computer is.
+Note that the number of tests is changing all the time, so it probably won't be exactly 587. And also the time they took to run will be different depending on how fast your computer is.
 
-These tests are the actual tests that the developers of MPF use to test MPF itself. We wrote all these tests to make sure that updates and changes we add to MPF don’t break things. :) So if these tests pass, you know your MPF installation is solid.
+These tests are the actual tests that the developers of MPF use to test MPF itself. We wrote all these tests to make sure that updates and changes we add to MPF don't break things. :) So if these tests pass, you know your MPF installation is solid.
 
-Remember though that MPF is actually two separate parts, the MPF game engine and the MPF media controller. The command you run just tested the game engine, so now let’s test the media controller. To do this, run the following command (basically the same thing as last time but with an “mc” added to the end, like this):
+Remember though that MPF is actually two separate parts, the MPF game engine and the MPF media controller. The command you run just tested the game engine, so now let's test the media controller. To do this, run the following command (basically the same thing as last time but with an “mc” added to the end, like this):
 
 ``` console
 python3 -m unittest discover mpfmc/tests
@@ -35,11 +35,11 @@ python3 -m unittest discover mpfmc/tests
 
 When you run the MPF-MC tests, you should see a graphical window pop up on the screen, and many of the tests will put graphics and words in that window. Also, some of the tests include audio, so if your speakers are on you should hear some sounds at some point.
 
-These tests take significantly longer (maybe 8x) than the MPF tests, but when they’re done, that graphical window should close, and you’ll see all the dots in your command window and a note that all the tests were successful.
+These tests take significantly longer (maybe 8x) than the MPF tests, but when they're done, that graphical window should close, and you'll see all the dots in your command window and a note that all the tests were successful.
 
 Notes about the MPF-MC tests:
 
-* These tests create a window on the screen and then just re-use the same window for all tests (to save time). So don’t worry if it looks like the window content is scaled weird or blurry or doesn’t fill the entire window.
+* These tests create a window on the screen and then just re-use the same window for all tests (to save time). So don't worry if it looks like the window content is scaled weird or blurry or doesn't fill the entire window.
 * Many of these tests are used to test internal workings of the media controller itself, so there will be lots of time when the pop up window is blank or appears frozen since the tests are testing non-visual things.
-* The animation and transition tests include testing functionality to stop, restart, pause, and skip frames. So if things look “jerky” in the tests, don’t worry, that doesn’t mean your computer is slow, it’s just how the tests work! :)
+* The animation and transition tests include testing functionality to stop, restart, pause, and skip frames. So if things look “jerky” in the tests, don't worry, that doesn't mean your computer is slow, it's just how the tests work! :)
 

--- a/docs/code/Writing_Tests/WritingCustomTestsForYourMachine.md
+++ b/docs/code/Writing_Tests/WritingCustomTestsForYourMachine.md
@@ -5,17 +5,17 @@ As we already mentioned, the creators of MPF are HUGE believers in the value of 
 
 For example, you can write a test that simulates starting a game, launching a ball, hitting a sequence of switches, and then verifying that a certain mode is running, or a light is the right color, or an achievement group is in the proper state, etc. Then you can advance the time to timeout a mode and verify that the mode as stopped, etc, etc.
 
-When you first start building your MPF config, you might think, “What’s the point?”… especially with some of the more simple tests. However your MPF config files will get complex pretty quickly, and often times you’ll think you have some mode done and working perfectly, but then a month later you change something that seems unrelated which ends up breaking it. Unfortunately this usually happens without you knowing it, and by the time you realize that something broke, more times has passed and it’s hard to figure out what broke what.
+When you first start building your MPF config, you might think, “What's the point?”… especially with some of the more simple tests. However your MPF config files will get complex pretty quickly, and often times you'll think you have some mode done and working perfectly, but then a month later you change something that seems unrelated which ends up breaking it. Unfortunately this usually happens without you knowing it, and by the time you realize that something broke, more times has passed and it's hard to figure out what broke what.
 
 So this is where unit tests come in! :)
 
-If you write simple unit tests that test each new thing you add to an MPF config file, then over time you’ll end up with a huge library of tests for your game. If you get in the habit of running your tests often, then you’ll know right away if a change that you made broke something. (And you’ll also know when everything is ok when all your tests pass again!)
+If you write simple unit tests that test each new thing you add to an MPF config file, then over time you'll end up with a huge library of tests for your game. If you get in the habit of running your tests often, then you'll know right away if a change that you made broke something. (And you'll also know when everything is ok when all your tests pass again!)
 
 Tutorial for writing your own tests
 
-We have a complete tutorial which walks you through writing tests for your own machine. This tutorial conveniently follows the general MPF tutorial at docs.missionpinball.org. Each step here matches the step with the same number there. (Just make sure you’ll looking at the same version of the documentation in both places.)
+We have a complete tutorial which walks you through writing tests for your own machine. This tutorial conveniently follows the general MPF tutorial at docs.missionpinball.org. Each step here matches the step with the same number there. (Just make sure you'll looking at the same version of the documentation in both places.)
 
-In the general MPF tutorial, each step builds on the previous to add more features to the config files for the tutorial project. In the unit test tutorial (what you’re reading here), each step shows you how to write the unit tests which test the new features you just added to the tutorial machine.
+In the general MPF tutorial, each step builds on the previous to add more features to the config files for the tutorial project. In the unit test tutorial (what you're reading here), each step shows you how to write the unit tests which test the new features you just added to the tutorial machine.
 
 You can follow along and learn here:
 
@@ -29,23 +29,23 @@ First, create a folder called tests in your machine folder. This would be alongs
 
 ### 2. Add an empty `__init__.py` file
 
-Next, inside your new tests folder, create a blank file called `__init__.py`. (That’s two underscores, then the word “init”, then two more underscores, then “.py”.) This file should be totally blank. (It just needs to exist.) This file is needed to let the Python test runner find and load the tests from this folder.
+Next, inside your new tests folder, create a blank file called `__init__.py`. (That's two underscores, then the word “init”, then two more underscores, then “.py”.) This file should be totally blank. (It just needs to exist.) This file is needed to let the Python test runner find and load the tests from this folder.
 
 ### 3. Add a test file
 
 Next you need to add a Python file which actually holds your tests. You can name this file whatever you want as long as it starts with “test”. (The reason for starting it with “test” is also so that the Python test runner knows that this file contains tests, allowing it to automatically find and run tests from it.)
 
-For now let’s call it test_step_2.py.
+For now let's call it test_step_2.py.
 
 Open that file and add the following lines to it: (If you are interested in what all this means, then read on below the file. Otherwise you can skip down to Step 4.)
 
-So what’s this file actually doing?
+So what's this file actually doing?
 
 The import line just imports the base class we use for MPF machine tests. (More details on that is covered in the Testing Class API page).
 
 Our specific class name TestTutorialMachine can be whatever you want. Again just make sure it starts with “Test” in order for the test runner to find out.
 
-Our specific method is called test_step_2_mpf_startup(). (Also it has to start with “test”). When the tests are run each method represents a separate “run” of MPF. The test runner will start up MPF and get it all up and running, and then it will move through the code in the test method, then it will cleanly shut down MPF when it’s done. If there are multiple test methods, then the test running will start and stop MPF multiple times. The key is that each test method is run against a “fresh” MPF copy.
+Our specific method is called test_step_2_mpf_startup(). (Also it has to start with “test”). When the tests are run each method represents a separate “run” of MPF. The test runner will start up MPF and get it all up and running, and then it will move through the code in the test method, then it will cleanly shut down MPF when it's done. If there are multiple test methods, then the test running will start and stop MPF multiple times. The key is that each test method is run against a “fresh” MPF copy.
 
 These test methods will also load the machine config files (just like if the command mpf was run the regular way).
 
@@ -55,7 +55,7 @@ Anyway, in our test method, we have the only actual line that does anything:
 self.assertModeRunning('attract')
 ```
 
-This just tests (“asserts”) that a mode called “attract” is running. There are all sorts of MPF-specific assertion methods which we’ll cover in later steps of this tutorial.
+This just tests (“asserts”) that a mode called “attract” is running. There are all sorts of MPF-specific assertion methods which we'll cover in later steps of this tutorial.
 
 ### 4. Run your test
 
@@ -80,7 +80,7 @@ That warning about the deprecation can be ignored (if you even have it.. you mig
 
 ### 5. Check out a failed test
 
-When you’re writing unit tests, you’ll end up dealing with failed tests a lot! So let’s purposefully change the test so it fails. In this case, change the line which asserts a mode called “attract” is running to look for a mode called “foo” instead, like this:
+When you're writing unit tests, you'll end up dealing with failed tests a lot! So let's purposefully change the test so it fails. In this case, change the line which asserts a mode called “attract” is running to look for a mode called “foo” instead, like this:
 
 ``` python
 self.assertModeRunning('foo')
@@ -116,14 +116,14 @@ Note that we see the test run failed, with one failure, and that we can scroll u
 
 So to get this test to work, you either need to change your MPF config to start a mode called “foo”, or you need to change the test back to looking for a mode called “attract”. :)
 
-### What if it didn’t work?
+### What if it didn't work?
 
-If the unit tests don’t work for you, there are a few things you can try.
+If the unit tests don't work for you, there are a few things you can try.
 
-If you get some kind of loading error or config error, make sure you’re running python -m unittest from your machine folder (not from the “tests” folder).
+If you get some kind of loading error or config error, make sure you're running python -m unittest from your machine folder (not from the “tests” folder).
 
 If you get a message about 0 tests run, make sure you have that empty __init__.py in your tests folder.
 
-And if you get some weird error that you can’t figure out, then post a message to the MPF Google Group.
+And if you get some weird error that you can't figure out, then post a message to the MPF Google Group.
 
 

--- a/docs/code/Writing_Tests/index.md
+++ b/docs/code/Writing_Tests/index.md
@@ -3,9 +3,9 @@
 
 The MPF dev team are strong believers in automated testing, and we use a test-driven development (TDD) process for developing MPF itself. (At the time of this writing, there are over 800 unit tests for MPF and MPF-MC, each which contain dozens of individual tests.)
 
-We have extended Python’s built-in unittest TestCase class for MPF-specific tests, including mocking critical internal elements and adding assertion methods for MPF features.
+We have extended Python's built-in unittest TestCase class for MPF-specific tests, including mocking critical internal elements and adding assertion methods for MPF features.
 
-You can run built-in tests to test MPF itself or extend them if you think you found a bug or if you’re adding features to MPF. We have also built TestCase classes you can use to write unittests for your own machine. Read on for details:
+You can run built-in tests to test MPF itself or extend them if you think you found a bug or if you're adding features to MPF. We have also built TestCase classes you can use to write unittests for your own machine. Read on for details:
 
 * [How to run MPF unittests](RunUnitTests.md)
 * [Writing Custom Tests for your Machine](WritingCustomTestsForYourMachine.md)

--- a/docs/code/api_reference/api_reference_config_players.md
+++ b/docs/code/api_reference/api_reference_config_players.md
@@ -1,5 +1,6 @@
 # Config Players
 
+
 Config players are available as machine attributes in the form of their player name plus \_player, for example, `self.machine.light_player` or `self.machine.score_player`.
 
 * [blocking_player](config_players/blocking_player.md)

--- a/docs/code/api_reference/api_reference_device.md
+++ b/docs/code/api_reference/api_reference_device.md
@@ -8,7 +8,7 @@ Note
 
 “Devices” in MPF are more than physical hardware devices. Many of the “game logic” components listed in the user documentation (achievements, ball holds, extra balls, etc.) are implemented as “devices” in MPF code. (So you can think of devices as being either physical or logical.)
 
-Here’s a list of all the device types in MPF, linked to their API references.
+Here's a list of all the device types in MPF, linked to their API references.
 
 * [accelerometers](devices/accelerometers.md)
 * [accruals](devices/accruals.md)

--- a/docs/code/api_reference/api_reference_misc_components.md
+++ b/docs/code/api_reference/api_reference_misc_components.md
@@ -1,6 +1,6 @@
 # Miscellaneous Components
 
-There are several other components and systems of MPF that don’t fit into any of the other categories. Those are covered here.
+There are several other components and systems of MPF that don't fit into any of the other categories. Those are covered here.
 
 * [Ball Search](misc_components/BallSearch.md)
 * [File Manager](misc_components/FileManager.md)

--- a/docs/code/api_reference/api_reference_modes.md
+++ b/docs/code/api_reference/api_reference_modes.md
@@ -1,6 +1,6 @@
 # Modes
 
-Covers all the “built-in” modes. They’re accessible via `self.machine.modes.*name*`, for example, `self.machine.modes.game` or `self.machine.modes.base`.
+Covers all the “built-in” modes. They're accessible via `self.machine.modes.*name*`, for example, `self.machine.modes.game` or `self.machine.modes.base`.
 
 * [attract](modes/attract.md)
 * [bonus](modes/bonus.md)

--- a/docs/code/api_reference/api_reference_testing_class_api.md
+++ b/docs/code/api_reference/api_reference_testing_class_api.md
@@ -6,9 +6,9 @@ These tests include several MPF-specific assertion methods for things like modes
 
 You can add commands in your tests to “advance” the time which the MPF tests can test quickly, so you can test a complete 3-minute game play session in a few hundred milliseconds of real world time.
 
-It might be helpful to look at the real internal tests that MPF uses (which all use these test classes) to get a feel for how tests are written in MPF. They’re available in the mpf/tests folder in the MPF repository. (They’re installed locally when you install MPF.)
+It might be helpful to look at the real internal tests that MPF uses (which all use these test classes) to get a feel for how tests are written in MPF. They're available in the mpf/tests folder in the MPF repository. (They're installed locally when you install MPF.)
 
-Here’s a diagram which shows how all the MPF and MPF-MC test case classes relate to each other:
+Here's a diagram which shows how all the MPF and MPF-MC test case classes relate to each other:
 
 ![Testing Classes](testing_class_api/test_classes.png)
 

--- a/docs/code/api_reference/core/auditor.md
+++ b/docs/code/api_reference/core/auditor.md
@@ -11,7 +11,7 @@ Bases: `object`
 Writes switch events, regular events, and player variables to an audit log file.
 
 ## Accessing the auditor in code
-There is only one instance of the auditor in MPF, and it’s accessible via self.machine.auditor.
+There is only one instance of the auditor in MPF, and it's accessible via self.machine.auditor.
 
 ## Methods & Attributes
 
@@ -23,7 +23,7 @@ Log an auditable event.
 Parameters:
 
 * **audit_class** – A string of the section we want this event to be logged to.
-* **event** – A string name of the event we’re auditing.
+* **event** – A string name of the event we're auditing.
 * ****kwargs** – Not used, but included since some of the audit events might include random kwargs.
 
 `audit_event(eventname, **kwargs)`
@@ -65,4 +65,4 @@ Parameters:
 
 `enabled`
 
-Attribute that’s viewed by other core components to let them know they should send auditing events. Set this via the enable() and disable() methods.
+Attribute that's viewed by other core components to let them know they should send auditing events. Set this via the enable() and disable() methods.

--- a/docs/code/api_reference/core/ball_controller.md
+++ b/docs/code/api_reference/core/ball_controller.md
@@ -12,7 +12,7 @@ Tracks and manages all the balls in a pinball machine.
 
 ## Accessing the ball_controller in code
 
-    There is only one instance of the ball_controller in MPF, and it’s accessible via self.machine.ball_controller.
+    There is only one instance of the ball_controller in MPF, and it's accessible via self.machine.ball_controller.
 
 ## Methods & Attributes
 
@@ -25,20 +25,20 @@ Inform ball controller about a capured ball (which might be new).
 `are_balls_collected(target: Union[str, Iterable[str]]) → bool`
 
 Check to see if all the balls are contained in devices tagged with the parameter that was passed.
-Note if you pass a target that’s not used in any ball devices, this method will return True. (Because you’re asking if all balls are nowhere, and they always are. :)
+Note if you pass a target that's not used in any ball devices, this method will return True. (Because you're asking if all balls are nowhere, and they always are. :)
 
 Parameters:
 
-* **target** – String or list of strings of the tags you’d like to collect the balls to. Default of None will be replaced with ‘home’ and ‘trough’.
+* **target** – String or list of strings of the tags you'd like to collect the balls to. Default of None will be replaced with 'home' and 'trough'.
 
 `collect_balls(target='home, trough') → None`
 
 Ensure that all balls are in contained in ball devices with the tag or list of tags you pass.
-Typically this would be used after a game ends, or when the machine is reset or first starts up, to ensure that all balls are in devices tagged with ‘home’ and/or ‘trough’.
+Typically this would be used after a game ends, or when the machine is reset or first starts up, to ensure that all balls are in devices tagged with 'home' and/or 'trough'.
 
 Parameters:
 
-* **target** – A string of the tag name or a list of tags names of the ball devices you want all the balls to end up in. Default is [‘home’, ‘trough’].
+* **target** – A string of the tag name or a list of tags names of the ball devices you want all the balls to end up in. Default is ['home', 'trough'].
 
 `dump_ball_counts() → None`
 
@@ -47,4 +47,4 @@ Dump ball count of all devices.
 `request_to_start_game(**kwargs) → bool`
 
 Handle result of the request_to_start_game event.
-Checks to make sure that the balls are in all the right places and returns. If too many balls are missing (based on the config files ‘Min Balls’ setting), it will return False to reject the game start request.
+Checks to make sure that the balls are in all the right places and returns. If too many balls are missing (based on the config files 'Min Balls' setting), it will return False to reject the game start request.

--- a/docs/code/api_reference/core/bcp.md
+++ b/docs/code/api_reference/core/bcp.md
@@ -12,7 +12,7 @@ BCP Module.
 
 ## Accessing the bcp in code
 
-There is only one instance of the bcp in MPF, and it’s accessible via self.machine.bcp.
+There is only one instance of the bcp in MPF, and it's accessible via self.machine.bcp.
 
 ## Methods & Attributes
 

--- a/docs/code/api_reference/core/device_manager.md
+++ b/docs/code/api_reference/core/device_manager.md
@@ -12,7 +12,7 @@ Manages all the devices in MPF.
 
 ## Accessing the device_manager in code
 
-There is only one instance of the device_manager in MPF, and it’s accessible via self.machine.device_manager.
+There is only one instance of the device_manager in MPF, and it's accessible via self.machine.device_manager.
 
 ## Methods & Attributes
 

--- a/docs/code/api_reference/core/events.md
+++ b/docs/code/api_reference/core/events.md
@@ -12,7 +12,7 @@ Handles all the events and manages the handlers in MPF.
 
 ## Accessing the events in code
 
-There is only one instance of the events in MPF, and it’s accessible via self.machine.events.
+There is only one instance of the events in MPF, and it's accessible via self.machine.events.
 
 ## Methods & Attributes
 
@@ -28,11 +28,11 @@ Register an event handler to respond to an event.
 
 Parameters:
 
-* **event** – String name of the event you’re adding a handler for. Since events are text strings, they don’t have to be pre-defined.
-* **handler** – The callable method that will be called when the event is fired. Since it’s possible for events to have kwargs attached to them, the handler method must include **kwargs in its signature.
-* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don’t matter. They’re called from highest to lowest. (i.e. priority 100 is called before priority 1.)
+* **event** – String name of the event you're adding a handler for. Since events are text strings, they don't have to be pre-defined.
+* **handler** – The callable method that will be called when the event is fired. Since it's possible for events to have kwargs attached to them, the handler method must include **kwargs in its signature.
+* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don't matter. They're called from highest to lowest. (i.e. priority 100 is called before priority 1.)
 * **blocking_facility** – Facility which can block this event.
-* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there’s a conflict, the event-level ones will win.
+* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there's a conflict, the event-level ones will win.
 
 Returns EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. For example: `my_handler = self.machine.events.add_handler('ev', self.test))` Then later to remove all the handlers that a module added, you could: for handler in handler_list: `events.remove_handler(my_handler)`
 
@@ -53,7 +53,7 @@ Parse an event string to divide the event name from a possible placeholder / con
 Parameters:
 
 * **event_string** – String to parse
-Returns 2-item tuple- First item is the event name. Second item is the condition (A BoolTemplate instance) if it exists, or None if it doesn’t.
+Returns 2-item tuple- First item is the event name. Second item is the condition (A BoolTemplate instance) if it exists, or None if it doesn't.
 
 `post(event: str, callback=None, **kwargs) → None`
 
@@ -61,9 +61,9 @@ Post an event which causes all the registered handlers to be called. Events are 
 
 Parameters:
 
-* **event** – A string name of the event you’re posting. Note that you can post whatever event you want. You don’t have to set up anything ahead of time, and if no handlers are registered for the event you post, so be it.
+* **event** – A string name of the event you're posting. Note that you can post whatever event you want. You don't have to set up anything ahead of time, and if no handlers are registered for the event you post, so be it.
 * **callback** – An optional method which will be called when the final handler is done processing this event. Default is None.
-* **`**kwargs`** – One or more options keyword/value pairs that will be passed to each handler. (The event manager will enforce that handlers have `**kwargs` in their signatures when they’re registered to prevent run-time crashes from unexpected kwargs that were included in post() calls.
+* **`**kwargs`** – One or more options keyword/value pairs that will be passed to each handler. (The event manager will enforce that handlers have `**kwargs` in their signatures when they're registered to prevent run-time crashes from unexpected kwargs that were included in post() calls.
 
 `post_async(event: str, **kwargs) → _asyncio.Future`
 
@@ -75,7 +75,7 @@ Post an boolean event which causes all the registered handlers to be called one-
 
 Parameters:
 
-* **event** – A string name of the event you’re posting. Note that you can post whatever event you want. You don’t have to set up anything ahead of time, and if no handlers are registered for the event you post, so be it.
+* **event** – A string name of the event you're posting. Note that you can post whatever event you want. You don't have to set up anything ahead of time, and if no handlers are registered for the event you post, so be it.
 * **callback** – An optional method which will be called when the final handler is done processing this event. Default is None. If any handler returns False and cancels this boolean event, the callback will still be called, but a new kwarg ev_result=False will be passed to it.
 * ****kwargs** – One or more options keyword/value pairs that will be passed to each handler.
 
@@ -85,9 +85,9 @@ Post a queue event which causes all the registered handlers to be called. Queue 
 
 Parameters:
 
-* **event** - A string name of the event you’re posting. Note that you can post whatever event you want. You don’t have to set up anything ahead of time, and if no handlers are registered for the event you post, so be it.
+* **event** - A string name of the event you're posting. Note that you can post whatever event you want. You don't have to set up anything ahead of time, and if no handlers are registered for the event you post, so be it.
 * **callback** - The method which will be called when the final handler is done processing this event and any handlers that registered waits have cleared their waits.
-* **`**kwargs`** - One or more options keyword/value pairs that will be passed to each handler. (Just make sure your handlers are expecting them. You can add `**kwargs` to your handler methods if certain ones don’t need them.)
+* **`**kwargs`** - One or more options keyword/value pairs that will be passed to each handler. (Just make sure your handlers are expecting them. You can add `**kwargs` to your handler methods if certain ones don't need them.)
 
 Post the queue event called `pizza_time`, and then call `self.pizza_done` when done: `self.machine.events.post_queue('pizza_time', self.pizza_done)`
 
@@ -101,9 +101,9 @@ Post a relay event which causes all the registered handlers to be called. A dict
 
 Parameters:
 
-* **event** – A string name of the event you’re posting. Note that you can post whatever event you want. You don’t have to set up anything ahead of time, and if no handlers are registered for the event you post, so be it.
+* **event** – A string name of the event you're posting. Note that you can post whatever event you want. You don't have to set up anything ahead of time, and if no handlers are registered for the event you post, so be it.
 * **callback** – The method which will be called when the final handler is done processing this event. Default is None.
-* **`**kwargs`** – One or more options keyword/value pairs that will be passed to each handler. (Just make sure your handlers are expecting them. You can add `**kwargs` to your handler methods if certain ones don’t need them.)
+* **`**kwargs`** – One or more options keyword/value pairs that will be passed to each handler. (Just make sure your handlers are expecting them. You can add `**kwargs` to your handler methods if certain ones don't need them.)
 
 Events are processed serially (e.g. one at a time), so if the event core is in the process of handling another event, this event is added to a queue and processed after the current event is done. You can control the order the handlers will be called by optionally specifying a priority when the handlers were registered. (Higher priority values will be processed first.) Relay events differ from standard events in that the resulting kwargs from one handler are passed to the next handler. (In other words, standard events mean that all the handlers get the same initial kwargs, whereas relay events “relay” the resulting kwargs from one handler to the next.)
 
@@ -165,7 +165,7 @@ Parameters:
 * **priority** – Optional priority of the new handler that will be registered.
 * ****kwargs** – The kwargs you want to check and the kwargs that will be registered with the new handler.
 
-If you don’t pass kwargs, this method will just look for the handler and event combination. If you do pass kwargs, it will make sure they match before replacing the existing entry. If this method doesn’t find a match, it will still add the new handler.
+If you don't pass kwargs, this method will just look for the handler and event combination. If you do pass kwargs, it will make sure they match before replacing the existing entry. If this method doesn't find a match, it will still add the new handler.
 
 `wait_for_any_event(event_names: List[str]) → _asyncio.Future`
 

--- a/docs/code/api_reference/core/info_lights.md
+++ b/docs/code/api_reference/core/info_lights.md
@@ -12,7 +12,7 @@ Uses lights to represent game state. Info lights are primarily used in EM and ea
 
 ## Accessing the info_lights in code
 
-There is only one instance of the info_lights in MPF, and it’s accessible via `self.machine.info_lights`.
+There is only one instance of the info_lights in MPF, and it's accessible via `self.machine.info_lights`.
 
 ## Methods & Attributes
 

--- a/docs/code/api_reference/core/light_controller.md
+++ b/docs/code/api_reference/core/light_controller.md
@@ -12,7 +12,7 @@ Handles light updates and light monitoring.
 
 ## Accessing the light_controller in code
 
-There is only one instance of the light_controller in MPF, and it’s accessible via `self.machine.light_controller`.
+There is only one instance of the light_controller in MPF, and it's accessible via `self.machine.light_controller`.
 
 ## Methods & Attributes
 

--- a/docs/code/api_reference/core/machine.md
+++ b/docs/code/api_reference/core/machine.md
@@ -74,10 +74,10 @@ Register a monitor.
 
 Parameters:
 
-* **monitor_class** – String name of the monitor class for this monitor that’s being registered.
+* **monitor_class** – String name of the monitor class for this monitor that's being registered.
 * **monitor** – Callback to notify
 
-MPF uses monitors to allow components to monitor certain internal elements of MPF. For example, a player variable monitor could be setup to be notified of any changes to a player variable, or a switch monitor could be used to allow a plugin to be notified of any changes to any switches. The MachineController’s list of registered monitors doesn’t actually do anything. Rather it’s a dictionary of sets which the monitors themselves can reference when they need to do something. We just needed a central registry of monitors.
+MPF uses monitors to allow components to monitor certain internal elements of MPF. For example, a player variable monitor could be setup to be notified of any changes to a player variable, or a switch monitor could be used to allow a plugin to be notified of any changes to any switches. The MachineController's list of registered monitors doesn't actually do anything. Rather it's a dictionary of sets which the monitors themselves can reference when they need to do something. We just needed a central registry of monitors.
 
 `reset() → None`
 

--- a/docs/code/api_reference/core/mode_controller.md
+++ b/docs/code/api_reference/core/mode_controller.md
@@ -12,7 +12,7 @@ Responsible for loading, unloading, and managing all modes in MPF.
 
 ## Accessing the mode_controller in code
 
-There is only one instance of the mode_controller in MPF, and it’s accessible via self.machine.mode_controller.
+There is only one instance of the mode_controller in MPF, and it's accessible via self.machine.mode_controller.
 
 ## Methods & Attributes
 
@@ -48,12 +48,12 @@ Load the modes from the modes: section of the machine configuration file.
 
 `register_load_method(load_method, config_section_name=None, priority=0, **kwargs)`
 
-Register a method which is called when the mode is loaded. Used by core components, plugins, etc. to register themselves with the Mode Controller for anything they need a mode to do when it’s registered.
+Register a method which is called when the mode is loaded. Used by core components, plugins, etc. to register themselves with the Mode Controller for anything they need a mode to do when it's registered.
 
 Parameters:
 
 * **load_method** – The method that will be called when this mode code loads.
-* **config_section_name** – An optional string for the section of the configuration file that will be passed to the load_method when it’s called.
+* **config_section_name** – An optional string for the section of the configuration file that will be passed to the load_method when it's called.
 * **priority** – Int of the relative priority which allows remote methods to be called in a specific order. Default is 0. Higher values will be called first.
 * ****kwargs** – Any additional keyword arguments specified will be passed to the load_method.
 
@@ -66,7 +66,7 @@ Register a method which is called anytime a mode is started. Used by core compon
 Parameters:
 
 * **start_method** – The method that will be called when this mode code loads.
-* **config_section_name** – An optional string for the section of the configuration file that will be passed to the start_method when it’s called.
+* **config_section_name** – An optional string for the section of the configuration file that will be passed to the start_method when it's called.
 * **priority** – Int of the relative priority which allows remote methods to be called in a specific order. Default is 0. Higher values will be called first.
 * ****kwargs** – Any additional keyword arguments specified will be passed to the start_method.
 

--- a/docs/code/api_reference/core/placeholder_manager.md
+++ b/docs/code/api_reference/core/placeholder_manager.md
@@ -12,7 +12,7 @@ Manages templates and placeholders for MPF.
 
 ## Accessing the placeholder_manager in code
 
-There is only one instance of the placeholder_manager in MPF, and it’s accessible via self.machine.placeholder_manager.
+There is only one instance of the placeholder_manager in MPF, and it's accessible via self.machine.placeholder_manager.
 
 ## Methods & Attributes
 

--- a/docs/code/api_reference/core/platform_controller.md
+++ b/docs/code/api_reference/core/platform_controller.md
@@ -12,7 +12,7 @@ Manages all platforms and rules.
 
 ## Accessing the platform_controller in code
 
-There is only one instance of the platform_controller in MPF, and it’s accessible via `self.machine.platform_controller`.
+There is only one instance of the platform_controller in MPF, and it's accessible via `self.machine.platform_controller`.
 
 ## Methods & Attributes
 

--- a/docs/code/api_reference/core/service.md
+++ b/docs/code/api_reference/core/service.md
@@ -12,7 +12,7 @@ Provides all service information and can perform service tasks.
 
 ## Accessing the service in code
 
-There is only one instance of the service in MPF, and it’s accessible via `self.machine.service`.
+There is only one instance of the service in MPF, and it's accessible via `self.machine.service`.
 
 ## Methods & Attributes
 

--- a/docs/code/api_reference/core/settings.md
+++ b/docs/code/api_reference/core/settings.md
@@ -12,7 +12,7 @@ Manages operator controllable settings.
 
 ## Accessing the settings in code
 
-There is only one instance of the settings in MPF, and it’s accessible via `self.machine.settings`.
+There is only one instance of the settings in MPF, and it's accessible via `self.machine.settings`.
 
 ## Methods & Attributes
 

--- a/docs/code/api_reference/core/show_controller.md
+++ b/docs/code/api_reference/core/show_controller.md
@@ -12,7 +12,7 @@ Manages all the shows in a pinball machine. The ShowController handles prioritie
 
 ## Accessing the show_controller in code
 
-There is only one instance of the show_controller in MPF, and it’s accessible via `self.machine.show_controller`.
+There is only one instance of the show_controller in MPF, and it's accessible via `self.machine.show_controller`.
 
 ## Methods & Attributes
 

--- a/docs/code/api_reference/core/switch_controller.md
+++ b/docs/code/api_reference/core/switch_controller.md
@@ -12,7 +12,7 @@ Tracks all switches in the machine, receives switch activity, and converts switc
 
 ## Accessing the switch_controller in code
 
-There is only one instance of the switch_controller in MPF, and it’s accessible via `self.machine.switch_controller`.
+There is only one instance of the switch_controller in MPF, and it's accessible via `self.machine.switch_controller`.
 
 ## Methods & Attributes
 
@@ -28,10 +28,10 @@ Register a handler to take action on a switch event.
 
 Parameters:
 
-* **switch_name** – String name of the switch you’re adding this handler for.
+* **switch_name** – String name of the switch you're adding this handler for.
 * **callback** – The method you want called when this switch handler fires.
-* **state** – Integer of the state transition you want to callback to be triggered on. Default is 1 which means it’s called when the switch goes from inactive to active, but you can also use 0 which means your callback will be called when the switch becomes inactive
-* **ms – Integer** - If you specify a ‘ms’ parameter, the handler won’t be called until the witch is in that state for that many milliseconds.
+* **state** – Integer of the state transition you want to callback to be triggered on. Default is 1 which means it's called when the switch goes from inactive to active, but you can also use 0 which means your callback will be called when the switch becomes inactive
+* **ms – Integer** - If you specify a 'ms' parameter, the handler won't be called until the witch is in that state for that many milliseconds.
 * **return_info** – If True, the switch controller will pass the parameters of the switch handler as arguments to the callback, including switch_name, state, and ms. If False (default), it just calls the callback with no parameters.
 * **callback_kwargs** – Additional kwargs that will be passed with the callback.
 
@@ -54,7 +54,7 @@ Parameters:
 * **switch** – Switch object to check.
 * **ms** – Milliseconds that the switch has been active. If this is non-zero, then this method will only return True if the switch has been in that state for at least the number of ms specified.
 
-Returns: True if the switch_name has been active for the given number of ms. If ms is not specified, returns True if the switch is in the state regardless of how long it’s been in that state.
+Returns: True if the switch_name has been active for the given number of ms. If ms is not specified, returns True if the switch is in the state regardless of how long it's been in that state.
 
 `is_inactive(switch, ms=None)`
 
@@ -63,7 +63,7 @@ Query whether a switch is inactive.
 Parameters:
 
 * **switch** – Switch object to check.
-* **ms** – Milliseconds that the switch has been inactive. If this is non-zero, then this method will only return True if the switch has been in that state for at least the number of ms specified. number of ms. If ms is not specified, returns True if the switch is in the state regardless of how long it’s been in that state.
+* **ms** – Milliseconds that the switch has been inactive. If this is non-zero, then this method will only return True if the switch has been in that state for at least the number of ms specified. number of ms. If ms is not specified, returns True if the switch is in the state regardless of how long it's been in that state.
 
 `is_state(switch: mpf.devices.switch.Switch, state, ms=0.0)`
 
@@ -75,7 +75,7 @@ Parameters:
 * **state** – Bool of the state to check. True is active and False is inactive.
 * **ms** – Milliseconds that the switch has been in that state. If this is non-zero, then this method will only return True if the switch has been in that state for at least the number of ms specified.
 
-Returns: True if the switch_name has been in the state for the given number of ms. If ms is not specified, returns True if the switch is in the state regardless of how long it’s been in that state.
+Returns: True if the switch_name has been in the state for the given number of ms. If ms is not specified, returns True if the switch is in the state regardless of how long it's been in that state.
 
 `log_active_switches(**kwargs)`
 
@@ -83,13 +83,13 @@ Write out entries to the INFO log file of all switches that are currently active
 
 `process_switch(name, state, logical=False, timestamp=None)`
 
-Process a new switch state change for a switch by name.  This is the method that is called by the platform driver whenever a switch changes state. It’s also used by the “other” modules that activate switches, including the keyboard and OSC interfaces. State 0 means the switch changed from active to inactive, and 1 means it changed from inactive to active. (The hardware & platform code handles NC versus NO switches and translates them to ‘active’ versus ‘inactive’.)
+Process a new switch state change for a switch by name.  This is the method that is called by the platform driver whenever a switch changes state. It's also used by the “other” modules that activate switches, including the keyboard and OSC interfaces. State 0 means the switch changed from active to inactive, and 1 means it changed from inactive to active. (The hardware & platform code handles NC versus NO switches and translates them to 'active' versus 'inactive'.)
 
 Parameters:
 
 * **name** – The string name of the switch.
-* **state** – Boolean or int of state of the switch you’re processing, True/1 is active, False/0 is inactive.
-* **logical** – Boolean which specifies whether the ‘state’ argument represents the “physical” or “logical” state of the switch. If True, a 1 means this switch is active and a 0 means it’s inactive, regardless of the NC/NO configuration of the switch. If False, then the state parameter passed will be inverted if the switch is configured to be an ‘NC’ type. Typically the hardware will send switch states in their raw (logical=False) states, but other interfaces like the keyboard and OSC will use logical=True.
+* **state** – Boolean or int of state of the switch you're processing, True/1 is active, False/0 is inactive.
+* **logical** – Boolean which specifies whether the 'state' argument represents the “physical” or “logical” state of the switch. If True, a 1 means this switch is active and a 0 means it's inactive, regardless of the NC/NO configuration of the switch. If False, then the state parameter passed will be inverted if the switch is configured to be an 'NC' type. Typically the hardware will send switch states in their raw (logical=False) states, but other interfaces like the keyboard and OSC will use logical=True.
 * **timestamp** – Timestamp when this switch change happened.
 
 `process_switch_by_num(num, state, platform, logical=False, timestamp=None)`
@@ -98,10 +98,10 @@ Process a switch state change by switch number.
 
 Parameters:
 
-* **num** – The switch number (based on the platform number) for the switch you’re setting.
+* **num** – The switch number (based on the platform number) for the switch you're setting.
 * **state** – The state to set, either 0 or 1.
 * **platform** – The platform this switch is on.
-* **logical** – Whether the state you’re setting is the logical or physical state of the switch. If a switch is NO (normally open), then the logical and physical states will be the same. NC (normally closed) switches will have physical and logical states that are inverted from each other.
+* **logical** – Whether the state you're setting is the logical or physical state of the switch. If a switch is NO (normally open), then the logical and physical states will be the same. NC (normally closed) switches will have physical and logical states that are inverted from each other.
 * **timestamp** – Timestamp when this switch change happened.
 
 `process_switch_obj(obj: mpf.devices.switch.Switch, state, logical, timestamp=None)`
@@ -111,11 +111,11 @@ Process a new switch state change for a switch by name.
 Parameters:
 
 * **obj** – The switch object.
-* **state** – Boolean or int of state of the switch you’re processing, True/1 is active, False/0 is inactive.
-* **logical** – Boolean which specifies whether the ‘state’ argument represents the “physical” or “logical” state of the switch. If True, a 1 means this switch is active and a 0 means it’s inactive, regardless of the NC/NO configuration of the switch. If False, then the state parameter passed will be inverted if the switch is configured to be an ‘NC’ type. Typically the hardware will send switch states in their raw (logical=False) states, but other interfaces like the keyboard and OSC will use logical=True.
+* **state** – Boolean or int of state of the switch you're processing, True/1 is active, False/0 is inactive.
+* **logical** – Boolean which specifies whether the 'state' argument represents the “physical” or “logical” state of the switch. If True, a 1 means this switch is active and a 0 means it's inactive, regardless of the NC/NO configuration of the switch. If False, then the state parameter passed will be inverted if the switch is configured to be an 'NC' type. Typically the hardware will send switch states in their raw (logical=False) states, but other interfaces like the keyboard and OSC will use logical=True.
 * **timestamp** – Timestamp when this switch change happened.
 
-This is the method that is called by the platform driver whenever a switch changes state. It’s also used by the “other” modules that activate switches, including the keyboard and OSC interfaces. State 0 means the switch changed from active to inactive, and 1 means it changed from inactive to active. (The hardware & platform code handles NC versus NO switches and translates them to ‘active’ versus ‘inactive’.)
+This is the method that is called by the platform driver whenever a switch changes state. It's also used by the “other” modules that activate switches, including the keyboard and OSC interfaces. State 0 means the switch changed from active to inactive, and 1 means it changed from inactive to active. (The hardware & platform code handles NC versus NO switches and translates them to 'active' versus 'inactive'.)
 
 `register_switch(switch: mpf.devices.switch.Switch)`
 
@@ -131,7 +131,7 @@ Remove a monitor callback.
 
 `remove_switch_handler(switch_name, callback, state=1, ms=0)`
 
-Remove a registered switch handler. Currently this only works if you specify everything exactly as you set it up. (Except for return_info, which doesn’t matter if true or false, it will remove either / both.
+Remove a registered switch handler. Currently this only works if you specify everything exactly as you set it up. (Except for return_info, which doesn't matter if true or false, it will remove either / both.
 
 `remove_switch_handler_by_key(switch_handler: mpf.core.switch_controller.SwitchHandler)`
 
@@ -151,7 +151,7 @@ Update the states of all the switches be re-reading the states from the hardware
 
 `verify_switches() → bool`
 
-Verify that switches states match the hardware. Loops through all the switches and queries their hardware states via their platform interfaces and then compares that to the state that MPF thinks the switches are in. Throws logging warnings if anything doesn’t match.  This method is notification only. It doesn’t fix anything.
+Verify that switches states match the hardware. Loops through all the switches and queries their hardware states via their platform interfaces and then compares that to the state that MPF thinks the switches are in. Throws logging warnings if anything doesn't match.  This method is notification only. It doesn't fix anything.
 
 `wait_for_any_switch(switches: List[mpf.devices.switch.Switch], state: int = 1, only_on_change=True, ms=0)`
 

--- a/docs/code/api_reference/core/switch_player.md
+++ b/docs/code/api_reference/core/switch_player.md
@@ -12,7 +12,7 @@ Plays back switch sequences from a config file, used for testing.
 
 ## Accessing the switch_player in code
 
-There is only one instance of the `switch_player` in MPF, and it’s accessible via `self.machine.switch_player`.
+There is only one instance of the `switch_player` in MPF, and it's accessible via `self.machine.switch_player`.
 
 ## Methods & Attributes
 

--- a/docs/code/api_reference/core/text_ui.md
+++ b/docs/code/api_reference/core/text_ui.md
@@ -12,7 +12,7 @@ Handles the text-based UI.
 
 ## Accessing the text_ui in code
 
-There is only one instance of the `text_ui` in MPF, and it’s accessible via `self.machine.text_ui`.
+There is only one instance of the `text_ui` in MPF, and it's accessible via `self.machine.text_ui`.
 
 ## Methods & Attributes
 

--- a/docs/code/api_reference/core/twitch_bot.md
+++ b/docs/code/api_reference/core/twitch_bot.md
@@ -12,7 +12,7 @@ Adds Twitch chat room events.
 
 ## Accessing the twitch_bot in code
 
-There is only one instance of the `twitch_bot` in MPF, and it’s accessible via `self.machine.twitch_bot`.
+There is only one instance of the `twitch_bot` in MPF, and it's accessible via `self.machine.twitch_bot`.
 
 ## Methods & Attributes
 

--- a/docs/code/api_reference/devices/accruals.md
+++ b/docs/code/api_reference/devices/accruals.md
@@ -20,7 +20,7 @@ Accruals have the following methods & attributes available. Note that methods & 
 
 `complete()`
 
-Mark this logic block as complete. Posts the ‘events_when_complete’ events and optionally restarts this logic block or disables it, depending on this block’s configuration settings.
+Mark this logic block as complete. Posts the 'events_when_complete' events and optionally restarts this logic block or disables it, depending on this block's configuration settings.
 
 `completed`
 

--- a/docs/code/api_reference/devices/ball_devices.md
+++ b/docs/code/api_reference/devices/ball_devices.md
@@ -8,7 +8,7 @@ class mpf.devices.ball_device.ball_device.BallDevice(*args, **kwargs)
 
 Bases: `mpf.core.system_wide_device.SystemWideDevice`
 
-Base class for a ‘Ball Device’ in a pinball machine. A ball device is anything that can hold one or more balls, such as a trough, an eject hole, a VUK, a catapult, etc.
+Base class for a 'Ball Device' in a pinball machine. A ball device is anything that can hold one or more balls, such as a trough, an eject hole, a VUK, a catapult, etc.
 
 Args: Same as Device.
 
@@ -26,7 +26,7 @@ Notify this device that there is a ball heading its way.
 
 `available_balls`
 
-Number of balls that are available to be ejected. This differs from balls since it’s possible that this device could have balls that are being used for some other eject, and thus not available.
+Number of balls that are available to be ejected. This differs from balls since it's possible that this device could have balls that are being used for some other eject, and thus not available.
 
 `balls`
 
@@ -105,7 +105,7 @@ Handle mechanical eject.
 
 `classmethod is_playfield()`
 
-Return True if this ball device is a Playfield-type device, False if it’s a regular ball device.
+Return True if this ball device is a Playfield-type device, False if it's a regular ball device.
 
 `lost_ejected_ball(target)`
 

--- a/docs/code/api_reference/devices/coils.md
+++ b/docs/code/api_reference/devices/coils.md
@@ -8,7 +8,7 @@ class mpf.devices.driver.Driver(machine: mpf.core.machine.MachineController, nam
 
 Bases: `mpf.core.system_wide_device.SystemWideDevice`
 
-Generic class that holds driver objects. A ‘driver’ is any device controlled from a driver board which is typically the high-voltage stuff like coils and flashers. This class exposes the methods you should use on these driver types of devices. Each platform module (i.e. P-ROC, FAST, etc.) subclasses this class to actually communicate with the physical hardware and perform the actions.
+Generic class that holds driver objects. A 'driver' is any device controlled from a driver board which is typically the high-voltage stuff like coils and flashers. This class exposes the methods you should use on these driver types of devices. Each platform module (i.e. P-ROC, FAST, etc.) subclasses this class to actually communicate with the physical hardware and perform the actions.
 
 Args: Same as the Device parent class
 
@@ -26,7 +26,7 @@ Disable this driver.
 
 `enable(pulse_ms: int = None, pulse_power: float = None, hold_power: float = None)`
 
-Enable a driver by holding it ‘on’.
+Enable a driver by holding it 'on'.
 
 Parameters:
 

--- a/docs/code/api_reference/devices/counters.md
+++ b/docs/code/api_reference/devices/counters.md
@@ -24,7 +24,7 @@ Check if counter is completed. Return true if the counter has reached or surpass
 
 `complete()`
 
-Mark this logic block as complete. Posts the`events_when_complete` events and optionally restarts this logic block or disables it, depending on this block’s configuration settings.
+Mark this logic block as complete. Posts the`events_when_complete` events and optionally restarts this logic block or disables it, depending on this block's configuration settings.
 
 `completed`
 
@@ -119,7 +119,7 @@ Restart this logic block by calling reset() and enable(). Automatically called w
 
 `stop_ignoring_hits(**kwargs)`
 
-Cause the Counter to stop ignoring subsequent hits that occur within the ‘multiple_hit_window’. Automatically called when the window time expires. Can safely be manually called.
+Cause the Counter to stop ignoring subsequent hits that occur within the 'multiple_hit_window'. Automatically called when the window time expires. Can safely be manually called.
 
 `subscribe_attribute(item, machine)`
 

--- a/docs/code/api_reference/devices/diverters.md
+++ b/docs/code/api_reference/devices/diverters.md
@@ -22,11 +22,11 @@ Diverters have the following methods & attributes available. Note that methods &
 
 `activate()`
 
-Physically activate this diverter’s coil.
+Physically activate this diverter's coil.
 
 `deactivate()`
 
-Deactivate this diverter.  This method will disable the activation_coil, and (optionally) if it’s configured with a deactivation coil, it will pulse it.
+Deactivate this diverter.  This method will disable the activation_coil, and (optionally) if it's configured with a deactivation coil, it will pulse it.
 
 `disable(auto=False)`
 
@@ -35,7 +35,7 @@ Disable this diverter. This method will remove the hardware rule if this diverte
 Parameters:
 
 * **auto** – Boolean value which is used to indicate whether this diverter disabled itself automatically. This is passed to the event which is posted.
-* ****kwargs** – This is here because this disable method is called by whatever event the game programmer specifies in their machine configuration file, so we don’t know what event that might be or whether it has random kwargs attached to it.
+* ****kwargs** – This is here because this disable method is called by whatever event the game programmer specifies in their machine configuration file, so we don't know what event that might be or whether it has random kwargs attached to it.
 
 `enable(auto=False)`
 

--- a/docs/code/api_reference/devices/extra_ball_groups.md
+++ b/docs/code/api_reference/devices/extra_ball_groups.md
@@ -56,7 +56,7 @@ Get the value of a placeholder.
 
 `is_ok_to_light() → bool`
 
-Check if it’s possible to light an extra ball. Returns True or False. This method checks to see if the group is enabled and whether the max_lit setting has been exceeded.
+Check if it's possible to light an extra ball. Returns True or False. This method checks to see if the group is enabled and whether the max_lit setting has been exceeded.
 
 `light()`
 

--- a/docs/code/api_reference/devices/extra_balls.md
+++ b/docs/code/api_reference/devices/extra_balls.md
@@ -64,7 +64,7 @@ Check whether this extra ball can be lit. This method takes into consideration w
 
 `light()`
 
-Light an extra ball for potential collection by the player. Lighting an extra ball will immediately increase count against the max_per_game setting, even if the extra ball is a member of a group that’s disabled or if the player never actually collects the extra ball. Note that this only really does anything if this extra ball is a member of a group.
+Light an extra ball for potential collection by the player. Lighting an extra ball will immediately increase count against the max_per_game setting, even if the extra ball is a member of a group that's disabled or if the player never actually collects the extra ball. Note that this only really does anything if this extra ball is a member of a group.
 
 `player`
 

--- a/docs/code/api_reference/devices/flippers.md
+++ b/docs/code/api_reference/devices/flippers.md
@@ -13,7 +13,7 @@ Represents a flipper in a pinball machine. Subclass of Device. Contains several 
 Parameters:
 
 * **machine** – A reference to the machine controller instance.
-* **name** – A string of the name you’ll refer to this flipper object as.
+* **name** – A string of the name you'll refer to this flipper object as.
 
 ## Accessing flippers in code
 
@@ -29,7 +29,7 @@ Disable the flipper.  This method makes it so the cabinet flipper buttons no lon
 
 `enable()`
 
-Enable the flipper by writing the necessary hardware rules to the hardware controller.  The hardware rules for coils can be kind of complex given all the options, so we’ve mapped all the options out here. We literally have methods to enable the various rules based on the rule letters here, which we’ve implemented below. Keeps it easy to understand. Note there’s a platform feature saved at: `self.machine.config['platform']['hw_enable_auto_disable']`. If True, it means that the platform hardware rules will automatically disable a coil that has been enabled when the trigger switch is disabled. If False, it means the hardware platform needs its own rule to disable the coil when the switch is disabled. Methods F and G below check for that feature setting and will not be applied to the hardware if it’s True.
+Enable the flipper by writing the necessary hardware rules to the hardware controller.  The hardware rules for coils can be kind of complex given all the options, so we've mapped all the options out here. We literally have methods to enable the various rules based on the rule letters here, which we've implemented below. Keeps it easy to understand. Note there's a platform feature saved at: `self.machine.config['platform']['hw_enable_auto_disable']`. If True, it means that the platform hardware rules will automatically disable a coil that has been enabled when the trigger switch is disabled. If False, it means the hardware platform needs its own rule to disable the coil when the switch is disabled. Methods F and G below check for that feature setting and will not be applied to the hardware if it's True.
 
 Two coils, using EOS switch to indicate the end of the power stroke: Rule Type Coil Switch Action A. Enable Main Button active D. Enable Hold Button active E. Disable Main EOS active
 

--- a/docs/code/api_reference/devices/lights.md
+++ b/docs/code/api_reference/devices/lights.md
@@ -20,20 +20,20 @@ Lights have the following methods & attributes available. Note that methods & at
 
 `clear_stack()`
 
-Remove all entries from the stack and resets this light to ‘off’.
+Remove all entries from the stack and resets this light to 'off'.
 
 `color(color, fade_ms=None, priority=0, key=None, start_time=None)`
 
-Add or update a color entry in this light’s stack.
+Add or update a color entry in this light's stack.
 
 Calling this methods is how you tell this light what color you want it to be.
 
 Parameters:
 
 * **color** – RGBColor() instance, or a string color name, hex value, or 3-integer list/tuple of colors.
-* **fade_ms** – Int of the number of ms you want this light to fade to the color in. A value of 0 means it’s instant. A value of None (the default) means that it will use this light’s and/or the machine’s default fade_ms setting.
-* **priority** – Int value of the priority of these incoming settings. If this light has current settings in the stack at a higher priority, the settings you’re adding here won’t take effect. However they’re still added to the stack, so if the higher priority settings are removed, then the next-highest apply.
-* **key** – An arbitrary identifier (can be any immutable object) that’s used to identify these settings for later removal. If any settings in the stack already have this key, those settings will be replaced with these new settings.
+* **fade_ms** – Int of the number of ms you want this light to fade to the color in. A value of 0 means it's instant. A value of None (the default) means that it will use this light's and/or the machine's default fade_ms setting.
+* **priority** – Int value of the priority of these incoming settings. If this light has current settings in the stack at a higher priority, the settings you're adding here won't take effect. However they're still added to the stack, so if the higher priority settings are removed, then the next-highest apply.
+* **key** – An arbitrary identifier (can be any immutable object) that's used to identify these settings for later removal. If any settings in the stack already have this key, those settings will be replaced with these new settings.
 * **start_time** – Time this occured to synchronize lights.
 
 `color_correct(color)`
@@ -67,7 +67,7 @@ Returns an updated RGBColor() instance with gamma corrected.
 
 `get_color()`
 
-Return an RGBColor() instance of the ‘color’ setting of the highest color setting in the stack.
+Return an RGBColor() instance of the 'color' setting of the highest color setting in the stack.
 
 This is usually the same color as the physical light, but not always (since physical lights are updated once per frame, this value could vary.
 
@@ -75,7 +75,7 @@ Also note the color returned is the “raw” color that does has not had the co
 
 `get_color_below(priority, key)`
 
-Return an RGBColor() instance of the ‘color’ setting of the highest color below a certain key.
+Return an RGBColor() instance of the 'color' setting of the highest color below a certain key.
 
 Similar to get_color.
 
@@ -124,17 +124,17 @@ Remove a group of color settings from the stack.
 
 Parameters:
 
-* **key** – The key of the settings to remove (based on the ‘key’ parameter that was originally passed to the color() method.)
+* **key** – The key of the settings to remove (based on the 'key' parameter that was originally passed to the color() method.)
 * **fade_ms** – Time to fade out the light.
 
-This method triggers a light update, so if the highest priority settings were removed, the light will be updated with whatever’s below it. If no settings remain after these are removed, the light will turn off.
+This method triggers a light update, so if the highest priority settings were removed, the light will be updated with whatever's below it. If no settings remain after these are removed, the light will turn off.
 
 `stack`
 
 A list of dicts which represents different commands that have come in to set this light to a certain color (and/or fade). Each entry in the list contains the following key/value pairs:
 
         `priority`:
-            The relative priority of this color command. Higher numbers take precedent, and the highest priority entry will be the command that’s currently active. In the event of a tie, whichever entry was added last wins (based on ‘start_time’ below).
+            The relative priority of this color command. Higher numbers take precedent, and the highest priority entry will be the command that's currently active. In the event of a tie, whichever entry was added last wins (based on 'start_time' below).
         `start_time`:
             The clock time when this command was added. Primarily used to calculate fades, but also used as a tie-breaker for multiple entries with the same priority.
         `start_color`:
@@ -142,7 +142,7 @@ A list of dicts which represents different commands that have come in to set thi
         `dest_time`:
             Clock time that represents when a fade (from start_color to dest_color) will be done. If this is 0, that means there is no fade. When a fade is complete, this value is reset to 0.
         `dest_color`:
-            RGBColor() of the destination this light is fading to. If a command comes in with no fade, then this will be the same as the ‘color’ below.
+            RGBColor() of the destination this light is fading to. If a command comes in with no fade, then this will be the same as the 'color' below.
         `key`:
             An arbitrary unique identifier to keep multiple entries in the stack separate. If a new color command comes in with a key that already exists for an entry in the stack, that entry will be replaced by the new entry. The key is also used to remove entries from the stack (e.g. when shows or modes end and they want to remove their commands from the light).
 

--- a/docs/code/api_reference/devices/playfields.md
+++ b/docs/code/api_reference/devices/playfields.md
@@ -24,15 +24,15 @@ Add live ball(s) to the playfield.
 
 Parameters:
 
-* **balls** – Integer of the number of balls you’d like to add.
-* **source_device** – Optional ball device object you’d like to add the ball(s) from.
+* **balls** – Integer of the number of balls you'd like to add.
+* **source_device** – Optional ball device object you'd like to add the ball(s) from.
 * **player_controlled** – Boolean which specifies whether this event is player controlled. (See not below for details)
 
-Returns True if it’s able to process the add_ball() request, False if it cannot.
+Returns True if it's able to process the add_ball() request, False if it cannot.
 
-The source_device arg is included to give you an options for specifying the source of the ball(s) to be added. This argument is optional, so if you don’t supply them then MPF will use the default_source_device of this playfield.
+The source_device arg is included to give you an options for specifying the source of the ball(s) to be added. This argument is optional, so if you don't supply them then MPF will use the default_source_device of this playfield.
 
-This method does not increase the game controller’s count of the number of balls in play. So if you want to add balls (like in a multiball scenario), you need to call this method along with self.machine.game.add_balls_in_play().)
+This method does not increase the game controller's count of the number of balls in play. So if you want to add balls (like in a multiball scenario), you need to call this method along with self.machine.game.add_balls_in_play().)
 
 MPF tracks the number of balls in play separately from the actual balls on the playfield because there are numerous situations where the two counts are not the same. For example, if a ball is in a VUK while some animation is playing, there are no balls on the playfield but still one ball in play, or if the player has a two-ball multiball and they shoot them both into locks, there are still two balls in play even though there are no balls on the playfield. The opposite can also be true, like when the player tilts then there are still balls on the playfield but no balls in play.
 
@@ -40,11 +40,11 @@ Explanation of the player_controlled parameter:
 
 Set player_controlled to True to indicate that MPF should wait for the player to eject the ball from the source_device rather than firing a coil. The logic works like this:
 
-If the source_device does not have an eject_coil defined, then it’s assumed that player_controlled is the only option. (e.g. this is a traditional plunger.) If the source_device does have an eject_coil defined, then there are two ways the eject could work. (1) there could be a “launch” button of some kind that’s used to fire the eject coil, or (2) the device could be the auto/manual combo style where there’s a mechanical plunger but also a coil which can eject the ball.
+If the source_device does not have an eject_coil defined, then it's assumed that player_controlled is the only option. (e.g. this is a traditional plunger.) If the source_device does have an eject_coil defined, then there are two ways the eject could work. (1) there could be a “launch” button of some kind that's used to fire the eject coil, or (2) the device could be the auto/manual combo style where there's a mechanical plunger but also a coil which can eject the ball.
 
 If player_controlled is true and the device has an eject_coil, MPF will look for the player_controlled_eject_tag and eject the ball when a switch with that tag is activated.
 
-If there is no player_controlled_eject_tag, MPF assumes it’s a manual plunger and will wait for the ball to disappear from the device based on the device’s ball count decreasing.
+If there is no player_controlled_eject_tag, MPF assumes it's a manual plunger and will wait for the ball to disappear from the device based on the device's ball count decreasing.
 
 `add_incoming_ball(incoming_ball: mpf.devices.ball_device.incoming_balls_handler.IncomingBall)`
 
@@ -74,7 +74,7 @@ An instance of mpf.core.delays.DelayManager which handles delays for this playfi
 
 Block ball search for this playfield.
 
-Blocking will disable ball search if it’s enabled or running, and will prevent ball search from enabling if it’s disabled until ball_search_resume() is called.
+Blocking will disable ball search if it's enabled or running, and will prevent ball search from enabling if it's disabled until ball_search_resume() is called.
 
 `event_ball_search_disable(**kwargs)`
 

--- a/docs/code/api_reference/devices/score_reel_groups.md
+++ b/docs/code/api_reference/devices/score_reel_groups.md
@@ -42,13 +42,13 @@ This method will pad shorter ints with zeros, and it will chop off leading digit
 
 Parameters:
 
-* **value** – The interger value you’d like to convert.
+* **value** – The interger value you'd like to convert.
 
 Returns a list containing the values for each corresponding score reel, with the lowest reel digit position in list position 0.
 
 `light(**kwargs)`
 
-Light up this ScoreReelGroup based on the ‘light_tag’ in its config.
+Light up this ScoreReelGroup based on the 'light_tag' in its config.
 
 `raise_config_error(msg, error_no, *, context=None) → NoReturn`
 
@@ -58,9 +58,9 @@ Raise a ConfigFileError exception.
 
 Reset the score reel group to display the value passed.
 
-This method will “jump” the score reel group to display the value that’s passed as an it. (Note this “jump” technique means it will just move the reels as fast as it can, and nonsensical values might show up on the reel while the movement is in progress.)
+This method will “jump” the score reel group to display the value that's passed as an it. (Note this “jump” technique means it will just move the reels as fast as it can, and nonsensical values might show up on the reel while the movement is in progress.)
 
-This method is used to “reset” a reel group to all zeros at the beginning of a game, and can also be used to reset a reel group that is confused or to switch a reel to the new player’s score if multiple players a sharing the same reel group.
+This method is used to “reset” a reel group to all zeros at the beginning of a game, and can also be used to reset a reel group that is confused or to switch a reel to the new player's score if multiple players a sharing the same reel group.
 
 Note you can choose to pass either an integer representation of the value, or a value list.
 
@@ -70,7 +70,7 @@ Parameters:
 
 `unlight(**kwargs)`
 
-Turn off the lights for this ScoreReelGroup based on the ‘light_tag’ in its config.
+Turn off the lights for this ScoreReelGroup based on the 'light_tag' in its config.
 
 `wait_for_ready()`
 

--- a/docs/code/api_reference/devices/score_reels.md
+++ b/docs/code/api_reference/devices/score_reels.md
@@ -30,7 +30,7 @@ This check only happens if self.ready is True. If the reel is not ready, it mean
 
 If this method finds an active switch, it sets self.physical_value to that. Otherwise it sets it to -999. It will also update self.assumed_value if it finds an active switch. Otherwise it leaves that value unchanged.
 
-This method is automatically called (via a delay) after the reel advances. The delay is based on the config value self.config[‘hw_confirm_time’].
+This method is automatically called (via a delay) after the reel advances. The delay is based on the config value self.config['hw_confirm_time'].
 
 TODO: What happens if there are multiple active switches? Currently it will return the highest one. Is that ok?
 
@@ -51,7 +51,7 @@ Parameters:
 * **value** – Destination value which this reel should try to reach.
 
 Returns: The value of the destination. If the current
-`self.assumed_value` is -999, this method will always return -999 since it doesn’t know where the reel is and therefore doesn’t know what the destination value would be.
+`self.assumed_value` is -999, this method will always return -999 since it doesn't know where the reel is and therefore doesn't know what the destination value would be.
 
 `stop(**kwargs)`
 

--- a/docs/code/api_reference/devices/sequences.md
+++ b/docs/code/api_reference/devices/sequences.md
@@ -26,7 +26,7 @@ Sequences have the following methods & attributes available. Note that methods &
 
 Mark this logic block as complete.
 
-Posts the ‘events_when_complete’ events and optionally restarts this logic block or disables it, depending on this block’s configuration settings.
+Posts the 'events_when_complete' events and optionally restarts this logic block or disables it, depending on this block's configuration settings.
 
 `completed`
 

--- a/docs/code/api_reference/devices/shot_groups.md
+++ b/docs/code/api_reference/devices/shot_groups.md
@@ -114,7 +114,7 @@ This method actually transfers the current state of each shot profile to the lef
 
 Parameters:
 
-* **direction** – String that specifies whether the rotation direction is to the left or right. Values are ‘right’ or ‘left’. Default of None will cause the shot group to rotate in the direction as specified by the rotation_pattern.
+* **direction** – String that specifies whether the rotation direction is to the left or right. Values are 'right' or 'left'. Default of None will cause the shot group to rotate in the direction as specified by the rotation_pattern.
 
 Note that this shot group must, and rotation_events for this shot group, must both be enabled for the rotation events to work.
 
@@ -122,13 +122,13 @@ Note that this shot group must, and rotation_events for this shot group, must bo
 
 Rotate the state of the shots to the left.
 
-This method is the same as calling rotate(‘left’)
+This method is the same as calling rotate('left')
 
 `rotate_right()`
 
 Rotate the state of the shots to the right.
 
-This method is the same as calling rotate(‘right’)
+This method is the same as calling rotate('right')
 
 `subscribe_attribute(item, machine)`
 

--- a/docs/code/api_reference/devices/switches.md
+++ b/docs/code/api_reference/devices/switches.md
@@ -24,7 +24,7 @@ Switches have the following methods & attributes available. Note that methods & 
 
 Add switch handler (callback) for this switch which is called when this switch state changes.
 
-Note that this method just calls the Switch Controller’s add_switch_handler() method behind the scenes.
+Note that this method just calls the Switch Controller's add_switch_handler() method behind the scenes.
 
 Parameters:
 

--- a/docs/code/api_reference/devices/timers.md
+++ b/docs/code/api_reference/devices/timers.md
@@ -31,7 +31,7 @@ Add ticks to this timer.
 
 Parameters:
 
-* **timer_value** – The number of ticks you want to add to this timer’s current value.
+* **timer_value** – The number of ticks you want to add to this timer's current value.
 * **kwargs** – Not used in this method. Only exists since this method is often registered as an event handler which may contain additional keyword arguments.
 
 `change_tick_interval(change=0.0, **kwargs)`
@@ -40,7 +40,7 @@ Change the interval for each “tick” of this timer.
 
 Parameters:
 
-* **change** – Float or int of the change you want to make to this timer’s tick rate. Note this value is multiplied by the current tick interval: >1 will increase the tick interval (slow the timer) and <1 will decrease the tick interval (accelerate the timer). To set an absolute value, use the set_tick_interval() method.
+* **change** – Float or int of the change you want to make to this timer's tick rate. Note this value is multiplied by the current tick interval: >1 will increase the tick interval (slow the timer) and <1 will decrease the tick interval (accelerate the timer). To set an absolute value, use the set_tick_interval() method.
 * **`**kwargs`** – Not used in this method. Only exists since this method is often registered as an event handler which may contain additional keyword arguments.
 
 `enable() → None`
@@ -76,7 +76,7 @@ Pause the timer and posts the `timer_(name)_paused` event.
 
 Parameters:
 
-* **timer_value** – How many seconds you want to pause the timer for. Note that this pause time is real-world seconds and does not take into consideration this timer’s tick interval.
+* **timer_value** – How many seconds you want to pause the timer for. Note that this pause time is real-world seconds and does not take into consideration this timer's tick interval.
 * ****kwargs** – Not used in this method. Only exists since this method is often registered as an event handler which may contain additional keyword arguments.
 
 `raise_config_error(msg, error_no, *, context=None) → NoReturn`
@@ -85,7 +85,7 @@ Raise a ConfigFileError exception.
 
 `reset(**kwargs)`
 
-Reset this timer based to the starting value that’s already been configured.
+Reset this timer based to the starting value that's already been configured.
 
 Does not start or stop the timer.
 
@@ -116,7 +116,7 @@ Parameters:
 
 `start(**kwargs)`
 
-Start this timer based on the starting value that’s already been configured.
+Start this timer based on the starting value that's already been configured.
 
 Use jump() if you want to set the starting time value.
 
@@ -139,7 +139,7 @@ Subtract ticks from this timer.
 
 Parameters:
 
-* **timer_value** – The number of ticks you want to subtract from this timer’s current value.
+* **timer_value** – The number of ticks you want to subtract from this timer's current value.
 * **`**kwargs`** – Not used in this method. Only exists since this method is often registered as an event handler which may contain additional keyword arguments.
 
 `ticks`

--- a/docs/code/api_reference/hardware_platforms/fast.md
+++ b/docs/code/api_reference/hardware_platforms/fast.md
@@ -22,7 +22,7 @@ The fast platform has the following methods & attributes available. Note that me
 
 Clear a hardware rule.
 
-This is used if you want to remove the linkage between a switch and some driver activity. For example, if you wanted to disable your flippers (so that a player pushing the flipper buttons wouldn’t cause the flippers to flip), you’d call this method with your flipper button as the sw_num.
+This is used if you want to remove the linkage between a switch and some driver activity. For example, if you wanted to disable your flippers (so that a player pushing the flipper buttons wouldn't cause the flippers to flip), you'd call this method with your flipper button as the sw_num.
 
 Parameters:
 
@@ -65,11 +65,11 @@ Configure the switch object for a FAST Pinball controller.
 
 FAST Controllers support two types of switches: local and network. Local switches are switches that are connected to the FAST controller board itself, and network switches are those connected to a FAST I/O board.
 
-MPF needs to know which type of switch is this is. You can specify the switch’s connection type in the config file via the connection: setting (either local or network).
+MPF needs to know which type of switch is this is. You can specify the switch's connection type in the config file via the connection: setting (either local or network).
 
 If a connection type is not specified, this method will use some intelligence to try to figure out which default should be used.
 
-If the DriverBoard type is fast, then it assumes the default is network. If it’s anything else (wpc, system11, bally, etc.) then it assumes the connection type is local. Connection types can be mixed and matched in the same machine.
+If the DriverBoard type is fast, then it assumes the default is network. If it's anything else (wpc, system11, bally, etc.) then it assumes the connection type is local. Connection types can be mixed and matched in the same machine.
 
 Parameters:
 
@@ -170,15 +170,15 @@ Register an IO board.
 
 Parameters:
 
-* **board** – ‘mpf.platform.fast.fast_io_board.FastIoBoard’ to register
+* **board** – 'mpf.platform.fast.fast_io_board.FastIoBoard' to register
 
 `register_processor_connection(name: str, communicator)`
 
 Register processor.
 
-Once a communication link has been established with one of the processors on the FAST board, this method lets the communicator let MPF know which processor it’s talking to.
+Once a communication link has been established with one of the processors on the FAST board, this method lets the communicator let MPF know which processor it's talking to.
 
-This is a separate method since we don’t know which processor is on which serial port ahead of time.
+This is a separate method since we don't know which processor is on which serial port ahead of time.
 
 Parameters:
 
@@ -223,4 +223,4 @@ Update all the LEDs connected to a FAST controller.
 
 This is done once per game loop for efficiency (i.e. all LEDs are sent as a single update rather than lots of individual ones).
 
-Also, every LED is updated every loop, even if it doesn’t change. This is in case some interference causes a LED to change color. Since we update every loop, it will only be the wrong color for one tick.
+Also, every LED is updated every loop, even if it doesn't change. This is in case some interference causes a LED to change color. Since we update every loop, it will only be the wrong color for one tick.

--- a/docs/code/api_reference/hardware_platforms/opp.md
+++ b/docs/code/api_reference/hardware_platforms/opp.md
@@ -26,7 +26,7 @@ The opp platform has the following methods & attributes available. Note that met
 
 Clear a hardware rule.
 
-This is used if you want to remove the linkage between a switch and some driver activity. For example, if you wanted to disable your flippers (so that a player pushing the flipper buttons wouldn’t cause the flippers to flip), you’d call this method with your flipper button as the sw_num.
+This is used if you want to remove the linkage between a switch and some driver activity. For example, if you wanted to disable your flippers (so that a player pushing the flipper buttons wouldn't cause the flippers to flip), you'd call this method with your flipper button as the sw_num.
 
 `configure_driver(config: mpf.core.platform.DriverConfig, number: str, platform_settings: dict)`
 

--- a/docs/code/api_reference/hardware_platforms/trinamics_steprocker.md
+++ b/docs/code/api_reference/hardware_platforms/trinamics_steprocker.md
@@ -10,7 +10,7 @@ Bases: `mpf.core.platform.StepperPlatform`
 
 Supports the Trinamics Step Rocker via PySerial.
 
-Works with Trinamics Step Rocker. TBD other ‘TMCL’ based steppers eval boards
+Works with Trinamics Step Rocker. TBD other 'TMCL' based steppers eval boards
 
 ## Accessing the trinamics_steprocker platform via code
 

--- a/docs/code/api_reference/index.md
+++ b/docs/code/api_reference/index.md
@@ -1,6 +1,6 @@
 # API Reference
 
-MPF’s API reference is broken into several categories. All of it is presented in the way that the modules and classes are actually used in MPF.
+MPF's API reference is broken into several categories. All of it is presented in the way that the modules and classes are actually used in MPF.
 
 * [Core Components](api_reference_core.md): MPF core components.
 
@@ -14,4 +14,4 @@ MPF’s API reference is broken into several categories. All of it is presented 
 
 * [Tests](api_reference_testing_class_api.md): All unit test base classes for writing tests for MPF and your own game.
 
-* [Miscellaneous Components](api_reference_misc_components.md): Things that don’t fit into other categories, including utility functions, the base classes for modes, players, timers, and other utility functions.
+* [Miscellaneous Components](api_reference_misc_components.md): Things that don't fit into other categories, including utility functions, the base classes for modes, players, timers, and other utility functions.

--- a/docs/code/api_reference/misc_components/BallSearch.md
+++ b/docs/code/api_reference/misc_components/BallSearch.md
@@ -18,7 +18,7 @@ The Ball Search has the following methods & attributes available. Note that meth
 
 Block ball search for this playfield.
 
-Blocking will disable ball search if it’s enabled or running, and will prevent ball search from enabling if it’s disabled until ball_search_unblock() is called.
+Blocking will disable ball search if it's enabled or running, and will prevent ball search from enabling if it's disabled until ball_search_unblock() is called.
 
 `blocked = None`
 

--- a/docs/code/api_reference/misc_components/DataManager.md
+++ b/docs/code/api_reference/misc_components/DataManager.md
@@ -41,7 +41,7 @@ Return a formatted log line with log link and context.
 
 `get_data(section=None)`
 
-Return the value of this DataManager’s data.
+Return the value of this DataManager's data.
 
 Parameters:
 

--- a/docs/code/api_reference/misc_components/DelayManager.md
+++ b/docs/code/api_reference/misc_components/DelayManager.md
@@ -24,14 +24,14 @@ Parameters:
 
 * **ms** – The number of milliseconds you want this delay to be for.
 * **callback** – The method that is called when this delay ends.
-* **name** – String name of this delay. This name is arbitrary and only used to identify the delay later if you want to remove or change it. If you don’t provide it, a UUID4 name will be created.
+* **name** – String name of this delay. This name is arbitrary and only used to identify the delay later if you want to remove or change it. If you don't provide it, a UUID4 name will be created.
 * ****kwargs** – Any other (optional) kwarg pairs you pass will be passed along as kwargs to the callback method.
 
 Returns string name or UUID4 of the delay which you can use to remove it later.
 
 `add_if_doesnt_exist(ms: int, callback: Callable[[...], None], name: str, **kwargs) → str`
 
-Add a delay only if a delay with that name doesn’t exist already.
+Add a delay only if a delay with that name doesn't exist already.
 
 Parameters:
 
@@ -48,7 +48,7 @@ Check to see if a delay exists.
 
 Parameters:
 
-* **delay** – A string of the delay you’re checking for.
+* **delay** – A string of the delay you're checking for.
 
 Returns true if the delay exists. False otherwise.
 
@@ -107,19 +107,19 @@ Removing a delay prevents the callback from being called and cancels the delay.
 
 Parameters:
 
-* **name** – String name of the delay you want to remove. If there is no delay with this name, that’s ok. Nothing happens.
+* **name** – String name of the delay you want to remove. If there is no delay with this name, that's ok. Nothing happens.
 
 `reset(ms: int, callback: Callable[[...], None], name: str, **kwargs) → str`
 
 Reset a delay.
 
-Resetting will first delete the existing delay (if it exists) and then add new delay with the new settings. If the delay does not exist, that’s ok, and this method is essentially the same as just adding a delay with this name.
+Resetting will first delete the existing delay (if it exists) and then add new delay with the new settings. If the delay does not exist, that's ok, and this method is essentially the same as just adding a delay with this name.
 
 Parameters:
 
 * **ms** – The number of milliseconds you want this delay to be for.
 * **callback** – The method that is called when this delay ends.
-* **name** – String name of this delay. This name is arbitrary and only used to identify the delay later if you want to remove or change it. If you don’t provide it, a UUID4 name will be created.
+* **name** – String name of this delay. This name is arbitrary and only used to identify the delay later if you want to remove or change it. If you don't provide it, a UUID4 name will be created.
 * ****kwargs** – Any other (optional) kwarg pairs you pass will be passed along as kwargs to the callback method.
 
 Returns string name or UUID4 of the delay which you can use to remove it later.
@@ -132,7 +132,7 @@ This will cancel the future running of the delay callback.
 
 Parameters:
 
-* **name** – Name of the delay to run. If this name is not an active delay, that’s fine. Nothing happens.
+* **name** – Name of the delay to run. If this name is not an active delay, that's fine. Nothing happens.
 
 `warning_log(msg: str, *args, context=None, error_no=None, **kwargs) → None`
 

--- a/docs/code/api_reference/misc_components/ModeBaseClass.md
+++ b/docs/code/api_reference/misc_components/ModeBaseClass.md
@@ -20,18 +20,18 @@ Return True if this mode is active.
 
 Register an event handler which is automatically removed when this mode stops.
 
-This method is similar to the Event Manager’s add_handler() method, except this method automatically unregisters the handlers when the mode ends.
+This method is similar to the Event Manager's add_handler() method, except this method automatically unregisters the handlers when the mode ends.
 
 Parameters:
 
-* **event** – String name of the event you’re adding a handler for. Since events are text strings, they don’t have to be pre-defined.
+* **event** – String name of the event you're adding a handler for. Since events are text strings, they don't have to be pre-defined.
 * **handler** – The method that will be called when the event is fired.
-* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don’t matter. They’re called from highest to lowest. (i.e. priority 100 is called before priority 1.)
-* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there’s a conflict, the event-level ones will win.
+* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don't matter. They're called from highest to lowest. (i.e. priority 100 is called before priority 1.)
+* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there's a conflict, the event-level ones will win.
 
-Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don’t need to remove the handler since the whole point of this method is they’re automatically removed when the mode stops.
+Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don't need to remove the handler since the whole point of this method is they're automatically removed when the mode stops.
 
-Note that if you do add a handler via this method and then remove it manually, that’s ok too.
+Note that if you do add a handler via this method and then remove it manually, that's ok too.
 
 `auto_stop_on_ball_end`
 
@@ -50,11 +50,11 @@ Parameters:
 
 `configure_mode_settings(config: dict) → None`
 
-Process this mode’s configuration settings from a config dictionary.
+Process this mode's configuration settings from a config dictionary.
 
 `create_mode_devices() → None`
 
-Create new devices that are specified in a mode config that haven’t been created in the machine-wide.
+Create new devices that are specified in a mode config that haven't been created in the machine-wide.
 
 `debug_log(msg: str, *args, context=None, error_no=None, **kwargs) → None`
 
@@ -130,7 +130,7 @@ Raise a ConfigFileError exception.
 
 `restart_on_next_ball`
 
-Controls whether this mode will restart on the next ball. This only works if the mode was running when the ball ended. It’s tracked per- player in the ‘restart_modes_on_next_ball’ player variable.
+Controls whether this mode will restart on the next ball. This only works if the mode was running when the ball ended. It's tracked per- player in the 'restart_modes_on_next_ball' player variable.
 
 `start(mode_priority=None, callback=None, **kwargs) → None`
 
@@ -138,7 +138,7 @@ Start this mode.
 
 Parameters:
 
-* **mode_priority** – Integer value of what you want this mode to run at. If you don’t specify one, it will use the “Mode: priority” setting from this mode’s configuration file.
+* **mode_priority** – Integer value of what you want this mode to run at. If you don't specify one, it will use the “Mode: priority” setting from this mode's configuration file.
 * **callback** – Callback to call when this mode has been started.
 * ****kwargs** – Catch-all since this mode might start from events with who-knows-what keyword arguments.
 

--- a/docs/code/api_reference/misc_components/Players.md
+++ b/docs/code/api_reference/misc_components/Players.md
@@ -22,7 +22,7 @@ First, player variables can be accessed as attributes of the player object direc
 self.machine.player.foo = 0
 ```
 
-If that variable didn’t exist, it will be automatically created.
+If that variable didn't exist, it will be automatically created.
 
 You can get the value of player variables by accessing them directly. For example:
 
@@ -30,7 +30,7 @@ You can get the value of player variables by accessing them directly. For exampl
 print(self.machine.player.foo)  # prints 0
 ```
 
-If you attempt to access a player variable that doesn’t exist, it will automatically be created with a value of 0.
+If you attempt to access a player variable that doesn't exist, it will automatically be created with a value of 0.
 
 Every time a player variable is created or changed, an MPF event is posted in the form player_ plus the variable name. For example, creating or changing the foo variable will cause an event called player_foo to be posted.
 
@@ -41,7 +41,7 @@ The player variable event will have four parameters posted along with it:
 * `change` (the change in the value)
 * `player_num` (the player number the variable belongs to)
 
-For the change parameter, it will attempt to subtract the old value from the new value. If that works, it will return the result as the change. If it doesn’t work (like if you’re not storing numbers in this variable), then the change parameter will be True if the new value is different and False if the value didn’t change.
+For the change parameter, it will attempt to subtract the old value from the new value. If that works, it will return the result as the change. If it doesn't work (like if you're not storing numbers in this variable), then the change parameter will be True if the new value is different and False if the value didn't change.
 
 For examples, the following three lines:
 

--- a/docs/code/api_reference/misc_components/RGBAColor.md
+++ b/docs/code/api_reference/misc_components/RGBAColor.md
@@ -16,7 +16,7 @@ The RGBAColor has the following methods & attributes available. Note that method
 
 Add (or updates if it already exists) a color.
 
-Note that this is not permanent, the list is reset when MPF restarts (though you can define your own custom colors in your config file’s colors: section). You can use this function to dynamically change the values of colors in shows (they take place the next time an LED switches to that color).
+Note that this is not permanent, the list is reset when MPF restarts (though you can define your own custom colors in your config file's colors: section). You can use this function to dynamically change the values of colors in shows (they take place the next time an LED switches to that color).
 
 Parameters:
 

--- a/docs/code/api_reference/misc_components/RGBColor.md
+++ b/docs/code/api_reference/misc_components/RGBColor.md
@@ -16,7 +16,7 @@ The RGBColor has the following methods & attributes available. Note that methods
 
 Add (or updates if it already exists) a color.
 
-Note that this is not permanent, the list is reset when MPF restarts (though you can define your own custom colors in your config file’s colors: section). You can use this function to dynamically change the values of colors in shows (they take place the next time an LED switches to that color).
+Note that this is not permanent, the list is reset when MPF restarts (though you can define your own custom colors in your config file's colors: section). You can use this function to dynamically change the values of colors in shows (they take place the next time an LED switches to that color).
 
 Parameters:
 

--- a/docs/code/api_reference/misc_components/UtilityFunctions.md
+++ b/docs/code/api_reference/misc_components/UtilityFunctions.md
@@ -50,7 +50,7 @@ Returns float.
 
 Recursively merge dictionaries.
 
-Used to merge dictionaries of dictionaries, like when we’re merging together the machine configuration files. This method is called recursively as it finds sub-dictionaries.
+Used to merge dictionaries of dictionaries, like when we're merging together the machine configuration files. This method is called recursively as it finds sub-dictionaries.
 
 For example, in the traditional python dictionary update() methods, if a dictionary key exists in the original and merging-in dictionary, the new value will overwrite the old value.
 
@@ -58,7 +58,7 @@ Consider the following example:
 
 Original dictionary: `config['foo']['bar'] = 1`
 
-New dictionary we’re merging in: `config['foo']['other_bar'] = 2`
+New dictionary we're merging in: `config['foo']['other_bar'] = 2`
 
 Default python dictionary update() method would have the updated dictionary as this:
 
@@ -116,7 +116,7 @@ Take a string input of hex numbers and an integer.
 Parameters:
 
 * **inputstring** – A string of incoming hex colors, like ffff00.
-* **maxvalue** – Integer of the max value you’d like to return. Default is 255. (This is the real value of why this method exists.)
+* **maxvalue** – Integer of the max value you'd like to return. Default is 255. (This is the real value of why this method exists.)
 
 Returns integer representation of the hex string.
 
@@ -129,7 +129,7 @@ This always groups the hex string in twos, so an input of ffff00 will be returne
 Parameters:
 
 * **input_string** – A string of incoming hex colors, like ffff00.
-* **output_length** – Integer value of the number of items you’d like in your returned list. Default is 3. This method will ignore extra characters if the input_string is too long, and it will pad the left with zeros if the input string is too short.
+* **output_length** – Integer value of the number of items you'd like in your returned list. Default is 3. This method will ignore extra characters if the input_string is too long, and it will pad the left with zeros if the input string is too short.
 
 Returns list of integers, like [255, 255, 0].
 
@@ -145,7 +145,7 @@ Return true if string is hex.
 
 `static is_power2(num: int) → bool`
 
-Check a number to see if it’s a power of two.
+Check a number to see if it's a power of two.
 
 Parameters:
 
@@ -240,7 +240,7 @@ This version honors placeholders/templates for events.
 
 Parameters:
 
-* **string** – The string you’d like to convert.
+* **string** – The string you'd like to convert.
 
 Returns a python list object containing whatever was between commas in the string.
 
@@ -262,7 +262,7 @@ Convert a comma-separated string into a Python list if not already a list.
 
 Parameters:
 
-* **string** – The string you’d like to convert.
+* **string** – The string you'd like to convert.
 
 Returns a python list object containing whatever was between commas in the string.
 
@@ -276,7 +276,7 @@ Example inputs:
 
 If no “s” or “ms” is provided, this method assumes “milliseconds.”
 
-If time is ‘None’ or a string of ‘None’, this method returns 0.
+If time is 'None' or a string of 'None', this method returns 0.
 
 Returns an integer. The examples listed above return 200, 2000 and 0, respectively.
 

--- a/docs/code/api_reference/modes/attract.md
+++ b/docs/code/api_reference/modes/attract.md
@@ -10,7 +10,7 @@ Bases: `mpf.core.mode.Mode`
 
 Default mode running in a machine when a game is not in progress.
 
-The attract mode’s main job is to watch for the start button to be pressed, to post the requests to start games, and to move the machine flow to the next mode if the request to start game comes back as approved.
+The attract mode's main job is to watch for the start button to be pressed, to post the requests to start games, and to move the machine flow to the next mode if the request to start game comes back as approved.
 
 ## Accessing the attract mode via code
 
@@ -28,18 +28,18 @@ Return True if this mode is active.
 
 Register an event handler which is automatically removed when this mode stops.
 
-This method is similar to the Event Manager’s add_handler() method, except this method automatically unregisters the handlers when the mode ends.
+This method is similar to the Event Manager's add_handler() method, except this method automatically unregisters the handlers when the mode ends.
 
 Parameters:
 
-* **event** – String name of the event you’re adding a handler for. Since events are text strings, they don’t have to be pre-defined.
+* **event** – String name of the event you're adding a handler for. Since events are text strings, they don't have to be pre-defined.
 * **handler** – The method that will be called when the event is fired.
-* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don’t matter. They’re called from highest to lowest. (i.e. priority 100 is called before priority 1.)
-* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there’s a conflict, the event-level ones will win.
+* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don't matter. They're called from highest to lowest. (i.e. priority 100 is called before priority 1.)
+* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there's a conflict, the event-level ones will win.
 
-Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don’t need to remove the handler since the whole point of this method is they’re automatically removed when the mode stops.
+Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don't need to remove the handler since the whole point of this method is they're automatically removed when the mode stops.
 
-Note that if you do add a handler via this method and then remove it manually, that’s ok too.
+Note that if you do add a handler via this method and then remove it manually, that's ok too.
 
 `configure_logging(logger: str, console_level: str = 'basic', file_level: str = 'basic', url_base=None)`
 
@@ -54,7 +54,7 @@ Parameters:
 
 `create_mode_devices() → None`
 
-Create new devices that are specified in a mode config that haven’t been created in the machine-wide.
+Create new devices that are specified in a mode config that haven't been created in the machine-wide.
 
 `debug_log(msg: str, *args, context=None, error_no=None, **kwargs) → None`
 
@@ -112,7 +112,7 @@ Called after the request_to_start_game event is posted.
 
 If result is True, this method posts the event game_start. If False, nothing happens, as the game start request was denied by some handler.
 
-Parameters:	ev_result – Bool result of the boolean event request_to_start_game. If any registered event handler did not want the game to start, this will be False. Otherwise it’s True.
+Parameters:	ev_result – Bool result of the boolean event request_to_start_game. If any registered event handler did not want the game to start, this will be False. Otherwise it's True.
 
 `start(mode_priority=None, callback=None, **kwargs) → None`
 
@@ -120,7 +120,7 @@ Start this mode.
 
 Parameters:
 
-* **mode_priority** – Integer value of what you want this mode to run at. If you don’t specify one, it will use the “Mode: priority” setting from this mode’s configuration file.
+* **mode_priority** – Integer value of what you want this mode to run at. If you don't specify one, it will use the “Mode: priority” setting from this mode's configuration file.
 * **callback** – Callback to call when this mode has been started.
 * ****kwargs** – Catch-all since this mode might start from events with who-knows-what keyword arguments.
 

--- a/docs/code/api_reference/modes/bonus.md
+++ b/docs/code/api_reference/modes/bonus.md
@@ -28,18 +28,18 @@ Return True if this mode is active.
 
 Register an event handler which is automatically removed when this mode stops.
 
-This method is similar to the Event Manager’s add_handler() method, except this method automatically unregisters the handlers when the mode ends.
+This method is similar to the Event Manager's add_handler() method, except this method automatically unregisters the handlers when the mode ends.
 
 Parameters:
 
-* **event** – String name of the event you’re adding a handler for. Since events are text strings, they don’t have to be pre-defined.
+* **event** – String name of the event you're adding a handler for. Since events are text strings, they don't have to be pre-defined.
 * **handler** – The method that will be called when the event is fired.
-* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don’t matter. They’re called from highest to lowest. (i.e. priority 100 is called before priority 1.)
-* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there’s a conflict, the event-level ones will win.
+* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don't matter. They're called from highest to lowest. (i.e. priority 100 is called before priority 1.)
+* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there's a conflict, the event-level ones will win.
 
-Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don’t need to remove the handler since the whole point of this method is they’re automatically removed when the mode stops.
+Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don't need to remove the handler since the whole point of this method is they're automatically removed when the mode stops.
 
-Note that if you do add a handler via this method and then remove it manually, that’s ok too.
+Note that if you do add a handler via this method and then remove it manually, that's ok too.
 
 `configure_logging(logger: str, console_level: str = 'basic', file_level: str = 'basic', url_base=None)`
 
@@ -54,7 +54,7 @@ Parameters:
 
 `create_mode_devices() → None`
 
-Create new devices that are specified in a mode config that haven’t been created in the machine-wide.
+Create new devices that are specified in a mode config that haven't been created in the machine-wide.
 
 `debug_log(msg: str, *args, context=None, error_no=None, **kwargs) → None`
 
@@ -116,7 +116,7 @@ Start this mode.
 
 Parameters:
 
-* **mode_priority** – Integer value of what you want this mode to run at. If you don’t specify one, it will use the “Mode: priority” setting from this mode’s configuration file.
+* **mode_priority** – Integer value of what you want this mode to run at. If you don't specify one, it will use the “Mode: priority” setting from this mode's configuration file.
 * **callback** – Callback to call when this mode has been started.
 * ****kwargs** – Catch-all since this mode might start from events with who-knows-what keyword arguments.
 

--- a/docs/code/api_reference/modes/carousel.md
+++ b/docs/code/api_reference/modes/carousel.md
@@ -26,18 +26,18 @@ Return True if this mode is active.
 
 Register an event handler which is automatically removed when this mode stops.
 
-This method is similar to the Event Manager’s add_handler() method, except this method automatically unregisters the handlers when the mode ends.
+This method is similar to the Event Manager's add_handler() method, except this method automatically unregisters the handlers when the mode ends.
 
 Parameters:
 
-* **event** – String name of the event you’re adding a handler for. Since events are text strings, they don’t have to be pre-defined.
+* **event** – String name of the event you're adding a handler for. Since events are text strings, they don't have to be pre-defined.
 * **handler** – The method that will be called when the event is fired.
-* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don’t matter. They’re called from highest to lowest. (i.e. priority 100 is called before priority 1.)
-* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there’s a conflict, the event-level ones will win.
+* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don't matter. They're called from highest to lowest. (i.e. priority 100 is called before priority 1.)
+* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there's a conflict, the event-level ones will win.
 
-Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don’t need to remove the handler since the whole point of this method is they’re automatically removed when the mode stops.
+Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don't need to remove the handler since the whole point of this method is they're automatically removed when the mode stops.
 
-Note that if you do add a handler via this method and then remove it manually, that’s ok too.
+Note that if you do add a handler via this method and then remove it manually, that's ok too.
 
 `configure_logging(logger: str, console_level: str = 'basic', file_level: str = 'basic', url_base=None)`
 
@@ -52,7 +52,7 @@ Parameters:
 
 `create_mode_devices() → None`
 
-Create new devices that are specified in a mode config that haven’t been created in the machine-wide.
+Create new devices that are specified in a mode config that haven't been created in the machine-wide.
 
 `debug_log(msg: str, *args, context=None, error_no=None, **kwargs) → None`
 
@@ -108,7 +108,7 @@ Start this mode.
 
 Parameters:
 
-* **mode_priority** – Integer value of what you want this mode to run at. If you don’t specify one, it will use the “Mode: priority” setting from this mode’s configuration file.
+* **mode_priority** – Integer value of what you want this mode to run at. If you don't specify one, it will use the “Mode: priority” setting from this mode's configuration file.
 * **callback** – Callback to call when this mode has been started.
 * ****kwargs** – Catch-all since this mode might start from events with who-knows-what keyword arguments.
 

--- a/docs/code/api_reference/modes/credits.md
+++ b/docs/code/api_reference/modes/credits.md
@@ -31,18 +31,18 @@ Parameters:	price_tiering – Boolean which controls whether this credit will be
 
 Register an event handler which is automatically removed when this mode stops.
 
-This method is similar to the Event Manager’s add_handler() method, except this method automatically unregisters the handlers when the mode ends.
+This method is similar to the Event Manager's add_handler() method, except this method automatically unregisters the handlers when the mode ends.
 
 Parameters:
 
-* **event** – String name of the event you’re adding a handler for. Since events are text strings, they don’t have to be pre-defined.
+* **event** – String name of the event you're adding a handler for. Since events are text strings, they don't have to be pre-defined.
 * **handler** – The method that will be called when the event is fired.
-* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don’t matter. They’re called from highest to lowest. (i.e. priority 100 is called before priority 1.)
-* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there’s a conflict, the event-level ones will win.
+* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don't matter. They're called from highest to lowest. (i.e. priority 100 is called before priority 1.)
+* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there's a conflict, the event-level ones will win.
 
-Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don’t need to remove the handler since the whole point of this method is they’re automatically removed when the mode stops.
+Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don't need to remove the handler since the whole point of this method is they're automatically removed when the mode stops.
 
-Note that if you do add a handler via this method and then remove it manually, that’s ok too.
+Note that if you do add a handler via this method and then remove it manually, that's ok too.
 
 `clear_all_credits(**kwargs)`
 
@@ -61,7 +61,7 @@ Parameters:
 
 `create_mode_devices() → None`
 
-Create new devices that are specified in a mode config that haven’t been created in the machine-wide.
+Create new devices that are specified in a mode config that haven't been created in the machine-wide.
 
 `debug_log(msg: str, *args, context=None, error_no=None, **kwargs) → None`
 
@@ -125,7 +125,7 @@ Start this mode.
 
 Parameters:
 
-* **mode_priority** – Integer value of what you want this mode to run at. If you don’t specify one, it will use the “Mode: priority” setting from this mode’s configuration file.
+* **mode_priority** – Integer value of what you want this mode to run at. If you don't specify one, it will use the “Mode: priority” setting from this mode's configuration file.
 * **callback** – Callback to call when this mode has been started.
 * ****kwargs** – Catch-all since this mode might start from events with who-knows-what keyword arguments.
 

--- a/docs/code/api_reference/modes/game.md
+++ b/docs/code/api_reference/modes/game.md
@@ -28,18 +28,18 @@ Return True if this mode is active.
 
 Register an event handler which is automatically removed when this mode stops.
 
-This method is similar to the Event Manager’s add_handler() method, except this method automatically unregisters the handlers when the mode ends.
+This method is similar to the Event Manager's add_handler() method, except this method automatically unregisters the handlers when the mode ends.
 
 Parameters:
 
-* **event** – String name of the event you’re adding a handler for. Since events are text strings, they don’t have to be pre-defined.
+* **event** – String name of the event you're adding a handler for. Since events are text strings, they don't have to be pre-defined.
 * **handler** – The method that will be called when the event is fired.
-* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don’t matter. They’re called from highest to lowest. (i.e. priority 100 is called before priority 1.)
-* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there’s a conflict, the event-level ones will win.
+* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don't matter. They're called from highest to lowest. (i.e. priority 100 is called before priority 1.)
+* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there's a conflict, the event-level ones will win.
 
-Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don’t need to remove the handler since the whole point of this method is they’re automatically removed when the mode stops.
+Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don't need to remove the handler since the whole point of this method is they're automatically removed when the mode stops.
 
-Note that if you do add a handler via this method and then remove it manually, that’s ok too.
+Note that if you do add a handler via this method and then remove it manually, that's ok too.
 
 `ball_drained(balls=0, **kwargs)`
 
@@ -65,7 +65,7 @@ Property which holds the current number of balls in play.
 
 Note that the number of balls in play is not necessarily the same as the number of balls that are active on the playfield. (For example, a ball could be held in a device while a show is playing, etc.)
 
-You can set this property to change it, or get it’s value.
+You can set this property to change it, or get it's value.
 
 If you set this value to 0, the ball ending process will be started.
 
@@ -82,7 +82,7 @@ Parameters:
 
 `create_mode_devices() → None`
 
-Create new devices that are specified in a mode config that haven’t been created in the machine-wide.
+Create new devices that are specified in a mode config that haven't been created in the machine-wide.
 
 `debug_log(msg: str, *args, context=None, error_no=None, **kwargs) → None`
 
@@ -162,9 +162,9 @@ Raise a ConfigFileError exception.
 
 Request to add a player to an active game.
 
-This method contains the logic to verify whether it’s ok to add a player. For example, the game must be on Ball 1 and the current number of players must be less than the max number allowed.
+This method contains the logic to verify whether it's ok to add a player. For example, the game must be on Ball 1 and the current number of players must be less than the max number allowed.
 
-Assuming this method believes it’s ok to add a player, it posts the boolean event player_add_request to give other modules the opportunity to deny it. For example, a credits module might deny the request if there are not enough credits in the machine.
+Assuming this method believes it's ok to add a player, it posts the boolean event player_add_request to give other modules the opportunity to deny it. For example, a credits module might deny the request if there are not enough credits in the machine.
 
 If player_add_request comes back True, the event player_added is posted with a reference to the new player object as a player kwarg.
 
@@ -174,7 +174,7 @@ Start this mode.
 
 Parameters:
 
-* **mode_priority** – Integer value of what you want this mode to run at. If you don’t specify one, it will use the “Mode: priority” setting from this mode’s configuration file.
+* **mode_priority** – Integer value of what you want this mode to run at. If you don't specify one, it will use the “Mode: priority” setting from this mode's configuration file.
 * **callback** – Callback to call when this mode has been started.
 * ****kwargs** – Catch-all since this mode might start from events with who-knows-what keyword arguments.
 

--- a/docs/code/api_reference/modes/high_score.md
+++ b/docs/code/api_reference/modes/high_score.md
@@ -28,18 +28,18 @@ Return True if this mode is active.
 
 Register an event handler which is automatically removed when this mode stops.
 
-This method is similar to the Event Manager’s add_handler() method, except this method automatically unregisters the handlers when the mode ends.
+This method is similar to the Event Manager's add_handler() method, except this method automatically unregisters the handlers when the mode ends.
 
 Parameters:
 
-* **event** – String name of the event you’re adding a handler for. Since events are text strings, they don’t have to be pre-defined.
+* **event** – String name of the event you're adding a handler for. Since events are text strings, they don't have to be pre-defined.
 * **handler** – The method that will be called when the event is fired.
-* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don’t matter. They’re called from highest to lowest. (i.e. priority 100 is called before priority 1.)
-* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there’s a conflict, the event-level ones will win.
+* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don't matter. They're called from highest to lowest. (i.e. priority 100 is called before priority 1.)
+* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there's a conflict, the event-level ones will win.
 
-Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don’t need to remove the handler since the whole point of this method is they’re automatically removed when the mode stops.
+Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don't need to remove the handler since the whole point of this method is they're automatically removed when the mode stops.
 
-Note that if you do add a handler via this method and then remove it manually, that’s ok too.
+Note that if you do add a handler via this method and then remove it manually, that's ok too.
 
 `configure_logging(logger: str, console_level: str = 'basic', file_level: str = 'basic', url_base=None)`
 
@@ -54,7 +54,7 @@ Parameters:
 
 `create_mode_devices() → None`
 
-Create new devices that are specified in a mode config that haven’t been created in the machine-wide.
+Create new devices that are specified in a mode config that haven't been created in the machine-wide.
 
 `debug_log(msg: str, *args, context=None, error_no=None, **kwargs) → None`
 
@@ -110,7 +110,7 @@ Start this mode.
 
 Parameters:
 
-* **mode_priority** – Integer value of what you want this mode to run at. If you don’t specify one, it will use the “Mode: priority” setting from this mode’s configuration file.
+* **mode_priority** – Integer value of what you want this mode to run at. If you don't specify one, it will use the “Mode: priority” setting from this mode's configuration file.
 * **callback** – Callback to call when this mode has been started.
 * ****kwargs** – Catch-all since this mode might start from events with who-knows-what keyword arguments.
 

--- a/docs/code/api_reference/modes/match.md
+++ b/docs/code/api_reference/modes/match.md
@@ -26,18 +26,18 @@ Return True if this mode is active.
 
 Register an event handler which is automatically removed when this mode stops.
 
-This method is similar to the Event Manager’s add_handler() method, except this method automatically unregisters the handlers when the mode ends.
+This method is similar to the Event Manager's add_handler() method, except this method automatically unregisters the handlers when the mode ends.
 
 Parameters:
 
-* **event** – String name of the event you’re adding a handler for. Since events are text strings, they don’t have to be pre-defined.
+* **event** – String name of the event you're adding a handler for. Since events are text strings, they don't have to be pre-defined.
 * **handler** – The method that will be called when the event is fired.
-* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don’t matter. They’re called from highest to lowest. (i.e. priority 100 is called before priority 1.)
-* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there’s a conflict, the event-level ones will win.
+* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don't matter. They're called from highest to lowest. (i.e. priority 100 is called before priority 1.)
+* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there's a conflict, the event-level ones will win.
 
-Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don’t need to remove the handler since the whole point of this method is they’re automatically removed when the mode stops.
+Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don't need to remove the handler since the whole point of this method is they're automatically removed when the mode stops.
 
-Note that if you do add a handler via this method and then remove it manually, that’s ok too.
+Note that if you do add a handler via this method and then remove it manually, that's ok too.
 
 `configure_logging(logger: str, console_level: str = 'basic', file_level: str = 'basic', url_base=None)`
 
@@ -52,7 +52,7 @@ Parameters:
 
 `create_mode_devices() → None`
 
-Create new devices that are specified in a mode config that haven’t been created in the machine-wide.
+Create new devices that are specified in a mode config that haven't been created in the machine-wide.
 
 `debug_log(msg: str, *args, context=None, error_no=None, **kwargs) → None`
 
@@ -108,7 +108,7 @@ Start this mode.
 
 Parameters:
 
-* **mode_priority** – Integer value of what you want this mode to run at. If you don’t specify one, it will use the “Mode: priority” setting from this mode’s configuration file.
+* **mode_priority** – Integer value of what you want this mode to run at. If you don't specify one, it will use the “Mode: priority” setting from this mode's configuration file.
 * **callback** – Callback to call when this mode has been started.
 * ****kwargs** – Catch-all since this mode might start from events with who-knows-what keyword arguments.
 

--- a/docs/code/api_reference/modes/service.md
+++ b/docs/code/api_reference/modes/service.md
@@ -26,18 +26,18 @@ Return True if this mode is active.
 
 Register an event handler which is automatically removed when this mode stops.
 
-This method is similar to the Event Manager’s add_handler() method, except this method automatically unregisters the handlers when the mode ends.
+This method is similar to the Event Manager's add_handler() method, except this method automatically unregisters the handlers when the mode ends.
 
 Parameters:
 
-* **event** – String name of the event you’re adding a handler for. Since events are text strings, they don’t have to be pre-defined.
+* **event** – String name of the event you're adding a handler for. Since events are text strings, they don't have to be pre-defined.
 * **handler** – The method that will be called when the event is fired.
-* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don’t matter. They’re called from highest to lowest. (i.e. priority 100 is called before priority 1.)
-* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there’s a conflict, the event-level ones will win.
+* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don't matter. They're called from highest to lowest. (i.e. priority 100 is called before priority 1.)
+* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there's a conflict, the event-level ones will win.
 
-Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don’t need to remove the handler since the whole point of this method is they’re automatically removed when the mode stops.
+Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don't need to remove the handler since the whole point of this method is they're automatically removed when the mode stops.
 
-Note that if you do add a handler via this method and then remove it manually, that’s ok too.
+Note that if you do add a handler via this method and then remove it manually, that's ok too.
 
 `configure_logging(logger: str, console_level: str = 'basic', file_level: str = 'basic', url_base=None)`
 
@@ -52,7 +52,7 @@ Parameters:
 
 `create_mode_devices() → None`
 
-Create new devices that are specified in a mode config that haven’t been created in the machine-wide.
+Create new devices that are specified in a mode config that haven't been created in the machine-wide.
 
 `debug_log(msg: str, *args, context=None, error_no=None, **kwargs) → None`
 
@@ -108,7 +108,7 @@ Start this mode.
 
 Parameters:
 
-* **mode_priority** – Integer value of what you want this mode to run at. If you don’t specify one, it will use the “Mode: priority” setting from this mode’s configuration file.
+* **mode_priority** – Integer value of what you want this mode to run at. If you don't specify one, it will use the “Mode: priority” setting from this mode's configuration file.
 * **callback** – Callback to call when this mode has been started.
 * ****kwargs** – Catch-all since this mode might start from events with who-knows-what keyword arguments.
 

--- a/docs/code/api_reference/modes/tilt.md
+++ b/docs/code/api_reference/modes/tilt.md
@@ -28,18 +28,18 @@ Return True if this mode is active.
 
 Register an event handler which is automatically removed when this mode stops.
 
-This method is similar to the Event Manager’s add_handler() method, except this method automatically unregisters the handlers when the mode ends.
+This method is similar to the Event Manager's add_handler() method, except this method automatically unregisters the handlers when the mode ends.
 
 Parameters:
 
-* **event** – String name of the event you’re adding a handler for. Since events are text strings, they don’t have to be pre-defined.
+* **event** – String name of the event you're adding a handler for. Since events are text strings, they don't have to be pre-defined.
 * **handler** – The method that will be called when the event is fired.
-* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don’t matter. They’re called from highest to lowest. (i.e. priority 100 is called before priority 1.)
-* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there’s a conflict, the event-level ones will win.
+* **priority** – An arbitrary integer value that defines what order the handlers will be called in. The default is 1, so if you have a handler that you want to be called first, add it here with a priority of 2. (Or 3 or 10 or 100000.) The numbers don't matter. They're called from highest to lowest. (i.e. priority 100 is called before priority 1.)
+* ****kwargs** – Any any additional keyword/argument pairs entered here will be attached to the handler and called whenever that handler is called. Note these are in addition to kwargs that could be passed as part of the event post. If there's a conflict, the event-level ones will win.
 
-Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don’t need to remove the handler since the whole point of this method is they’re automatically removed when the mode stops.
+Returns a EventHandlerKey to the handler which you can use to later remove the handler via remove_handler_by_key. Though you don't need to remove the handler since the whole point of this method is they're automatically removed when the mode stops.
 
-Note that if you do add a handler via this method and then remove it manually, that’s ok too.
+Note that if you do add a handler via this method and then remove it manually, that's ok too.
 
 `configure_logging(logger: str, console_level: str = 'basic', file_level: str = 'basic', url_base=None)`
 
@@ -54,7 +54,7 @@ Parameters:
 
 `create_mode_devices() → None`
 
-Create new devices that are specified in a mode config that haven’t been created in the machine-wide.
+Create new devices that are specified in a mode config that haven't been created in the machine-wide.
 
 `debug_log(msg: str, *args, context=None, error_no=None, **kwargs) → None`
 
@@ -112,7 +112,7 @@ Reset the tilt warnings for the current player.
 
 Process a slam tilt.
 
-This method posts the slam_tilt event and (if a game is active) sets the game mode’s slam_tilted attribute to True.
+This method posts the slam_tilt event and (if a game is active) sets the game mode's slam_tilted attribute to True.
 
 `start(mode_priority=None, callback=None, **kwargs) → None`
 
@@ -120,7 +120,7 @@ Start this mode.
 
 Parameters:
 
-* **mode_priority** – Integer value of what you want this mode to run at. If you don’t specify one, it will use the “Mode: priority” setting from this mode’s configuration file.
+* **mode_priority** – Integer value of what you want this mode to run at. If you don't specify one, it will use the “Mode: priority” setting from this mode's configuration file.
 * **callback** – Callback to call when this mode has been started.
 * ****kwargs** – Catch-all since this mode might start from events with who-knows-what keyword arguments.
 
@@ -143,7 +143,7 @@ Returns true if the mode is running. Otherwise false.
 
 Cause the ball to tilt.
 
-This will post an event called tilt, set the game mode’s tilted attribute to True, disable the flippers and autofire devices, end the current ball, and wait for all the balls to drain.
+This will post an event called tilt, set the game mode's tilted attribute to True, disable the flippers and autofire devices, end the current ball, and wait for all the balls to drain.
 
 `tilt_settle_ms_remaining()`
 

--- a/docs/code/api_reference/testing_class_api/MockBcpClient.md
+++ b/docs/code/api_reference/testing_class_api/MockBcpClient.md
@@ -8,7 +8,7 @@ Bases: `mpf.core.bcp.bcp_client.BaseBcpClient`
 
 A Mock BCP Client.
 
-This is used in tests require BCP for testing but where you don’t actually create a real BCP connection.
+This is used in tests require BCP for testing but where you don't actually create a real BCP connection.
 
 ## Methods & Attributes
 

--- a/docs/code/api_reference/testing_class_api/MpfBcpTestCase.md
+++ b/docs/code/api_reference/testing_class_api/MpfBcpTestCase.md
@@ -81,7 +81,7 @@ Checks whether dictionary is a superset of subset.
 
 `assertEqual(first, second, msg=None)`
 
-Fail if the two objects are unequal as determined by the ‘==’ operator.
+Fail if the two objects are unequal as determined by the '==' operator.
 
 `assertEventCalled(event_name, times=None)`
 
@@ -261,7 +261,7 @@ Objects that are equal automatically fail.
 
 `assertNotEqual(first, second, msg=None)`
 
-Fail if the two objects are equal as determined by the ‘!=’ operator.
+Fail if the two objects are equal as determined by the '!=' operator.
 
 `assertNotIn(member, container, msg=None)`
 
@@ -306,9 +306,9 @@ with self.assertRaises(SomeException):
   do_something()
 ```
 
-An optional keyword argument ‘msg’ can be provided when assertRaises is used as a context object.
+An optional keyword argument 'msg' can be provided when assertRaises is used as a context object.
 
-The context manager keeps a reference to the exception as the ‘exception’ attribute. This allows you to inspect the exception after the assertion:
+The context manager keeps a reference to the exception as the 'exception' attribute. This allows you to inspect the exception after the assertion:
 
 ``` python
 with self.assertRaises(SomeException) as cm:
@@ -387,9 +387,9 @@ with self.assertWarns(SomeWarning):
   do_something()
 ```
 
-An optional keyword argument ‘msg’ can be provided when assertWarns is used as a context object.
+An optional keyword argument 'msg' can be provided when assertWarns is used as a context object.
 
-The context manager keeps a reference to the first matching warning as the ‘warning’ attribute; similarly, the ‘filename’ and ‘lineno’ attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
+The context manager keeps a reference to the first matching warning as the 'warning' attribute; similarly, the 'filename' and 'lineno' attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
 
 ``` python
 with self.assertWarns(SomeWarning) as cm:
@@ -474,7 +474,7 @@ Return options for the machine controller.
 Force this test class to use a certain platform.
 Returns:	String name of the platform this test class will use.
 
-If you don’t include this method in your test class, the platform will be set to virtual. If you want to use the smart virtual platform, you would add the following to your test class:
+If you don't include this method in your test class, the platform will be set to virtual. If you want to use the smart virtual platform, you would add the following to your test class:
 
 ``` python
 def get_platform(self):
@@ -543,7 +543,7 @@ Parameters:
 
 Mocking an event is an easy way to check if an event was called without configuring some kind of callback action in your tests.
 
-Note that an event must be mocked here before it’s posted in order for assertEventNotCalled() and assertEventCalled() to work.
+Note that an event must be mocked here before it's posted in order for assertEventNotCalled() and assertEventCalled() to work.
 
 Mocking an event will not “break” it. In other words, any other registered handlers for this event will also be called even if the event has been mocked.
 
@@ -625,9 +625,9 @@ Setup test.
 
 `set_num_balls_known(balls)`
 
-Set the ball controller’s num_balls_known attribute.
+Set the ball controller's num_balls_known attribute.
 
-This is needed for tests where you don’t have any ball devices and other situations where you need the ball controller to think the machine has a certain amount of balls to run a test.
+This is needed for tests where you don't have any ball devices and other situations where you need the ball controller to think the machine has a certain amount of balls to run a test.
 
 Example:
 
@@ -637,7 +637,7 @@ self.set_num_balls_known(3)
 
 Returns a one-line description of the test, or None if no description has been provided.
 
-The default implementation of this method returns the first line of the specified test method’s docstring.
+The default implementation of this method returns the first line of the specified test method's docstring.
 
 `skipTest(reason)`
 

--- a/docs/code/api_reference/testing_class_api/MpfFakeGameTestCase.md
+++ b/docs/code/api_reference/testing_class_api/MpfFakeGameTestCase.md
@@ -119,7 +119,7 @@ Checks whether dictionary is a superset of subset.
 
 `assertEqual(first, second, msg=None)`
 
-Fail if the two objects are unequal as determined by the ‘==’ operator.
+Fail if the two objects are unequal as determined by the '==' operator.
 
 `assertEventCalled(event_name, times=None)`
 
@@ -318,7 +318,7 @@ Objects that are equal automatically fail.
 
 `assertNotEqual(first, second, msg=None)`
 
-Fail if the two objects are equal as determined by the ‘!=’ operator.
+Fail if the two objects are equal as determined by the '!=' operator.
 
 `assertNotIn(member, container, msg=None)`
 
@@ -386,9 +386,9 @@ with self.assertRaises(SomeException):
 do_something()
 ```
 
-An optional keyword argument ‘msg’ can be provided when assertRaises is used as a context object.
+An optional keyword argument 'msg' can be provided when assertRaises is used as a context object.
 
-The context manager keeps a reference to the exception as the ‘exception’ attribute. This allows you to inspect the exception after the assertion:
+The context manager keeps a reference to the exception as the 'exception' attribute. This allows you to inspect the exception after the assertion:
 
 ``` python
 with self.assertRaises(SomeException) as cm:
@@ -467,9 +467,9 @@ with self.assertWarns(SomeWarning):
 do_something()
 ```
 
-An optional keyword argument ‘msg’ can be provided when assertWarns is used as a context object.
+An optional keyword argument 'msg' can be provided when assertWarns is used as a context object.
 
-The context manager keeps a reference to the first matching warning as the ‘warning’ attribute; similarly, the ‘filename’ and ‘lineno’ attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
+The context manager keeps a reference to the first matching warning as the 'warning' attribute; similarly, the 'filename' and 'lineno' attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
 
 ``` python
 with self.assertWarns(SomeWarning) as cm:
@@ -570,7 +570,7 @@ Return options for the machine controller.
 Force this test class to use a certain platform.
 Returns:	String name of the platform this test class will use.
 
-If you don’t include this method in your test class, the platform will be set to virtual. If you want to use the smart virtual platform, you would add the following to your test class:
+If you don't include this method in your test class, the platform will be set to virtual. If you want to use the smart virtual platform, you would add the following to your test class:
 
 ``` python
 def get_platform(self):
@@ -636,7 +636,7 @@ Parameters:	event_name – String name of the event to mock.
 
 Mocking an event is an easy way to check if an event was called without configuring some kind of callback action in your tests.
 
-Note that an event must be mocked here before it’s posted in order for assertEventNotCalled() and assertEventCalled() to work.
+Note that an event must be mocked here before it's posted in order for assertEventNotCalled() and assertEventCalled() to work.
 
 Mocking an event will not “break” it. In other words, any other registered handlers for this event will also be called even if the event has been mocked.
 
@@ -714,9 +714,9 @@ Setup test.
 
 `set_num_balls_known(balls)`
 
-Set the ball controller’s num_balls_known attribute.
+Set the ball controller's num_balls_known attribute.
 
-This is needed for tests where you don’t have any ball devices and other situations where you need the ball controller to think the machine has a certain amount of balls to run a test.
+This is needed for tests where you don't have any ball devices and other situations where you need the ball controller to think the machine has a certain amount of balls to run a test.
 
 Example:
 
@@ -728,7 +728,7 @@ self.set_num_balls_known(3)
 
 Returns a one-line description of the test, or None if no description has been provided.
 
-The default implementation of this method returns the first line of the specified test method’s docstring.
+The default implementation of this method returns the first line of the specified test method's docstring.
 
 `skipTest(reason)`
 
@@ -752,7 +752,7 @@ Start two player game.
 
 Stop the current game.
 
-This method asserts that a game is running, then call’s the game mode’s end_game() method, then asserts that the game has successfully stopped.
+This method asserts that a game is running, then call's the game mode's end_game() method, then asserts that the game has successfully stopped.
 
 Example:
 

--- a/docs/code/api_reference/testing_class_api/MpfGameTestCase.md
+++ b/docs/code/api_reference/testing_class_api/MpfGameTestCase.md
@@ -124,7 +124,7 @@ Checks whether dictionary is a superset of subset.
 
 `assertEqual(first, second, msg=None)`
 
-Fail if the two objects are unequal as determined by the ‘==’ operator.
+Fail if the two objects are unequal as determined by the '==' operator.
 
 `assertEventCalled(event_name, times=None)`
 
@@ -323,7 +323,7 @@ Objects that are equal automatically fail.
 
 `assertNotEqual(first, second, msg=None)`
 
-Fail if the two objects are equal as determined by the ‘!=’ operator.
+Fail if the two objects are equal as determined by the '!=' operator.
 
 `assertNotIn(member, container, msg=None)`
 
@@ -392,9 +392,9 @@ with self.assertRaises(SomeException):
 do_something()
 ```
 
-An optional keyword argument ‘msg’ can be provided when assertRaises is used as a context object.
+An optional keyword argument 'msg' can be provided when assertRaises is used as a context object.
 
-The context manager keeps a reference to the exception as the ‘exception’ attribute. This allows you to inspect the exception after the assertion:
+The context manager keeps a reference to the exception as the 'exception' attribute. This allows you to inspect the exception after the assertion:
 
 ``` python
 with self.assertRaises(SomeException) as cm:
@@ -473,9 +473,9 @@ with self.assertWarns(SomeWarning):
 do_something()
 ```
 
-An optional keyword argument ‘msg’ can be provided when assertWarns is used as a context object.
+An optional keyword argument 'msg' can be provided when assertWarns is used as a context object.
 
-The context manager keeps a reference to the first matching warning as the ‘warning’ attribute; similarly, the ‘filename’ and ‘lineno’ attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
+The context manager keeps a reference to the first matching warning as the 'warning' attribute; similarly, the 'filename' and 'lineno' attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
 
 ``` python
 with self.assertWarns(SomeWarning) as cm:
@@ -574,7 +574,7 @@ Return options for the machine controller.
 Force this test class to use a certain platform.
 Returns:	String name of the platform this test class will use.
 
-If you don’t include this method in your test class, the platform will be set to virtual. If you want to use the smart virtual platform, you would add the following to your test class:
+If you don't include this method in your test class, the platform will be set to virtual. If you want to use the smart virtual platform, you would add the following to your test class:
 
 def get_platform(self):
 return 'smart_virtual`
@@ -636,7 +636,7 @@ Parameters:	event_name – String name of the event to mock.
 
 Mocking an event is an easy way to check if an event was called without configuring some kind of callback action in your tests.
 
-Note that an event must be mocked here before it’s posted in order for assertEventNotCalled() and assertEventCalled() to work.
+Note that an event must be mocked here before it's posted in order for assertEventNotCalled() and assertEventCalled() to work.
 
 Mocking an event will not “break” it. In other words, any other registered handlers for this event will also be called even if the event has been mocked.
 
@@ -712,9 +712,9 @@ Setup test.
 
 `set_num_balls_known(balls)`
 
-Set the ball controller’s num_balls_known attribute.
+Set the ball controller's num_balls_known attribute.
 
-This is needed for tests where you don’t have any ball devices and other situations where you need the ball controller to think the machine has a certain amount of balls to run a test.
+This is needed for tests where you don't have any ball devices and other situations where you need the ball controller to think the machine has a certain amount of balls to run a test.
 
 Example:
 
@@ -726,7 +726,7 @@ self.set_num_balls_known(3)
 
 Returns a one-line description of the test, or None if no description has been provided.
 
-The default implementation of this method returns the first line of the specified test method’s docstring.
+The default implementation of this method returns the first line of the specified test method's docstring.
 
 `skipTest(reason)`
 
@@ -756,7 +756,7 @@ Start two player game.
 
 Stop the current game.
 
-This method asserts that a game is running, then call’s the game mode’s end_game() method, then asserts that the game has successfully stopped.
+This method asserts that a game is running, then call's the game mode's end_game() method, then asserts that the game has successfully stopped.
 
 Example:
 

--- a/docs/code/api_reference/testing_class_api/MpfMachineTestCase.md
+++ b/docs/code/api_reference/testing_class_api/MpfMachineTestCase.md
@@ -77,7 +77,7 @@ Checks whether dictionary is a superset of subset.
 
 `assertEqual(first, second, msg=None)`
 
-Fail if the two objects are unequal as determined by the ‘==’ operator.
+Fail if the two objects are unequal as determined by the '==' operator.
 
 `assertEventCalled(event_name, times=None)`
 
@@ -257,7 +257,7 @@ Objects that are equal automatically fail.
 
 `assertNotEqual(first, second, msg=None)`
 
-Fail if the two objects are equal as determined by the ‘!=’ operator.
+Fail if the two objects are equal as determined by the '!=' operator.
 
 `assertNotIn(member, container, msg=None)`
 
@@ -302,9 +302,9 @@ with self.assertRaises(SomeException):
   do_something()
 ```
 
-An optional keyword argument ‘msg’ can be provided when assertRaises is used as a context object.
+An optional keyword argument 'msg' can be provided when assertRaises is used as a context object.
 
-The context manager keeps a reference to the exception as the ‘exception’ attribute. This allows you to inspect the exception after the assertion:
+The context manager keeps a reference to the exception as the 'exception' attribute. This allows you to inspect the exception after the assertion:
 
 ``` python
 with self.assertRaises(SomeException) as cm:
@@ -383,9 +383,9 @@ with self.assertWarns(SomeWarning):
   do_something()
 ```
 
-An optional keyword argument ‘msg’ can be provided when assertWarns is used as a context object.
+An optional keyword argument 'msg' can be provided when assertWarns is used as a context object.
 
-The context manager keeps a reference to the first matching warning as the ‘warning’ attribute; similarly, the ‘filename’ and ‘lineno’ attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
+The context manager keeps a reference to the first matching warning as the 'warning' attribute; similarly, the 'filename' and 'lineno' attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
 
 ``` python
 with self.assertWarns(SomeWarning) as cm:
@@ -470,7 +470,7 @@ Return options for the machine controller.
 Force this test class to use a certain platform.
 Returns:	String name of the platform this test class will use.
 
-If you don’t include this method in your test class, the platform will be set to virtual. If you want to use the smart virtual platform, you would add the following to your test class:
+If you don't include this method in your test class, the platform will be set to virtual. If you want to use the smart virtual platform, you would add the following to your test class:
 
 ``` python
 def get_platform(self):
@@ -537,7 +537,7 @@ Parameters:
 
 Mocking an event is an easy way to check if an event was called without configuring some kind of callback action in your tests.
 
-Note that an event must be mocked here before it’s posted in order for assertEventNotCalled() and assertEventCalled() to work.
+Note that an event must be mocked here before it's posted in order for assertEventNotCalled() and assertEventCalled() to work.
 
 Mocking an event will not “break” it. In other words, any other registered handlers for this event will also be called even if the event has been mocked.
 
@@ -613,9 +613,9 @@ Setup test.
 
 `set_num_balls_known(balls)`
 
-Set the ball controller’s num_balls_known attribute.
+Set the ball controller's num_balls_known attribute.
 
-This is needed for tests where you don’t have any ball devices and other situations where you need the ball controller to think the machine has a certain amount of balls to run a test.
+This is needed for tests where you don't have any ball devices and other situations where you need the ball controller to think the machine has a certain amount of balls to run a test.
 
 Example:
 
@@ -627,7 +627,7 @@ self.set_num_balls_known(3)
 
 Returns a one-line description of the test, or None if no description has been provided.
 
-The default implementation of this method returns the first line of the specified test method’s docstring.
+The default implementation of this method returns the first line of the specified test method's docstring.
 
 `skipTest(reason)`
 

--- a/docs/code/api_reference/testing_class_api/MpfTestCase.md
+++ b/docs/code/api_reference/testing_class_api/MpfTestCase.md
@@ -1,5 +1,6 @@
 # MpfTestCase
 
+
 ``` python
 class mpf.tests.MpfTestCase.MpfTestCase(methodName='runTest')
 ```
@@ -79,7 +80,7 @@ Checks whether dictionary is a superset of subset.
 
 `assertEqual(first, second, msg=None)`
 
-Fail if the two objects are unequal as determined by the ‘==’ operator.
+Fail if the two objects are unequal as determined by the '==' operator.
 
 `assertEventCalled(event_name, times=None)`
 
@@ -259,7 +260,7 @@ Objects that are equal automatically fail.
 
 `assertNotEqual(first, second, msg=None)`
 
-Fail if the two objects are equal as determined by the ‘!=’ operator.
+Fail if the two objects are equal as determined by the '!=' operator.
 
 `assertNotIn(member, container, msg=None)`
 
@@ -304,9 +305,9 @@ with self.assertRaises(SomeException):
   do_something()
 ```
 
-An optional keyword argument ‘msg’ can be provided when assertRaises is used as a context object.
+An optional keyword argument 'msg' can be provided when assertRaises is used as a context object.
 
-The context manager keeps a reference to the exception as the ‘exception’ attribute. This allows you to inspect the exception after the assertion:
+The context manager keeps a reference to the exception as the 'exception' attribute. This allows you to inspect the exception after the assertion:
 
 ``` python
 with self.assertRaises(SomeException) as cm:
@@ -385,9 +386,9 @@ with self.assertWarns(SomeWarning):
   do_something()
 ```
 
-An optional keyword argument ‘msg’ can be provided when assertWarns is used as a context object.
+An optional keyword argument 'msg' can be provided when assertWarns is used as a context object.
 
-The context manager keeps a reference to the first matching warning as the ‘warning’ attribute; similarly, the ‘filename’ and ‘lineno’ attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
+The context manager keeps a reference to the first matching warning as the 'warning' attribute; similarly, the 'filename' and 'lineno' attributes give you information about the line of Python code from which the warning was triggered. This allows you to inspect the warning after the assertion:
 
 ``` python
 with self.assertWarns(SomeWarning) as cm:
@@ -472,7 +473,7 @@ Return options for the machine controller.
 Force this test class to use a certain platform.
 Returns:	String name of the platform this test class will use.
 
-If you don’t include this method in your test class, the platform will be set to virtual. If you want to use the smart virtual platform, you would add the following to your test class:
+If you don't include this method in your test class, the platform will be set to virtual. If you want to use the smart virtual platform, you would add the following to your test class:
 
 def get_platform(self):
   return 'smart_virtual'
@@ -539,7 +540,7 @@ Parameters:
 
 Mocking an event is an easy way to check if an event was called without configuring some kind of callback action in your tests.
 
-Note that an event must be mocked here before it’s posted in order for assertEventNotCalled() and assertEventCalled() to work.
+Note that an event must be mocked here before it's posted in order for assertEventNotCalled() and assertEventCalled() to work.
 
 Mocking an event will not “break” it. In other words, any other registered handlers for this event will also be called even if the event has been mocked.
 
@@ -617,9 +618,9 @@ Setup test.
 
 `set_num_balls_known(balls)`
 
-Set the ball controller’s num_balls_known attribute.
+Set the ball controller's num_balls_known attribute.
 
-This is needed for tests where you don’t have any ball devices and other situations where you need the ball controller to think the machine has a certain amount of balls to run a test.
+This is needed for tests where you don't have any ball devices and other situations where you need the ball controller to think the machine has a certain amount of balls to run a test.
 
 Example:
 
@@ -631,7 +632,7 @@ self.set_num_balls_known(3)
 
 Returns a one-line description of the test, or None if no description has been provided.
 
-The default implementation of this method returns the first line of the specified test method’s docstring.
+The default implementation of this method returns the first line of the specified test method's docstring.
 
 `skipTest(reason)`
 

--- a/docs/code/api_reference/testing_class_api/TestDataManager.md
+++ b/docs/code/api_reference/testing_class_api/TestDataManager.md
@@ -8,7 +8,7 @@ Bases: `mpf.core.data_manager.DataManager`
 
 A patched version of the DataManager which is used in unit tests.
 
-The main change is that the `save_all()` method doesn’t actually write anything to disk so the tests don’t fill up the disk with unneeded data.
+The main change is that the `save_all()` method doesn't actually write anything to disk so the tests don't fill up the disk with unneeded data.
 
 ## Methods & Attributes
 
@@ -20,7 +20,7 @@ Return a formatted log line with log link and context.
 
 `get_data(section=None)`
 
-Return the value of this DataManager’s data.
+Return the value of this DataManager's data.
 
 Parameters:
 

--- a/docs/code/api_reference/testing_class_api/TestMachineController.md
+++ b/docs/code/api_reference/testing_class_api/TestMachineController.md
@@ -88,14 +88,14 @@ Register a monitor.
 
 Parameters:
 
-* **monitor_class** – String name of the monitor class for this monitor that’s being registered.
+* **monitor_class** – String name of the monitor class for this monitor that's being registered.
 * **monitor** – Callback to notify
 
 MPF uses monitors to allow components to monitor certain internal elements of MPF.
 
 For example, a player variable monitor could be setup to be notified of any changes to a player variable, or a switch monitor could be used to allow a plugin to be notified of any changes to any switches.
 
-The MachineController’s list of registered monitors doesn’t actually do anything. Rather it’s a dictionary of sets which the monitors themselves can reference when they need to do something. We just needed a central registry of monitors.
+The MachineController's list of registered monitors doesn't actually do anything. Rather it's a dictionary of sets which the monitors themselves can reference when they need to do something. We just needed a central registry of monitors.
 
 `reset() → None`
 

--- a/docs/code/index.md
+++ b/docs/code/index.md
@@ -4,9 +4,9 @@ title: "Adding custom code to your game"
 
 # Adding custom code to your game
 
-While one of the goals of MPF is to allow you to do as much of your game’s configuration as possible with the config files, we recognize that many people will want to mix in some custom code to their machines.
+While one of the goals of MPF is to allow you to do as much of your game's configuration as possible with the config files, we recognize that many people will want to mix in some custom code to their machines.
 
-Fortunately that’s easy to do, and you don’t have to “hack” MPF or break anything to make it happen!
+Fortunately that's easy to do, and you don't have to “hack” MPF or break anything to make it happen!
 
 The amount of custom code you use is up to you, depending on your personal preferences, your comfort with Python, and what exactly you want to do with your machine.
 

--- a/docs/code/introduction/index.md
+++ b/docs/code/introduction/index.md
@@ -4,7 +4,7 @@ This introduction chapter should give you a quick start into extending MPF.
 
 !!! note "Mode custom code vs. machine custom code"
 
-    Note that MPF also has the ability to run custom mode code which is code that is associated with a certain game mode and is generally only active when the mode it’s in is active. So if you just want to write your own custom game logic, you’ll probably use mode code. MPF has well the ability to run machine wide code, which is active as long as MPF is running regardless of the mode you are in. You need to decide what code extension you need.
+    Note that MPF also has the ability to run custom mode code which is code that is associated with a certain game mode and is generally only active when the mode it's in is active. So if you just want to write your own custom game logic, you'll probably use mode code. MPF has well the ability to run machine wide code, which is active as long as MPF is running regardless of the mode you are in. You need to decide what code extension you need.
 
 Follow either the examples for the [machine wide](machine_code.md) extension or the [mode wide](mode_code.md) extension. In the next step most extensions probably have to deal in one or the other way with variables, follow this [variable guide](variables_in_code.md) to learn how to deal with MPF variables in your own code.
 

--- a/docs/code/introduction/machine_code.md
+++ b/docs/code/introduction/machine_code.md
@@ -9,11 +9,11 @@ MPF contains a “CustomCode” concept which lets you add custom code to your g
 
 CustomCode classes are Python modules that run at the “root” of your game. You can use them to do anything you want.
 
-CustomCode classes are sort of “machine-level” custom code. CustomCode classes are nice if you have some kind of custom device type that doesn’t match up to any of MPF’s built in devices. The elevator and claw unloader in Demolition Man is a good example, and what we’ll use here.
+CustomCode classes are sort of “machine-level” custom code. CustomCode classes are nice if you have some kind of custom device type that doesn't match up to any of MPF's built in devices. The elevator and claw unloader in Demolition Man is a good example, and what we'll use here.
 
 (You can read about how to download and run Demo Man in the example games section section of the MPF User Documentation.)
 
-Here’s how to create a custom code class:
+Here's how to create a custom code class:
 ## Create your custom code file
 
 First, add a `custom_code` folder to your machine folder. Then inside there, create the Python file that will hold your custom code classes.
@@ -22,7 +22,7 @@ All your classes will be referenced as `custom_code.file_name.ClassName`.
 
 ## Open and edit your custom code class file
 
-Next, edit the class file you created. At a bare minimum, you’ll need this:
+Next, edit the class file you created. At a bare minimum, you'll need this:
 
 ``` python
 from mpf.core.custom_code import CustomCode
@@ -33,7 +33,7 @@ class Claw(CustomCode):
 
 Note that MPF contains a CustomCode base class which is very simple. You can see the [CustomCode source](https://github.com/missionpinball/mpf/blob/dev/mpf/core/custom_code.py) on GitHub. We called our class Claw in this case.
 
-Pretty much all this does is give you a reference to the main MPF machine controller at `self.machine`, as well as setup a delay manager you can use and set the name of your class. There’s also an `on_load()` method which is called when the class is loaded which you can use in your own code.
+Pretty much all this does is give you a reference to the main MPF machine controller at `self.machine`, as well as setup a delay manager you can use and set the name of your class. There's also an `on_load()` method which is called when the class is loaded which you can use in your own code.
 
 ## Add the class to your machine config
 
@@ -50,7 +50,7 @@ This references class Claw in file claw.py which lives package custom_code.
 
 ## Real-world example
 
-At this point you should be able to run your game, though nothing should happen because you haven’t added any code to your code.
+At this point you should be able to run your game, though nothing should happen because you haven't added any code to your code.
 
 Take a look at the final Demo Man claw class to see what we did there. Since custom code classes have access to self.machine and they load when MPF loads, you can do anything you want in them.
 

--- a/docs/code/introduction/mode_code.md
+++ b/docs/code/introduction/mode_code.md
@@ -9,7 +9,7 @@ The easiest and most common way to add custom Python code into your MPF game is 
 
 This “mode code” (as we call it) has access to the full MPF API. You can post events, register event handlers which run custom things when events are posted, access device state and control devices, read and set player variables, post slides… really anything MPF can do, you can do.
 
-Here’s how you get started with custom mode code.
+Here's how you get started with custom mode code.
 
 ## Create the module (file) to hold you code
 
@@ -48,7 +48,7 @@ Notice that we named our custom class Base. You can name it whatever you want.
 
 Once you create your custom mode code, you need to tell MPF that this mode uses custom code instead of just the built-in code.
 
-To do this, add a `code:` entry into the mode config file for the mode where you’re adding custom code. So in this case, that would be in the `/modes/base/config/base.yaml` file, like this:
+To do this, add a `code:` entry into the mode config file for the mode where you're adding custom code. So in this case, that would be in the `/modes/base/config/base.yaml` file, like this:
 
 ``` yaml
 mode:
@@ -57,11 +57,11 @@ mode:
   code: base.Base
 ```
 
-Note that the value for the `code:` section is the name of the Python module (the file), then a dot, then the name of the class from that file. So in this case, that’s base.Base.
+Note that the value for the `code:` section is the name of the Python module (the file), then a dot, then the name of the class from that file. So in this case, that's base.Base.
 
 ## Run your game!
 
-At this point you should be able to run your game and nothing should happen. This is good, because if it doesn’t crash, that means you did everything right. Of course nothing special happens because you didn’t actually add any code to your custom mode code, so you won’t see anything different.
+At this point you should be able to run your game and nothing should happen. This is good, because if it doesn't crash, that means you did everything right. Of course nothing special happens because you didn't actually add any code to your custom mode code, so you won't see anything different.
 
 ## Add some custom methods to do things
 
@@ -71,26 +71,26 @@ You can look at the Mode base class (the link from GitHub from earlier) to see w
 
 * **mode_start:** Called every time the mode starts, just after the mode_(name)\_started event is posted.
 
-* **add_mode_event_handler:** This is the same as the main add_event_handler() method from the Event Manager, except since it’s mode-specific it will also automatically remove any event handlers that you registered when the mode stops. (If you want to register event handlers that are always watching for events even when the mode is not running, you can use the regular `self.machine.mode.add_handler()` method.
+* **add_mode_event_handler:** This is the same as the main add_event_handler() method from the Event Manager, except since it's mode-specific it will also automatically remove any event handlers that you registered when the mode stops. (If you want to register event handlers that are always watching for events even when the mode is not running, you can use the regular `self.machine.mode.add_handler()` method.
 
-You don’t have to use all of these if you don’t want to.
+You don't have to use all of these if you don't want to.
 
 Also, modes have additional convenience attributes you can use within your mode code:
 
-* **self.config:** A link to the config dictionary for the mode’s config file.
+* **self.config:** A link to the config dictionary for the mode's config file.
 
-* **self.priority:** The priority the mode is running at. (Don’t change this. Just read it.)
+* **self.priority:** The priority the mode is running at. (Don't change this. Just read it.)
 
 
 * **self.delay:** An instance of the delay manager you can use to set delayed callbacks for this mode. Any active ones will be automatically removed when the mode ends.
 
-* **self.player:** A link to the current player object that’s automatically updated when the player changes. This will be None if the mode is running outside of a game.
+* **self.player:** A link to the current player object that's automatically updated when the player changes. This will be None if the mode is running outside of a game.
 
 * **self.active:** A boolean (True/False) value you can query to see if the mode is running.
 
 ## Example usage
 
-Here’s an example of some mode code in use. This example is just a bunch of random things, but again, since you’re writing code here, the sky’s the limit! Seriously you could do all your game logic in mode code and not use the MPF configs at all if you wanted to.
+Here's an example of some mode code in use. This example is just a bunch of random things, but again, since you're writing code here, the sky's the limit! Seriously you could do all your game logic in mode code and not use the MPF configs at all if you wanted to.
 
 
 ``` python

--- a/docs/code/introduction/setup.md
+++ b/docs/code/introduction/setup.md
@@ -9,7 +9,7 @@
 
 If you want to work on the core MPF or MPF-MC code, you have to install MPF and MPF-MC a bit differently than the normal process.
 
-Why? Because normally when you install MPF and MPF-MC via pip, they get installed as Python packages into your Python/Lib/site-packages folder, and that location is not too conducive to editing MPF source code since it’s in a deep random location. Also, if you ever ran pip again to update your MPF installation, you would potentially overwrite any changes you made.
+Why? Because normally when you install MPF and MPF-MC via pip, they get installed as Python packages into your Python/Lib/site-packages folder, and that location is not too conducive to editing MPF source code since it's in a deep random location. Also, if you ever ran pip again to update your MPF installation, you would potentially overwrite any changes you made.
 
 Instead, you need to install MPF and MPF-MC in “developer” (also known as “editable”) mode. This mode will let you run MPF and MPF-MC from the folder of your choice, and will allow code changes or additions you make to be immediately available whenever you run MPF.
 
@@ -17,7 +17,7 @@ Instead, you need to install MPF and MPF-MC in “developer” (also known as �
 
 MPF is cross-platform and runs the same on Mac, Windows, or Linux. So any changes or additions you make should work on all platforms.
 
-If you’re on Windows or Mac, the easiest way to get a git client installed is to use the GitHub Desktop app. This app will also install the git command line tools.
+If you're on Windows or Mac, the easiest way to get a git client installed is to use the GitHub Desktop app. This app will also install the git command line tools.
 
 ## 2. Clone the MPF and/or MPF-MC repo(s)
 
@@ -33,15 +33,15 @@ Same thing for the mpf-mc repository :
 git clone --recursive https://github.com/missionpinball/mpf-mc.git
 ```
 
-If you’re using the GitHub Desktop app, you can also browse to the repos on GitHub and click the green “Clone or Download” button, and then click the “Open in Desktop” link. That will pop up a box that prompts you to pick a folder for the local codebase.
+If you're using the GitHub Desktop app, you can also browse to the repos on GitHub and click the green “Clone or Download” button, and then click the “Open in Desktop” link. That will pop up a box that prompts you to pick a folder for the local codebase.
 
-Then inside that folder, you’ll end up with an mpf folder for MPF and mpf-mc folder for MPF-MC.
+Then inside that folder, you'll end up with an mpf folder for MPF and mpf-mc folder for MPF-MC.
 
 ## 3. Install MPF / MPF-MC in “developer” mode
 
-Create a “virtualenv” for your MPF development in a mpf-env directory (Note : if you don’t have virtualenv installed, you can get it via pip by running pip3 install virtualenv.
+Create a “virtualenv” for your MPF development in a mpf-env directory (Note : if you don't have virtualenv installed, you can get it via pip by running pip3 install virtualenv.
 
-Using virtualenv lets you keep all the other Python packages MPF needs (pyserial, pyyaml, kivy, etc.) together in a “virtual” environment that you’ll use for MPF and helps keep everything in your Python environment cleaner in general.
+Using virtualenv lets you keep all the other Python packages MPF needs (pyserial, pyyaml, kivy, etc.) together in a “virtual” environment that you'll use for MPF and helps keep everything in your Python environment cleaner in general.
 
 Create a new virtualenv called “mpf-venv” (or whatever you want to name it) like this:
 
@@ -60,7 +60,7 @@ On Macs, you will need to uninstall and reinstall kivy in the the virtual envirm
 1) pip uninstall kivy
 2) pip install kivy -no-binary :all:
 
-Each time you’ll work with your MPF development version you’ll have to switch to this environment.
+Each time you'll work with your MPF development version you'll have to switch to this environment.
 
 ``` console
 source mpf-venv/bin/activate
@@ -68,7 +68,7 @@ source mpf-venv/bin/activate
 
 Note: in this environment, thanks to the “-p python3” option of virtualenv, the version of Python and pip is 3.x automatically.
 
-Next you’ll install MPF and MPF-MC. This is pretty much like a regular install, except that you’ll also use the -e command line option which means these packages will be installed in “editable” mode.
+Next you'll install MPF and MPF-MC. This is pretty much like a regular install, except that you'll also use the -e command line option which means these packages will be installed in “editable” mode.
 
 Install mpf and mpf-mc like this:
 
@@ -91,7 +91,7 @@ Be sure to add your name to the AUTHORS file in the root of the MPF or MPF-MC re
 
 ## 5. Write / update unit tests
 
-We make heavy use of unit tests to ensure that future changes don’t break existing functionality. So write new unit tests to cover whatever you just wrote, and be sure to rerun all the unit tests to make sure your changes or additions didn’t break anything else.
+We make heavy use of unit tests to ensure that future changes don't break existing functionality. So write new unit tests to cover whatever you just wrote, and be sure to rerun all the unit tests to make sure your changes or additions didn't break anything else.
 
 More information on creating and running MPF unit tests is here.
 

--- a/docs/install/linux/index.md
+++ b/docs/install/linux/index.md
@@ -1,4 +1,5 @@
 ---
+
 title: Installing MPF on Linux
 ---
 
@@ -155,12 +156,12 @@ Failed to initialize MPF
 Traceback (most recent call last):
 File “/usr/local/lib/python3.8/dist-packages/mpf/platforms/p_roc_common.py”, line 31, in <module>
   import pinproc
-ModuleNotFoundError: No module named ‘pinproc’
+ModuleNotFoundError: No module named 'pinproc'
 During handling of the above exception, another exception occurred:
 Traceback (most recent call last):
 File “/usr/local/lib/python3.8/dist-packages/mpf/platforms/p_roc_common.py”, line 41, in <module>
   raise ImportError
-ImportError: No module named ‘pinproc’
+ImportError: No module named 'pinproc'
 ```
 
 Try Changing `Edit install-proc:`

--- a/docs/mechs/lights/index.md
+++ b/docs/mechs/lights/index.md
@@ -87,7 +87,7 @@ lights:
 ```
 
 ## Fully working Example 1 - Basics
-Let’s bring above informaton together and learn by example. Though the following example is a fully working minimal set for the Cobra controller, it is as well helpful to understand the concpet more if you use a different set of hardware. For this example to work physically, the Cobra board needs to have 5V power supply and a Neopixel strip connected to NEO0. No need for a high voltage power supply like you need for coils. The example has been built for a WS2811 strip, but can be used as well for a WS2812 strips and others. This `config.yaml` is the only configuration file you need in your project. The config file is fully valid for the Cobra board connected to a Linux PC running MPF. If you have a Cobra board but run Windows or macOS you have to change the `ports`. If you run a completely different hardware you have to adapt the `hardware` section.
+Let's bring above informaton together and learn by example. Though the following example is a fully working minimal set for the Cobra controller, it is as well helpful to understand the concpet more if you use a different set of hardware. For this example to work physically, the Cobra board needs to have 5V power supply and a Neopixel strip connected to NEO0. No need for a high voltage power supply like you need for coils. The example has been built for a WS2811 strip, but can be used as well for a WS2812 strips and others. This `config.yaml` is the only configuration file you need in your project. The config file is fully valid for the Cobra board connected to a Linux PC running MPF. If you have a Cobra board but run Windows or macOS you have to change the `ports`. If you run a completely different hardware you have to adapt the `hardware` section.
 
 ``` yaml
 #config_version=5
@@ -149,7 +149,7 @@ When you run this configuration, you can use the keys 1 - 5 to set certain light
 
 * off: to switch an led off
 * hex code: e.g. DFFF00 to define each color channel, here red=DF, green=FF, blue=00. Note that the code has no leading # since that would be a comment in your config file
-* html name: e.g. LightSalmon, you can check the available names here https://htmlcolorcodes.com/color-names/ Capitalization doesn’t matter in the config file, e.g. LightSalmon or lightsalmon are equally good
+* html name: e.g. LightSalmon, you can check the available names here https://htmlcolorcodes.com/color-names/ Capitalization doesn't matter in the config file, e.g. LightSalmon or lightsalmon are equally good
 
 
 In the `light_player` section you can either define the color as value

--- a/docs/testing/index.md
+++ b/docs/testing/index.md
@@ -28,7 +28,7 @@ Test Driven Developer / TDD which says you should write your tests *before* you 
 I can 100% guarantee that writing good tests will save you time in the long run AND it will make your game more stable.
 2:36
 
-Bonus: there are “fuzz” tests too which are just automated tests that hit all the switches randomly and make sure MPF doesn’t crash or hang. Good for beefing up your machine before you’re done, and something you should set up EARLY and run OFTEN so you don’t have surprises 2 days before a show
+Bonus: there are “fuzz” tests too which are just automated tests that hit all the switches randomly and make sure MPF doesn't crash or hang. Good for beefing up your machine before you're done, and something you should set up EARLY and run OFTEN so you don't have surprises 2 days before a show
 
 Consolidate this content to here:
 


### PR DESCRIPTION
I feel pretty strongly that we should just use standard ascii single quotes instead of special case single quotes (I blame Windows and Mac word processors). My experience when editing a bunch of headers of different pages in a previous PR was that the leading single quote does not get treated as a non-word character, leading to incorrect jump-highlighting and word-highlighting behaviors, which is really annoying. As well, if any of the special characters make it into a code sample, they could result in unrunnable code for a user copying a snippet.