### PR TITLE
Mkdocs navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,15 +55,16 @@ theme:
   # https://squidfunk.github.io/mkdocs-material/upgrade
   # https://squidfunk.github.io/mkdocs-material/reference/code-blocks
   features:
-    - navigation.instant    # setting-up-navigation/#instant-loading      -- Use XHR instead of page reloads on browsing links
-    - navigation.footer     # upgrade/#navigationfooter                   -- Enable Next and Previous buttons in footer
-    - navigation.tabs       # setting-up-navigation/#navigation-tabs      -- Enables the header tab navigation on large screens
-    - navigation.indexes    # setting-up-navigation/#section-index-pages  -- Allows section headers to be standalone pages
-    - navigation.top        # setting-up-navigation/#back-to-top-button   -- Button appears when user scrolls down then up
-    - navigation.tracking   # setting-up-navigation/#anchor-tracking      -- Update url bar #anchor as you scroll
-    - content.action.edit   # upgrade/#contentaction                      -- Enables link to edit on github
-    - toc.follow            # setting-up-navigation/#anchor-following     -- Sidebar automatically scrolls with content
-    - content.code.annotate # reference/code-blocks/#code-annotations     -- Allows + button annotations
+    - navigation.instant      # setting-up-navigation/#instant-loading        # Use XHR instead of page reloads on browsing links
+    - navigation.footer       # upgrade/#navigationfooter                     # Enable Next and Previous buttons in footer
+    - navigation.tabs         # setting-up-navigation/#navigation-tabs        # Enables the header tab navigation on large screens
+    - navigation.tabs.sticky  # setting-up-navigation/#sticky-navigation-tabs # Keep section headers visible instead of collapsing on scroll
+    - navigation.indexes      # setting-up-navigation/#section-index-pages    # Allows section headers to be standalone pages
+    - navigation.top          # setting-up-navigation/#back-to-top-button     # Button appears when user scrolls down then up
+    - navigation.tracking     # setting-up-navigation/#anchor-tracking        # Update url bar #anchor as you scroll
+    - content.action.edit     # upgrade/#contentaction                        # Enables link to edit on github
+    - toc.follow              # setting-up-navigation/#anchor-following       # Sidebar automatically scrolls with content
+    - content.code.annotate   # reference/code-blocks/#code-annotations       # Allows + button annotations
 
   palette:                  # https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#color-palette-toggle
     # Palette toggle for light mode


### PR DESCRIPTION
Add a feature flag so that the URL anchor updates as you scroll (helpful on mobile if trying to copy direct config property links, for example)

Also add a feature flag so that the header sections do not hide when you scroll down, per suggestion https://groups.google.com/g/mpf-users/c/cxFVYjMuJv8