### PR TITLE
Remove Breaking Line from Code Snippet

### DIFF
--- a/docs/tutorial/14_add_a_mode.md
+++ b/docs/tutorial/14_add_a_mode.md
@@ -94,7 +94,6 @@ four spaces and type `priority: 100`. Your `base.yaml` file should now
 look like this:
 
 ``` yaml
-##! mode: my_mode
 #config_version=5
 mode:
   start_events: ball_started


### PR DESCRIPTION
the first line "##! mode: my_mode" causes MPF to exit on error when it is included in the file and it seems as though it should be removed from the code snippet on this page.

14_add_a_mode.md