### PR TITLE
More FAST docs

### DIFF
--- a/docs/config/fast.md
+++ b/docs/config/fast.md
@@ -34,6 +34,7 @@ See [fast:net: config reference](fast/fast_net.md) for more details.
 ### exp:
 
 This contains the configuration for the EXP boards, which handle lights and various motors and accessories.
+See [fast:exp: config reference](fast/fast_exp.md) for more details.
 
 ### exp_int:
 
@@ -41,7 +42,7 @@ When using the Raspberry PI directly connected to a Neuron board, the Neuron's L
 To enable use of these headers, define the `FP-EXP-2000` model board in the `exp_int` instead of `exp` configuration.
 If using other EXP boards, you still define those on the normal `exp` configuration.
 For an example, see this [pull request](https://github.com/missionpinball/mpf/pull/1895) on Github.
-See [fast:exp: config reference](fast/fast_exp.md) for more details.
+See [fast:exp: config reference](fast/fast_exp.md#using-exp_int) for more details.
 
 ### aud:
 

--- a/docs/config/fast/fast_aud.md
+++ b/docs/config/fast/fast_aud.md
@@ -15,7 +15,7 @@ Within the [`fast:`](../fast.md) section of your machine-wide config, you config
 
 ### Sample config:
 
-```yaml
+``` yaml
 fast:
   aud:
     port: auto

--- a/docs/config/fast/fast_exp.md
+++ b/docs/config/fast/fast_exp.md
@@ -27,7 +27,7 @@ The connection baud rate.
 
 ### boards:
 
-Dict of string board names to dicts of EXP board properties. Defaults to empty.
+Subconfig of string board names to [fast:exp:board](fast_exp_board.md) configs with your EXP board properties. Defaults to empty.
 
 Example:
 
@@ -41,17 +41,6 @@ fast:
       playfield_0081:
         model: FP-EXP-0081
 ```
-
-#### model:
-
-The product number of the IO board. E.G. `FP-EXP-0081`
-
-#### ignore_led_errors:
-
-Single value, boolean, default: `false`
-
-If false, LED hex communication decode errors will be raised as errors when encountered from this board.
-If you encounter instability due to these errors, set this to true to silently ignore them.
 
 ## Using exp_int
 

--- a/docs/config/fast/fast_exp.md
+++ b/docs/config/fast/fast_exp.md
@@ -31,7 +31,7 @@ Subconfig of string board names to [fast:exp:board](fast_exp_board.md) configs w
 
 Example:
 
-```yaml
+``` yaml
 fast:
   exp:
     port: auto
@@ -49,7 +49,7 @@ In order to access these Neuron LED headers, you must define a parallel structur
 
 Example:
 
-```yaml
+``` yaml
 fast:
   exp:
     boards:

--- a/docs/config/fast/fast_exp_board.md
+++ b/docs/config/fast/fast_exp_board.md
@@ -1,0 +1,98 @@
+---
+title: "fast:exp: Config Reference"
+---
+
+# fast:exp: Config Reference
+
+--8<-- "deeper_config_section.md"
+
+| Valid in | |
+|-----|:----:|
+|[machine](../instructions/machine_config.md) config files|**YES** :white_check_mark:|
+|[mode](../instructions/mode_config.md) config files|**NO** :no_entry_sign:|
+
+Within the [`fast:exp:`](fast_exp.md) (or `fast_int:`) section of your [fast:](../fast.md) config, you configure each of your EXP boards, as well as your Neuron EXP interface.
+
+### model:
+
+The product number of the IO board. E.G. `FP-EXP-0081`
+Supported models in MPF as of 0.57.4 are:
+
+* `FP-EXP-2000` - the Neuron LED ports
+* `FP-EXP-1313` - single shaker interface
+* `FP-EXP-0051` - DC motors, 4 LED headers
+* `FP-EXP-0061` - Stepper board, 4 LED headers
+* `FP-EXP-0071` - Servo board, 4 LED headers
+* `FP-EXP-0081` - 2x4 LED headers
+* `FP-EXP-0091` - 4 LED headers, custom breakouts
+
+### address:
+
+Single value, string, default: special
+
+If you do not provide a value, the default address for the board model will be used.
+If you are using only a single board of each model number, it should not be necessary to specify the address.
+If you are using multiple boards with the same model, you must disambiguate them by modifying the solder jumpers.
+The guide for this is in the [FAST website documentation](https://fastpinball.com/programming/exp/#expansion-board-addresses), but the general algorithm is that Jumper 0 being closed will increment the address by 1,
+and Jumper 1 will increment the address by 2, so both will increment by 3, allowing up to four boards of the same model to be used in one system.
+
+The FAST website has the full chart, but these are the default address values for each supported EXP board:
+
+* `FP-EXP-2000` - `48`
+* `FP-EXP-1313` - `30`
+* `FP-EXP-0051` - `D0`
+* `FP-EXP-0061` - `90`
+* `FP-EXP-0071` - `B4`
+* `FP-EXP-0081` - `84`
+* `FP-EXP-0091` - `88`
+
+### breakouts:
+
+Single value, type: `dict`. Defaults to empty.
+
+Specification of the remote breakout boards.
+
+### led_ports:
+
+Single value, type: `dict`. Defaults to empty.
+
+Specification of the LED port configurations.
+
+### led_fade_time:
+
+Single value, type: `time string (ms)`
+[Instructions for entering time strings](../instructions/time_strings.md). Defaults to empty.
+
+Specify the fade default for LEDs on this board. Note that values above the limit of 8191 (ms) will raise an error.
+
+### led_hz:
+
+Single value, float, default: `30`
+
+Specify the refresh rate of the LEDs for this board. Note that values above the limit of 31.25 will be set to the limit.
+
+### ignore_led_errors:
+
+Single value, boolean, default: `false`
+
+If false, LED hex communication decode errors will be raised as errors when encountered from this board.
+If you encounter instability due to these errors, set this to true to silently ignore them.
+
+## Using `exp_int:` - Raspberry Pi only
+
+If using a Raspberry Pi connected directly to the Neuron controller, the LED headers on the Neuron will not be available on the normal EXP interface.
+In order to access these Neuron LED headers, you must define a parallel structure to the existing `exp:` configuration, and move the Neuron EXP board definition over to it.
+
+Example:
+
+```yaml
+fast:
+  exp_int:
+    boards:
+      neuron:
+        model: FP-EXP-2000
+```
+
+## FAST Docs:
+
+For more information, see the [FAST EXP Interface MPF Config page](https://fastpinball.com/mpf/config/exp/).

--- a/docs/config/fast/fast_exp_board.md
+++ b/docs/config/fast/fast_exp_board.md
@@ -181,7 +181,7 @@ In order to access these Neuron LED headers, you must define a parallel structur
 
 Example:
 
-```yaml
+``` yaml
 fast:
   exp_int:
     boards:

--- a/docs/config/fast/fast_exp_board.md
+++ b/docs/config/fast/fast_exp_board.md
@@ -54,9 +54,105 @@ Specification of the remote breakout boards.
 
 ### led_ports:
 
-Single value, type: `dict`. Defaults to empty.
+Single value, type: `list`. Defaults to empty.
 
-Specification of the LED port configurations.
+!!! note "This feature is not yet available and will require multiple upgrade steps"
+
+    `led_ports` configuration is only supported on FAST EXP firmware 0.48, and as such
+    requires upgrading to MPF version `0.58.0.dev1` or `0.81.0.dev1` via git or manual install.
+    To prepare for this support, you should upgrade to `0.57.5` or `0.80.0` and upgrade all EXP
+    firmware to 0.48, which is mandatory on 0.58 and 0.81 even if not using any custom header definitions.
+
+Specification of the LED port configurations. Ports on most EXP boards go from 1-4, with the 0081 having a second set at numbers 5-8.
+Each group of four ports may have up to 128 lights split in any way between the four ports. Each port may also be defined as one of four types.
+The default assumption is that each port is 32 lights, WS2182 type (RGB LEDs only).
+
+#### Changing port led counts:
+
+To change the distribution of RGB lights, you must define some ports which will claim less than the standard 32 lights in order to also assign more than 32 to others.
+
+``` yaml
+fast:
+  exp:
+    boards:
+      neuron:
+        model: FP-EXP-2000
+        led_ports:
+          - port: 2
+            count: 10
+          - port: 4
+            count: 54
+          # ports 1 and 3 do not have to be defined as
+          # they will default to 32 and we will have exactly 128 claimed
+lights:
+  last_on_chain_two:
+    number: neuron-2-10
+  last_on_chain_four:
+    number: neuron-2-54
+```
+
+#### Changing port led types:
+
+To change to RGBW SK6812 units, you can define the port to have just a type override:
+
+``` yaml
+fast:
+  exp:
+    boards:
+      neuron:
+        model: FP-EXP-2000
+        led_ports:
+          - port: 1
+            type: sk6812
+lights:
+  my_sk6218_unit:
+    number: neuron-1-1
+    type: rgb
+    # the rgbw type should not be used with SK6218s
+    # on FAST hardware, use rgb or grb as appropriate
+```
+
+The SK6812 type is organized such that every four addresses is split up as channels 0, 1, and 2 as R G and B, and special channel W (inaccessible through normal channel lookups) as the last channel, which is set based on the floor value between the three other components.
+For example, the color 'FFBBAA' would result in a white component value of 'AA' automatically.
+There are no current plans for a workaround for different behavior or way to disable this with four-channel support.
+
+#### Mixing WS2182 and SK6812, RGB and RGBW on a single chain:
+
+The protocols for WS2182 and SK6812 light data are different and accidentally compatible, so it is possible to
+set up a mostly-working string of lights with both kinds of unit mixed in. Due to GRBW and GRB channel orderings and four-vs-three channel-per-package management, you may end up having to hand define every channel on every light in a mixed string.
+
+To specify which numbers on a mixed chain have four-channel SK6812 units, use the additional option `rgbw_numbers`
+
+``` yaml
+fast:
+  exp:
+    boards:
+      neuron:
+        model: FP-EXP-2000
+        led_ports:
+          - port: 1
+            type: mixed
+            count: 64
+            rgbw_numbers: [1, 3, 64]
+          - port: 2
+            count: 0 # relocated all 32 to port 1
+lights:
+  my_first_sk6218_unit:
+    number: neuron-1-1
+    type: rgb # the rgbw type should not be used with SK6218s on FAST hardware, use rgb or grb as appropriate
+  my_first_ws2182_unit:
+    number: neuron-1-2
+    type: rgb # a true rgb unit
+  my_second_sk6218_unit:
+    number: neuron-1-3
+  my_second_ws2182_unit:
+    number: neuron-1-4
+
+  my_last_sk6812_unit:
+    number: neuron-1-64
+```
+
+The white channel of the SK6812 units on a mixed port will behave with the same floor function as the sk6812 type port configuration.
 
 ### led_fade_time:
 

--- a/docs/config/fast/fast_net.md
+++ b/docs/config/fast/fast_net.md
@@ -29,7 +29,7 @@ Note that the Playfield Interchange board is pass-through, and is not listed in 
 
 Example:
 
-```yaml
+``` yaml
 fast:
   net:
     controller: neuron

--- a/docs/config/light_player.md
+++ b/docs/config/light_player.md
@@ -64,7 +64,7 @@ There is also a special wildcard / catch-all that can be used to address ALL lig
 Using the asterisk (or star) instead of a tag name will make the setting apply to every light.
 This is **not** a true wildcard matcher like you can use with filesystem searches (e.g. where "file_12*.txt" might match "file_123.txt" and also "file_12345.txt").
 
-```yaml
+``` yaml
 light_player:
   turn_everything_on_event:
     "*": on

--- a/docs/hardware/fast/config.md
+++ b/docs/hardware/fast/config.md
@@ -134,14 +134,14 @@ used on a Nano).
 
 So an example for Windows might look like this:
 
-```yaml
+``` yaml
 fast:
     ports: com3, com4, com5
 ```
 
 And an example for Mac or Linux might look like this:
 
-```yaml
+``` yaml
 fast:
    ports: /dev/tty.usbserial-141B, /dev/tty.usbserial-141C
 ```
@@ -168,7 +168,7 @@ default with a timeout of 1 second. If you would like to disable this,
 or you'd like to change the timeout, you can do so in the `fast:`
 section of your machine-wide config.
 
-```yaml
+``` yaml
 fast:
    ports: com3, com4, com5  # or whatever your ports are
    watchdog: 1000

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -876,6 +876,7 @@ nav:
       - "fadecandy:": config/fadecandy.md
       - "fast:": config/fast.md
       - "fast:exp:": config/fast/fast_exp.md
+      - "fast:exp:board:": config/fast/fast_exp_board.md
       - "fast:net:": config/fast/fast_net.md
       - "fast:aud:": config/fast/fast_aud.md
       - "fast_coils:": config/fast_coils.md


### PR DESCRIPTION
Adds documentation for the exp: subconfig of fast: for the FAST EXP system.
Includes documentation for the not-yet-released led_ports: subconfig that allows changing EXP header types, including mixed SK6812/WS2812 strings and headers powering chains of other lengths than 32 units.