### PR TITLE
Update Code Snippet to Agree with Text

### DIFF
--- a/docs/tutorial/14_add_a_mode.md
+++ b/docs/tutorial/14_add_a_mode.md
@@ -97,7 +97,7 @@ look like this:
 ##! mode: my_mode
 #config_version=5
 mode:
-  start_events: ball_started
+  start_events: ball_starting
   priority: 100
 ```
 


### PR DESCRIPTION
In the YAML code snippet showing the reader an example of how to build their first mode, line 4 of the snippet "start_events: ball_started" should read "start_events: ball_starting" in order to agree with the rest of the documentation on this page.